### PR TITLE
Updates to some test that rely on a delays

### DIFF
--- a/src/IO.Ably.Tests/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ChannelSandboxSpecs.cs
@@ -374,7 +374,15 @@ namespace IO.Ably.Tests.Realtime
 
             await channel.PublishAsync(new Message("test", "best") { ClientId = "client1" });
 
-            await Task.Delay(4000);
+            // wait up to ten seconds
+            for (var i = 0; i < 100; i++)
+            {
+                if (!messageReceived)
+                    await Task.Delay(100);
+                else
+                    break;
+            }
+
             messageReceived.Should().BeTrue();
         }
 

--- a/src/IO.Ably.Tests/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ChannelSpecs.cs
@@ -315,6 +315,13 @@ namespace IO.Ably.Tests.Realtime
 
                 await Task.Delay(150);
 
+                for (var i = 0; i < 5; i++)
+                {
+                    if (_channel.State == ChannelState.Attaching)
+                        await Task.Delay(50);
+                    else
+                        break;
+                }
 
                 _channel.State.Should().Be(previousState);
                 _channel.ErrorReason.Should().NotBeNull();
@@ -457,6 +464,7 @@ namespace IO.Ably.Tests.Realtime
             [Trait("spec", "RTL5f")]
             public async Task ShouldReturnToPreviousStateIfDetachedMessageWasNotReceivedWithinDefaultTimeout()
             {
+                TaskCompletionSource<bool> tsc = new TaskCompletionSource<bool>();
                 SetState(ChannelState.Attached);
                 _client.Options.RealtimeRequestTimeout = TimeSpan.FromMilliseconds(100);
                 bool detachSuccess = true;
@@ -465,9 +473,10 @@ namespace IO.Ably.Tests.Realtime
                 {
                     detachSuccess = success;
                     detachError = error;
+                    tsc.SetResult(true);
                 });
 
-                await Task.Delay(150);
+                await tsc.Task;
 
                 _channel.State.Should().Be(ChannelState.Attached);
                 _channel.ErrorReason.Should().NotBeNull();

--- a/src/IO.Ably.Tests/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ConnectionSandBoxSpecs.cs
@@ -439,8 +439,17 @@ namespace IO.Ably.Tests.Realtime
             await WaitForState(client, ConnectionState.Connected);
 
             await Task.Delay(1000);
-            sentMessages.Where(x => x.Channel == "test-channel" && x.Action == ProtocolMessage.MessageAction.Detach)
-                .Should().HaveCount(2);
+            int count = 0;
+            for (var i = 0; i < 20; i++)
+            {
+                count = sentMessages.Count(x => x.Channel == "test-channel" && x.Action == ProtocolMessage.MessageAction.Detach);
+                if (count < 2)
+                    await Task.Delay(100);
+                else
+                    break;
+            }
+
+            count.ShouldBeEquivalentTo(2);
             channel.State.Should().Be(ChannelState.Detached);
         }
 

--- a/src/IO.Ably.Tests/Realtime/CountDownTimerSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/CountDownTimerSpecs.cs
@@ -58,13 +58,24 @@ namespace IO.Ably.Tests.Realtime
 
             var timeout = TimeSpan.FromMilliseconds(10);
             int called = 0;
-            Action callback = () => Interlocked.Increment(ref called);
-            timer.Start(timeout, callback);
+            void Callback()
+            {
+                Interlocked.Increment(ref called);
+            }
+
+            timer.Start(timeout, Callback);
 
             // Act
             timer.Abort();
-            timer.Start(timeout, callback);
-            await Task.Delay(50);
+            timer.Start(timeout, Callback);
+
+            for (var i = 0; i < 20; i++)
+            {
+                if (called == 0)
+                    await Task.Delay(50);
+                else
+                    break;
+            }
 
             // Assert
             called.Should().Be(1);


### PR DESCRIPTION
I have updated some tests I found to be unreliable because they were assuming a valid response would arrive with in a certain time frame, which was true when the tests were run in isolation, but often not so when the whole suite was run.

Most of the fixes involve changing code like this

`await Task.Delay(100);`

to something like this

`for (var i = 0; i < 10; i++)
{
    if (expectedResult)
        break;
    else        
        await Task.Delay(100);
}`

Which I hope is fairly self explanatory.

For one test it made more sense to use a TaskCompletionSource.