### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Subscribing to all events:
 ```csharp
 channel.Subscribe(message =>
 {
-    var name = message.name;
-    var data = message.data;
+    var name = message.Name;
+    var data = message.Data;
 });
 ```
 
@@ -89,8 +89,8 @@ Subscribing to specific events:
 ```csharp
 channel.Subscribe("myEvent", message =>
 {
-    var name = message.name;
-    var data = message.data;
+    var name = message.Name;
+    var data = message.Data;
 });
 ```
 


### PR DESCRIPTION
I spotted some capitalisation errors in the Readme.
The idiomatic C# style is to capitalise publicly accessible properties and methods, which ably-dotnet follows.

https://github.com/ably/ably-dotnet/blob/master/src/IO.Ably.Shared/Types/Message.cs#L43
https://github.com/ably/ably-dotnet/blob/master/src/IO.Ably.Shared/Types/Message.cs#L51