### PR TITLE
Removed obsolete assembly binding redirects from the Test project

### DIFF
--- a/src/IO.Ably.Tests/App.config
+++ b/src/IO.Ably.Tests/App.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+
 <configuration>
   <connectionStrings>
     <add name="Ably" connectionString="AHSz6w.uQXPNQ:FGBZbsKSwqbCpkob" />
@@ -12,47 +13,6 @@
 
 
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-
-
-      <dependentAssembly>
-
-
-        <assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
-
-
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
-
-
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.3.2.0" newVersion="4.3.2.0" />
-      </dependentAssembly>
-
-
-      <dependentAssembly>
-
-
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-
-
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
-
-
-      </dependentAssembly>
-
-
-      <dependentAssembly>
-
-
-        <assemblyIdentity name="System.Threading.ThreadPool" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-
-
-        <bindingRedirect oldVersion="0.0.0.0-4.0.11.0" newVersion="4.0.11.0" />
-
-
-      </dependentAssembly>
-
 
     </assemblyBinding>
 


### PR DESCRIPTION
Assembly binding redirects were causing the test runner to look for an out of date assembly, which caused it to throw an error and thus not run any tests.
Removing the redirects solves the issue