### PR TITLE
added specific json converters to TokenRequest

### DIFF
--- a/src/IO.Ably.Shared/TokenRequestPostData.cs
+++ b/src/IO.Ably.Shared/TokenRequestPostData.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using IO.Ably.CustomSerialisers;
 using IO.Ably.Encryption;
 using MsgPack.Serialization;
 using Newtonsoft.Json;
@@ -28,6 +29,7 @@ namespace IO.Ably
 		/// and the attributes of the issuing key
         /// </summary>
         [JsonProperty("ttl")]
+        [JsonConverter(typeof(TimeSpanJsonConverter))]
         public TimeSpan? Ttl { get; set; }
 
 
@@ -37,6 +39,7 @@ namespace IO.Ably
 		/// this capability with the capability of the issuing key.
         /// </summary>
         [JsonProperty("capability", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(CapabilityJsonConverter))]
         public Capability Capability { get; set; }
 
         /// <summary>
@@ -51,6 +54,7 @@ namespace IO.Ably
         /// token requests from being replayed.
         /// </summary>
         [JsonProperty("timestamp")]
+        [JsonConverter(typeof(DateTimeOffsetJsonConverter))]
         public DateTimeOffset? Timestamp
         {
             get { return _timestamp; }


### PR DESCRIPTION
tested this with my sample messaging client referenced in #110 and everything worked great.

previous TokenRequest serialized:
```json
{
    "keyName": "Oz7RFA.puyghg",
    "ttl": "01:00:00",
    "capability": {
        "resources": [
            {
                "name": "*",
                "allowedOperations": [
                    "*"
                ],
                "allowsAll": true
            }
        ]
    },
    "clientId": "7a25852e-9708-4864-a12a-5820199dfcd5",
    "timestamp": "2017-06-21T19:48:52.2411818+00:00",
    "nonce": "fa3cc548dda54f319ac7d736030abf7c",
    "mac": "OhpF6MjBR17hpX+4VhjEi3WMQcJLXQCdQ36EN2rUYNo="
}
```
after this commit:
```json
{
    "keyName": "Oz7RFA.puyghg",
    "ttl": 3600000,
    "capability": "{ \"*\": [ \"*\" ] }",
    "clientId": "c2fd25ff-302a-4209-a400-5963a551ba91",
    "timestamp": 1498085123383,
    "nonce": "4e2c2c07e01b477bb3819cf4845f3a6b",
    "mac": "4lsWB6+414Il29xK1GWe7O9q4aihL5voy8g03ngAgjg="
}
```