### PR TITLE
Standardise on 'initialized' for channel/connection state etc

### DIFF
--- a/src/Ably.AcceptanceTests/RealtimeChannelAcceptanceTests.cs
+++ b/src/Ably.AcceptanceTests/RealtimeChannelAcceptanceTests.cs
@@ -40,7 +40,7 @@ namespace Ably.AcceptanceTests
 
             // Assert
             target.Name.ShouldBeEquivalentTo("test");
-            target.State.ShouldBeEquivalentTo(Realtime.ChannelState.Initialised);
+            target.State.ShouldBeEquivalentTo(Realtime.ChannelState.Initialized);
         }
 
         [Test]

--- a/src/Ably.Core/AblyBase.cs
+++ b/src/Ably.Core/AblyBase.cs
@@ -37,7 +37,7 @@ namespace Ably
         }
 
         /// <summary>
-        /// Initialises the Ably Auth type based on the options passed.
+        /// Initializes the Ably Auth type based on the options passed.
         /// </summary>
         internal void InitAuth(IAblyRest restClient)
         {

--- a/src/Ably.Core/AblyRealtimeOptions.cs
+++ b/src/Ably.Core/AblyRealtimeOptions.cs
@@ -24,7 +24,7 @@ namespace Ably
         public bool EchoMessages { get; set; }
 
         /// <summary>
-        /// A connection recovery string, specified by a client when initialising the library 
+        /// A connection recovery string, specified by a client when initializing the library 
         /// with the intention of inheriting the state of an earlier connection. See the Ably 
         /// Realtime API documentation for further information on connection state recovery.
         /// </summary>

--- a/src/Ably.Core/AuthOptions.cs
+++ b/src/Ably.Core/AuthOptions.cs
@@ -47,7 +47,7 @@ namespace Ably
         }
 
         /// <summary>
-        /// Initialised a new instance of AuthOptions by populating the KeyId and KeyValue properties from the full Key
+        /// Initialized a new instance of AuthOptions by populating the KeyId and KeyValue properties from the full Key
         /// </summary>
         /// <param name="key">Full ably key string</param>
         public AuthOptions(string key)

--- a/src/Ably.Core/IPaginatedResource.cs
+++ b/src/Ably.Core/IPaginatedResource.cs
@@ -44,7 +44,7 @@ namespace Ably
 
     public class PaginatedResource
     {
-        public static PaginatedResource<T> InitialisePartialResult<T>( WebHeaderCollection headers, int? limit = null)
+        public static PaginatedResource<T> InitializePartialResult<T>( WebHeaderCollection headers, int? limit = null)
         {
             var result = new PaginatedResource<T>(limit ?? Config.Limit);
             result.CurrentQuery = DataRequestQuery.GetLinkQuery(headers, DataRequestLinkType.Current);

--- a/src/Ably.Core/MessageEncoders/MessageHandler.cs
+++ b/src/Ably.Core/MessageEncoders/MessageHandler.cs
@@ -23,17 +23,17 @@ namespace Ably.MessageEncoders
         {
             _protocol = protocol;
 
-            InitialiseMessageEncoders(protocol);
+            InitializeMessageEncoders(protocol);
         }
 
-        private void InitialiseMessageEncoders(Protocol protocol)
+        private void InitializeMessageEncoders(Protocol protocol)
         {
             Encoders.Add(new JsonEncoder(protocol));
             Encoders.Add(new Utf8Encoder(protocol));
             Encoders.Add(new CipherEncoder(protocol));
             Encoders.Add(new Base64Encoder(protocol));
 
-            Logger.Debug(string.Format("Initialising message encodings. {0} initialised", string.Join(",", Encoders.Select( x=> x.EncodingName))));
+            Logger.Debug(string.Format("Initializing message encodings. {0} initialized", string.Join(",", Encoders.Select( x=> x.EncodingName))));
         }
 
         public T ParseMessagesResponse<T>(AblyResponse response) where T : class
@@ -154,21 +154,21 @@ namespace Ably.MessageEncoders
             LogResponse(response);
             if (typeof(T) == typeof(PaginatedResource<Message>))
             {
-                var result = PaginatedResource.InitialisePartialResult<Message>(response.Headers, GetLimit(request));
+                var result = PaginatedResource.InitializePartialResult<Message>(response.Headers, GetLimit(request));
                 result.AddRange(ParseMessagesResponse(response, request.ChannelOptions));
                 return result as T;
             }
 
             if (typeof(T) == typeof(PaginatedResource<Stats>))
             {
-                var result = PaginatedResource.InitialisePartialResult<Stats>(response.Headers, GetLimit(request));
+                var result = PaginatedResource.InitializePartialResult<Stats>(response.Headers, GetLimit(request));
                 result.AddRange(ParseStatsResponse(response));
                 return result as T;
             }
 
             if (typeof(T) == typeof(PaginatedResource<PresenceMessage>))
             {
-                var result = PaginatedResource.InitialisePartialResult<PresenceMessage>(response.Headers, GetLimit(request));
+                var result = PaginatedResource.InitializePartialResult<PresenceMessage>(response.Headers, GetLimit(request));
                 result.AddRange(ParsePresenceMessages(response));
                 return result as T;
             }

--- a/src/Ably.Core/Realtime/Channel.cs
+++ b/src/Ably.Core/Realtime/Channel.cs
@@ -85,7 +85,7 @@ namespace Ably.Realtime
         /// </summary>
         public void Detach()
         {
-            if (this.State == ChannelState.Initialised || this.State == ChannelState.Detaching ||
+            if (this.State == ChannelState.Initialized || this.State == ChannelState.Detaching ||
                 this.State == ChannelState.Detached)
             {
                 return;
@@ -146,7 +146,7 @@ namespace Ably.Realtime
 
         public void Publish(IEnumerable<Message> messages, Action<bool, ErrorInfo> callback)
         {
-            if (this.State == ChannelState.Initialised || this.State == ChannelState.Attaching)
+            if (this.State == ChannelState.Initialized || this.State == ChannelState.Attaching)
             {
                 // TODO: Add callback
                 this.queuedMessages.AddRange(messages);

--- a/src/Ably.Core/Realtime/ChannelState.cs
+++ b/src/Ably.Core/Realtime/ChannelState.cs
@@ -8,10 +8,10 @@ namespace Ably.Realtime
     public enum ChannelState
     {
         /// <summary>
-        /// A channel object having this state has been initialised but no attach has 
+        /// A channel object having this state has been initialized but no attach has 
         /// yet been attempted.
         /// </summary>
-        Initialised,
+        Initialized,
 
         /// <summary>
         /// An attach has been initiated by sending a request to the service. This is a 

--- a/src/Ably.Core/Realtime/ConnectionState.cs
+++ b/src/Ably.Core/Realtime/ConnectionState.cs
@@ -8,14 +8,14 @@ namespace Ably.Realtime
     public enum ConnectionState
     {
         /// <summary>
-        /// A connection object having this state has been initialised but no connection has yet been 
+        /// A connection object having this state has been initialized but no connection has yet been 
         /// attempted.
         /// </summary>
         Initialized,
 
         /// <summary>
         /// A connection attempt has been initiated. The connecting state is entered as soon as the library 
-        /// has completed initialisation, and is reentered each time connection is re-attempted following 
+        /// has completed initialization, and is reentered each time connection is re-attempted following 
         /// disconnection.
         /// </summary>
         Connecting,

--- a/src/Ably.Core/Realtime/Presence.cs
+++ b/src/Ably.Core/Realtime/Presence.cs
@@ -70,9 +70,9 @@ namespace Ably.Realtime
 
         private void UpdatePresence(PresenceMessage msg, Action<bool, ErrorInfo> callback)
         {
-            if (this.channel.State == ChannelState.Initialised || this.channel.State == ChannelState.Attaching)
+            if (this.channel.State == ChannelState.Initialized || this.channel.State == ChannelState.Attaching)
             {
-                if (this.channel.State == ChannelState.Initialised)
+                if (this.channel.State == ChannelState.Initialized)
                 {
                     this.channel.Attach();
                 }

--- a/src/Ably.Core/RestClient.cs
+++ b/src/Ably.Core/RestClient.cs
@@ -33,7 +33,7 @@ namespace Ably
         internal IAblyHttpClient _httpClient;
         internal MessageHandler _messageHandler;
 
-        /// <summary>Initialises the RestClient by reading the Key from a connection string with key 'Ably'</summary>
+        /// <summary>Initializes the RestClient by reading the Key from a connection string with key 'Ably'</summary>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2214:DoNotCallOverridableMethodsInConstructors")]
         public RestClient()
         {
@@ -41,10 +41,10 @@ namespace Ably
             if( string.IsNullOrEmpty( key ) )
                 throw new AblyException( "A connection string with key 'Ably' doesn't exist in the application configuration" );
             _options = new AblyOptions( key );
-            InitialiseAbly();
+            InitializeAbly();
         }
 
-        /// <summary>Initialises the RestClient using the api key provided</summary>
+        /// <summary>Initializes the RestClient using the api key provided</summary>
         /// <param name="apiKey">Full api key</param>
         public RestClient(string apiKey)
             : this(new AblyOptions(apiKey))
@@ -53,7 +53,7 @@ namespace Ably
         }
 
         /// <summary>
-        /// Convenience method for initialising the RestClient by passing a Action{AblyOptions}
+        /// Convenience method for initializing the RestClient by passing a Action{AblyOptions}
         /// <example>
         /// var rest = new RestClient(opt => {
         ///  opt.Key = "fake.key:value";
@@ -66,21 +66,21 @@ namespace Ably
         {
             _options = new AblyOptions();
             init(_options);
-            InitialiseAbly();
+            InitializeAbly();
         }
 
         /// <summary>
-        /// Initialise the library with a custom set of options
+        /// Initialize the library with a custom set of options
         /// </summary>
         /// <param name="ablyOptions"></param>
         public RestClient(AblyOptions ablyOptions)
         {
             _options = ablyOptions;
-            InitialiseAbly();
+            InitializeAbly();
         }
 
-        /// <summary>Initialises the rest client and validates the passed in options</summary>
-        private void InitialiseAbly()
+        /// <summary>Initializes the rest client and validates the passed in options</summary>
+        private void InitializeAbly()
         {
             if (_options == null)
             {

--- a/src/Ably.Tests/CapabilityTests.cs
+++ b/src/Ably.Tests/CapabilityTests.cs
@@ -70,7 +70,7 @@ namespace Ably.Tests
         }
 
         [Fact]
-        public void Capability_InitialisedWith2Resources_AddsThemCorrectlyToAllowedResourced()
+        public void Capability_InitializedWith2Resources_AddsThemCorrectlyToAllowedResourced()
         {
             var capabilityString = "{ \"first\": [ \"*\" ], \"second\": [ \"publish\" ] }";
             var capability = new Capability(capabilityString);

--- a/src/Ably.Tests/Realtime/PresenceTests.cs
+++ b/src/Ably.Tests/Realtime/PresenceTests.cs
@@ -589,7 +589,7 @@ namespace Ably.Tests
             // Arrange
             Mock<IConnectionManager> manager = new Mock<IConnectionManager>();
             Mock<IRealtimeChannel> channel = new Mock<IRealtimeChannel>();
-            channel.SetupGet(c => c.State).Returns(ChannelState.Initialised);
+            channel.SetupGet(c => c.State).Returns(ChannelState.Initialized);
             var target = new Presence(manager.Object, channel.Object, "testClient");
 
             // Act
@@ -600,7 +600,7 @@ namespace Ably.Tests
         }
 
         [Theory]
-        [InlineData(ChannelState.Initialised)]
+        [InlineData(ChannelState.Initialized)]
         [InlineData(ChannelState.Attaching)]
         public void UpdatingPresence_WhenConnectionIsConnecting_QueuesMessages(ChannelState state)
         {
@@ -618,7 +618,7 @@ namespace Ably.Tests
         }
 
         [Theory]
-        [InlineData(ChannelState.Initialised)]
+        [InlineData(ChannelState.Initialized)]
         [InlineData(ChannelState.Attaching)]
         public void UpdatingPresence_WhenChannelIsAttached_SendsQueuedMessages(ChannelState state)
         {
@@ -637,7 +637,7 @@ namespace Ably.Tests
         }
 
         [Theory]
-        [InlineData(ChannelState.Initialised)]
+        [InlineData(ChannelState.Initialized)]
         [InlineData(ChannelState.Attaching)]
         public void UpdatingPresence_WhenChannelIsAttached_SendsQueuedMessages_CallsCallbacks(ChannelState state)
         {
@@ -664,7 +664,7 @@ namespace Ably.Tests
         }
 
         [Theory]
-        [InlineData(ChannelState.Initialised)]
+        [InlineData(ChannelState.Initialized)]
         [InlineData(ChannelState.Attaching)]
         public void UpdatingPresence_WhenChannelIsAttached_SendsQueuedMessages_AsASingleMessage(ChannelState state)
         {
@@ -684,7 +684,7 @@ namespace Ably.Tests
         }
 
         [Theory]
-        [InlineData(ChannelState.Initialised)]
+        [InlineData(ChannelState.Initialized)]
         [InlineData(ChannelState.Attaching)]
         public void UpdatingPresence_WhenChannelIsAttached_SendsQueuedMessages_AsASingleMessage_CallsCallbacks(ChannelState state)
         {
@@ -717,7 +717,7 @@ namespace Ably.Tests
         }
 
         [Theory]
-        [InlineData(ChannelState.Initialised)]
+        [InlineData(ChannelState.Initialized)]
         [InlineData(ChannelState.Attaching)]
         public void UpdatingPresence_WhenChannelIsFailed_FailsQueuedMessages(ChannelState state)
         {
@@ -736,7 +736,7 @@ namespace Ably.Tests
         }
 
         [Theory]
-        [InlineData(ChannelState.Initialised)]
+        [InlineData(ChannelState.Initialized)]
         [InlineData(ChannelState.Attaching)]
         public void UpdatingPresence_WhenChannelIsFailed_FailsQueuedMessages_CallsCallbacks(ChannelState state)
         {

--- a/src/Ably.Tests/Realtime/RealtimeChannelTests.cs
+++ b/src/Ably.Tests/Realtime/RealtimeChannelTests.cs
@@ -35,7 +35,7 @@ namespace Ably.Tests
             Realtime.Channel target = new Realtime.Channel("test", "client", manager.Object);
 
             // Assert
-            Assert.Equal(ChannelState.Initialised, target.State);
+            Assert.Equal(ChannelState.Initialized, target.State);
         }
 
         [Fact]

--- a/src/Ably.Tests/RestTests.cs
+++ b/src/Ably.Tests/RestTests.cs
@@ -49,14 +49,14 @@ namespace Ably.Tests
         }
 
         [Fact]
-        public void Ctor_WithKeyPassedInOptions_InitialisesClient()
+        public void Ctor_WithKeyPassedInOptions_InitializesClient()
         {
             var client = new RestClient(opts => opts.Key = ValidKey);
             Assert.NotNull(client);
         }
 
         [Fact]
-        public void Init_WithKeyInOptions_InitialisesClient()
+        public void Init_WithKeyInOptions_InitializesClient()
         {
             var client = new RestClient(opts => opts.Key = ValidKey);
             Assert.NotNull(client);


### PR DESCRIPTION
See discussion in https://github.com/ably/wiki/issues/68

blind whole-repo `s/nitialis/nitializ/`' - haven't tested it, so please test before merging