### PR TITLE
A fix to comply with RTL4b 

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Channel.cs
+++ b/src/IO.Ably.Shared/Realtime/Channel.cs
@@ -140,9 +140,9 @@ namespace IO.Ably.Realtime
                 return;
             }
 
-            if (ConnectionState == ConnectionState.Failed)
+            if (IsTerminalConnectionState)
             {
-                throw new AblyException("Cannot attach when connection is in Failed state");
+                throw new AblyException($"Cannot attach when connection is in {ConnectionState.ToString()} state");
             }
 
             if (AttachedAwaiter.StartWait(callback, ConnectionManager.Options.RealtimeRequestTimeout))

--- a/src/IO.Ably.Shared/Realtime/Channel.cs
+++ b/src/IO.Ably.Shared/Realtime/Channel.cs
@@ -142,7 +142,7 @@ namespace IO.Ably.Realtime
 
             if (IsTerminalConnectionState)
             {
-                throw new AblyException($"Cannot attach when connection is in {ConnectionState.ToString()} state");
+                throw new AblyException($"Cannot attach when connection is in {ConnectionState} state");
             }
 
             if (AttachedAwaiter.StartWait(callback, ConnectionManager.Options.RealtimeRequestTimeout))


### PR DESCRIPTION
Using the existing IsTerminalConnectionState (which returns true if the connection is Closed, Closing, Suspended Or Failed and false otherwise) to check if an exception should be thrown when attaching a channel as per RTL4b.

This feature is covered by [this test](https://github.com/ably/ably-dotnet/blob/025cf1e2eccfd3e544e64d0f0da98ca75ac7e343/src/IO.Ably.Tests/Realtime/ChannelSpecs.cs#L268), which now passes.