### PR TITLE
Injectable INowProvider

### DIFF
--- a/src/IO.Ably.Shared/AblyRealtime.cs
+++ b/src/IO.Ably.Shared/AblyRealtime.cs
@@ -27,7 +27,7 @@ namespace IO.Ably
 
             RestClient = createRestFunc(options);
             Channels = new RealtimeChannels(this);
-            Connection = new Connection(this);
+            Connection = new Connection(this, options.NowProvider);
             Connection.Initialise();
 
             if (options.AutoConnect)

--- a/src/IO.Ably.Shared/ClientOptions.cs
+++ b/src/IO.Ably.Shared/ClientOptions.cs
@@ -158,7 +158,7 @@ namespace IO.Ably
 
         public INowProvider NowProvider
         {
-            get => _nowProvider ?? (_nowProvider = Defaults.NowProvider);
+            get => _nowProvider ?? (_nowProvider = Defaults.NowProvider());
             set => _nowProvider = value;
         }
 

--- a/src/IO.Ably.Shared/ClientOptions.cs
+++ b/src/IO.Ably.Shared/ClientOptions.cs
@@ -156,7 +156,7 @@ namespace IO.Ably
 
         public SynchronizationContext CustomContext { get; set; }
 
-        public INowProvider NowProvider
+        internal INowProvider NowProvider
         {
             get => _nowProvider ?? (_nowProvider = Defaults.NowProvider());
             set => _nowProvider = value;

--- a/src/IO.Ably.Shared/ClientOptions.cs
+++ b/src/IO.Ably.Shared/ClientOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using IO.Ably.Rest;
+using IO.Ably.Shared;
 using IO.Ably.Transport;
 
 namespace IO.Ably
@@ -8,6 +9,7 @@ namespace IO.Ably
     public class ClientOptions : AuthOptions
     {
         private string _clientId;
+        private INowProvider _nowProvider;
 
         /// <summary>
         ///
@@ -153,6 +155,12 @@ namespace IO.Ably
         public bool CaptureCurrentSynchronizationContext { get; set; } = true;
 
         public SynchronizationContext CustomContext { get; set; }
+
+        public INowProvider NowProvider
+        {
+            get => _nowProvider ?? (_nowProvider = Defaults.NowProvider);
+            set => _nowProvider = value;
+        }
 
         internal AuthMethod Method
         {

--- a/src/IO.Ably.Shared/Config.cs
+++ b/src/IO.Ably.Shared/Config.cs
@@ -1,12 +1,14 @@
 using System;
 using IO.Ably.Encryption;
+using IO.Ably.Shared;
 
 namespace IO.Ably
 {
     public static class Config
     {
         public static Func<CipherParams, IChannelCipher> GetCipher = Crypto.GetCipher;
-        internal static Func<DateTimeOffset> Now = () => DateTimeOffset.UtcNow;
+
+        //internal static Func<DateTimeOffset> Now = () => DateTimeOffset.UtcNow;
         
         public static string Host = "rest.ably.io";
         public const int Port = 80;

--- a/src/IO.Ably.Shared/Defaults.cs
+++ b/src/IO.Ably.Shared/Defaults.cs
@@ -45,7 +45,7 @@ namespace IO.Ably
         /// <summary>The default log level you'll see in the debug output.</summary>
         internal const LogLevel DefaultLogLevel = LogLevel.Warning;
 
-        public static readonly INowProvider NowProvider = new DefaultNowProvider();
+        public static INowProvider NowProvider() => new DefaultNowProvider();
 
 
         static Defaults()

--- a/src/IO.Ably.Shared/Defaults.cs
+++ b/src/IO.Ably.Shared/Defaults.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
+using IO.Ably.Shared;
 using IO.Ably.Transport;
 
 namespace IO.Ably
@@ -44,9 +45,20 @@ namespace IO.Ably
         /// <summary>The default log level you'll see in the debug output.</summary>
         internal const LogLevel DefaultLogLevel = LogLevel.Warning;
 
+        public static readonly INowProvider NowProvider = new DefaultNowProvider();
+
+
         static Defaults()
         {
             FallbackHosts = new[] { "a.ably-realtime.com", "b.ably-realtime.com", "c.ably-realtime.com", "d.ably-realtime.com", "e.ably-realtime.com" };
         }
+
+        private class DefaultNowProvider : INowProvider {
+            public DateTimeOffset Now()
+            {
+                return DateTimeOffset.UtcNow;
+            }
+        }
+
     }
 }

--- a/src/IO.Ably.Shared/Defaults.cs
+++ b/src/IO.Ably.Shared/Defaults.cs
@@ -45,7 +45,7 @@ namespace IO.Ably
         /// <summary>The default log level you'll see in the debug output.</summary>
         internal const LogLevel DefaultLogLevel = LogLevel.Warning;
 
-        public static INowProvider NowProvider() => new DefaultNowProvider();
+        internal static INowProvider NowProvider() => new DefaultNowProvider();
 
 
         static Defaults()

--- a/src/IO.Ably.Shared/Http/AblyHttpClient.cs
+++ b/src/IO.Ably.Shared/Http/AblyHttpClient.cs
@@ -6,10 +6,11 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+using IO.Ably.Shared;
 
 namespace IO.Ably
 {
-    internal class AblyHttpClient : IAblyHttpClient
+    internal class AblyHttpClient : NowProviderConcern, IAblyHttpClient
     {
         internal AblyHttpOptions Options { get; }
 
@@ -17,8 +18,9 @@ namespace IO.Ably
 
         internal HttpClient Client { get; set; }
 
-        internal AblyHttpClient(AblyHttpOptions options, HttpMessageHandler messageHandler =null)
+        internal AblyHttpClient(AblyHttpOptions options, HttpMessageHandler messageHandler = null)
         {
+            NowProvider = options.NowProvider;
             Options = options;
             CreateInternalHttpClient(options.HttpRequestTimeout, messageHandler);
         }
@@ -44,13 +46,13 @@ namespace IO.Ably
             var random = new Random();
 
             int currentTry = 0;
-            var startTime = Config.Now();
+            var startTime = Now();
             var numberOfRetries = Options.HttpMaxRetryCount;
             var host = CustomHost.IsNotEmpty() ? CustomHost : Options.Host;
 
             while (currentTry < numberOfRetries)
             {
-                var requestTime = Config.Now();
+                DateTimeOffset requestTime = Now();
                 if ((requestTime - startTime).TotalSeconds >= Options.HttpMaxRetryDuration.TotalSeconds)
                 {
                     Logger.Error("Cumulative retry timeout of {0}s was exceeded", Config.CommulativeFailedRequestTimeOutInSeconds);
@@ -289,6 +291,7 @@ namespace IO.Ably
                 return "?" + query;
             return string.Empty;
         }
+        
     }
 
 

--- a/src/IO.Ably.Shared/Http/AblyHttpOptions.cs
+++ b/src/IO.Ably.Shared/Http/AblyHttpOptions.cs
@@ -30,7 +30,7 @@ namespace IO.Ably
             HttpMaxRetryCount = 3;
             HttpMaxRetryDuration = TimeSpan.FromSeconds(10);
 
-            NowProvider = Defaults.NowProvider;
+            NowProvider = Defaults.NowProvider();
         }
 
         public AblyHttpOptions(ClientOptions options)

--- a/src/IO.Ably.Shared/Http/AblyHttpOptions.cs
+++ b/src/IO.Ably.Shared/Http/AblyHttpOptions.cs
@@ -16,7 +16,7 @@ namespace IO.Ably
         internal TimeSpan HttpMaxRetryDuration { get; set; }
         public bool IsDefaultHost { get; set; } = true;
 
-        public INowProvider NowProvider { get; set; }
+        internal INowProvider NowProvider { get; set; }
 
         public AblyHttpOptions() //Used for testing
         {

--- a/src/IO.Ably.Shared/Http/AblyHttpOptions.cs
+++ b/src/IO.Ably.Shared/Http/AblyHttpOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using IO.Ably.Shared;
 
 namespace IO.Ably
 {
@@ -15,6 +16,8 @@ namespace IO.Ably
         internal TimeSpan HttpMaxRetryDuration { get; set; }
         public bool IsDefaultHost { get; set; } = true;
 
+        public INowProvider NowProvider { get; set; }
+
         public AblyHttpOptions() //Used for testing
         {
             Host = Defaults.RestHost;
@@ -26,6 +29,8 @@ namespace IO.Ably
             HttpRequestTimeout = TimeSpan.FromSeconds(15);
             HttpMaxRetryCount = 3;
             HttpMaxRetryDuration = TimeSpan.FromSeconds(10);
+
+            NowProvider = Defaults.NowProvider;
         }
 
         public AblyHttpOptions(ClientOptions options)
@@ -40,6 +45,8 @@ namespace IO.Ably
             HttpRequestTimeout = options.HttpRequestTimeout;
             HttpMaxRetryCount = options.IsDefaultRestHost ? options.HttpMaxRetryCount : 1;
             HttpMaxRetryDuration = options.HttpMaxRetryDuration;
+
+            NowProvider = options.NowProvider;
         }
     }
 }

--- a/src/IO.Ably.Shared/INowProvider.cs
+++ b/src/IO.Ably.Shared/INowProvider.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace IO.Ably.Shared
+{
+    public interface INowProvider
+    {
+        DateTimeOffset Now();
+    }
+}

--- a/src/IO.Ably.Shared/IO.Ably.Shared.projitems
+++ b/src/IO.Ably.Shared/IO.Ably.Shared.projitems
@@ -29,7 +29,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)IPlatform.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IRealtimeClient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)JsonHelper.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)NowProviderFactory.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NowProviderConcern.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Realtime\RealtimeChannels.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\RestChannels.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyncExtensions.cs" />

--- a/src/IO.Ably.Shared/IO.Ably.Shared.projitems
+++ b/src/IO.Ably.Shared/IO.Ably.Shared.projitems
@@ -24,10 +24,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\TaskExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpUtility.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IChannelCommands.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)INowProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IoC.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IPlatform.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IRealtimeClient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)JsonHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NowProviderFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Realtime\RealtimeChannels.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\RestChannels.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyncExtensions.cs" />

--- a/src/IO.Ably.Shared/Logger.cs
+++ b/src/IO.Ably.Shared/Logger.cs
@@ -2,6 +2,7 @@ using System;
 using System.Diagnostics;
 using System.Text;
 using System.Threading;
+using IO.Ably.Shared;
 
 namespace IO.Ably
 {
@@ -105,7 +106,7 @@ namespace IO.Ably
         }
 
 
-        internal class InternalLogger
+        internal class InternalLogger : NowProviderConcern
         {
             /// <summary>Maximum level to log.</summary>
             /// <remarks>E.g. set to LogLevel.Warning to have only errors and warnings in the log.</remarks>
@@ -115,10 +116,12 @@ namespace IO.Ably
             public bool IsDebug => LogLevel == LogLevel.Debug;
 
             public InternalLogger() : this(Defaults.DefaultLogLevel, new DefaultLoggerSink()) {}
-            public InternalLogger(LogLevel logLevel, ILoggerSink loggerSink)
+            public InternalLogger(LogLevel logLevel, ILoggerSink loggerSink): this(logLevel, loggerSink, null ) {} 
+            public InternalLogger(LogLevel logLevel, ILoggerSink loggerSink, INowProvider nowProvider)
             {
                 LogLevel = logLevel;
                 LoggerSink = loggerSink;
+                NowProvider = nowProvider ?? Defaults.NowProvider;
             }
 
             public IDisposable SetTempDestination(ILoggerSink i)
@@ -143,7 +146,7 @@ namespace IO.Ably
 
             public string GetLogMessagePreifx()
             {
-                var timeStamp = Config.Now().ToString("hh:mm:ss.fff");
+                var timeStamp = Now().ToString("hh:mm:ss.fff");
                 return $"{timeStamp}";
             }
 

--- a/src/IO.Ably.Shared/Logger.cs
+++ b/src/IO.Ably.Shared/Logger.cs
@@ -121,7 +121,7 @@ namespace IO.Ably
             {
                 LogLevel = logLevel;
                 LoggerSink = loggerSink;
-                NowProvider = nowProvider ?? Defaults.NowProvider;
+                NowProvider = nowProvider ?? Defaults.NowProvider();
             }
 
             public IDisposable SetTempDestination(ILoggerSink i)

--- a/src/IO.Ably.Shared/NowProviderConcern.cs
+++ b/src/IO.Ably.Shared/NowProviderConcern.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace IO.Ably.Shared
+{
+    /// <summary>
+    /// Designed to be inherited by a class (or instanced and composed on to a class that implements INowProvider) that want to be concerned with providing a Now() implementation
+    /// </summary>
+    public class NowProviderConcern : INowProvider
+    {
+        internal INowProvider NowProvider { get; set; }
+        protected NowProviderConcern(INowProvider nowProvider)
+        {
+            NowProvider = nowProvider;
+        }
+
+        public NowProviderConcern()
+        {}
+
+        public DateTimeOffset Now()
+        {
+            return NowProvider.Now();
+        }
+    }
+}

--- a/src/IO.Ably.Shared/Realtime/Connection.cs
+++ b/src/IO.Ably.Shared/Realtime/Connection.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using IO.Ably.Shared;
 using IO.Ably.Transport;
 using IO.Ably.Transport.States.Connection;
 using IO.Ably.Types;
@@ -16,7 +17,7 @@ namespace IO.Ably.Realtime
         Offline
     }
 
-    public sealed class Connection : EventEmitter<ConnectionState, ConnectionStateChange>, IDisposable
+    public sealed class Connection : EventEmitter<ConnectionState, ConnectionStateChange>, IDisposable, INowProvider
     {
         private static readonly ConcurrentBag<WeakReference<Action<NetworkState>>> OsEventSubscribers = new ConcurrentBag<WeakReference<Action<NetworkState>>>();
 
@@ -47,8 +48,11 @@ namespace IO.Ably.Realtime
         internal ChannelMessageProcessor ChannelMessageProcessor { get; set; }
         private string _host;
 
-        internal Connection(AblyRealtime realtimeClient)
+        public INowProvider NowProvider { get; }
+
+        internal Connection(AblyRealtime realtimeClient, INowProvider nowProvider)
         {
+            NowProvider = nowProvider;
             FallbackHosts = Defaults.FallbackHosts.Shuffle().ToList();
             RealtimeClient = realtimeClient;
             RegisterWithOSNetworkStateEvents(HandleNetworkStateChange);
@@ -56,7 +60,7 @@ namespace IO.Ably.Realtime
 
         internal void Initialise()
         {
-            ConnectionManager = new ConnectionManager(this);
+            ConnectionManager = new ConnectionManager(this, NowProvider);
             ChannelMessageProcessor = new ChannelMessageProcessor(ConnectionManager, RealtimeClient.Channels);
             ConnectionState = new ConnectionInitializedState(ConnectionManager);
         }
@@ -153,7 +157,7 @@ namespace IO.Ably.Realtime
 
         public void Ping(Action<TimeSpan?, ErrorInfo> callback)
         {
-            ConnectionHeartbeatRequest.Execute(ConnectionManager, callback);
+            ConnectionHeartbeatRequest.Execute(ConnectionManager, NowProvider, callback);
         }
 
         /// <summary>
@@ -204,6 +208,11 @@ namespace IO.Ably.Realtime
             {
                 Serial = message.ConnectionSerial.Value;
             }
+        }
+
+        public DateTimeOffset Now()
+        {
+            return NowProvider.Now();
         }
     }
 }

--- a/src/IO.Ably.Shared/Realtime/Connection.cs
+++ b/src/IO.Ably.Shared/Realtime/Connection.cs
@@ -48,7 +48,7 @@ namespace IO.Ably.Realtime
         internal ChannelMessageProcessor ChannelMessageProcessor { get; set; }
         private string _host;
 
-        public INowProvider NowProvider { get; }
+        internal INowProvider NowProvider { get; }
 
         internal Connection(AblyRealtime realtimeClient, INowProvider nowProvider)
         {

--- a/src/IO.Ably.Shared/TokenDetails.cs
+++ b/src/IO.Ably.Shared/TokenDetails.cs
@@ -45,7 +45,7 @@ namespace IO.Ably
 
         public TokenDetails()
         {
-            NowProvider = Defaults.NowProvider;
+            NowProvider = Defaults.NowProvider();
         }
         public TokenDetails(INowProvider nowProvider)
         {
@@ -55,7 +55,7 @@ namespace IO.Ably
         public TokenDetails(string token)
         {
             Token = token;
-            NowProvider = Defaults.NowProvider;
+            NowProvider = Defaults.NowProvider();
         }
         public TokenDetails(string token, INowProvider nowProvider)
         {

--- a/src/IO.Ably.Shared/TokenDetails.cs
+++ b/src/IO.Ably.Shared/TokenDetails.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using IO.Ably.Shared;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -7,7 +8,7 @@ namespace IO.Ably
     /// <summary>
     /// A class providing details of a token and its associated metadata
     /// </summary>
-    public sealed class TokenDetails
+    public sealed class TokenDetails : NowProviderConcern
     {
         /// <summary>
         /// The allowed capabilities for this token. <see cref="Capability"/>
@@ -41,19 +42,30 @@ namespace IO.Ably
 
         [JsonProperty("keyName")]
         public string KeyName { get; set; }
-       
+
         public TokenDetails()
         {
+            NowProvider = Defaults.NowProvider;
+        }
+        public TokenDetails(INowProvider nowProvider)
+        {
+            NowProvider = nowProvider;
         }
 
         public TokenDetails(string token)
         {
             Token = token;
+            NowProvider = Defaults.NowProvider;
+        }
+        public TokenDetails(string token, INowProvider nowProvider)
+        {
+            Token = token;
+            NowProvider = nowProvider;
         }
 
         public void Expire()
         {
-            Expires = Config.Now().AddDays(-1);
+            Expires = Now().AddDays(-1);
         }
 
         /// <summary>
@@ -105,7 +117,7 @@ namespace IO.Ably
             if (token == null)
                 return false;
             var exp = token.Expires;
-            return (exp == DateTimeOffset.MinValue) || (exp >= Config.Now());
+            return (exp == DateTimeOffset.MinValue) || (exp >= token.Now());
         }
     }
 }

--- a/src/IO.Ably.Shared/TokenRequestPostData.cs
+++ b/src/IO.Ably.Shared/TokenRequestPostData.cs
@@ -11,7 +11,7 @@ namespace IO.Ably
 
         public TokenRequest() : this(Defaults.NowProvider())
         {}
-        public TokenRequest(INowProvider nowProvider)
+        internal TokenRequest(INowProvider nowProvider)
         {
             NowProvider = nowProvider;
             Nonce = Guid.NewGuid().ToString("N").ToLower();

--- a/src/IO.Ably.Shared/TokenRequestPostData.cs
+++ b/src/IO.Ably.Shared/TokenRequestPostData.cs
@@ -11,7 +11,7 @@ namespace IO.Ably
 
         public TokenRequest()
         {
-            NowProvider = Defaults.NowProvider;
+            NowProvider = Defaults.NowProvider();
         }
         public TokenRequest(INowProvider nowProvider)
         {

--- a/src/IO.Ably.Shared/TokenRequestPostData.cs
+++ b/src/IO.Ably.Shared/TokenRequestPostData.cs
@@ -1,15 +1,21 @@
 using System;
 using IO.Ably.Encryption;
+using IO.Ably.Shared;
 using Newtonsoft.Json;
 
 namespace IO.Ably
 {
-    public class TokenRequest
+    public class TokenRequest : NowProviderConcern
     {
         private DateTimeOffset? _timestamp;
 
         public TokenRequest()
         {
+            NowProvider = Defaults.NowProvider;
+        }
+        public TokenRequest(INowProvider nowProvider)
+        {
+            NowProvider = nowProvider;
             Nonce = Guid.NewGuid().ToString("N").ToLower();
         }
 
@@ -76,7 +82,7 @@ namespace IO.Ably
             this.KeyName = keyName;
             Capability = tokenParams.Capability ?? Capability.AllowAll;
             ClientId = tokenParams.ClientId;
-            var now = Config.Now();
+            var now = Now();
 
             if (tokenParams.Nonce.IsNotEmpty())
                 Nonce = tokenParams.Nonce;

--- a/src/IO.Ably.Shared/TokenRequestPostData.cs
+++ b/src/IO.Ably.Shared/TokenRequestPostData.cs
@@ -9,10 +9,8 @@ namespace IO.Ably
     {
         private DateTimeOffset? _timestamp;
 
-        public TokenRequest()
-        {
-            NowProvider = Defaults.NowProvider();
-        }
+        public TokenRequest() : this(Defaults.NowProvider())
+        {}
         public TokenRequest(INowProvider nowProvider)
         {
             NowProvider = nowProvider;

--- a/src/IO.Ably.Shared/Transport/ConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionManager.cs
@@ -3,12 +3,13 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using IO.Ably.MessageEncoders;
 using IO.Ably.Realtime;
+using IO.Ably.Shared;
 using IO.Ably.Transport.States.Connection;
 using IO.Ably.Types;
 
 namespace IO.Ably.Transport
 {
-    internal class ConnectionManager : IConnectionManager, ITransportListener, IConnectionContext
+    internal class ConnectionManager : NowProviderConcern, IConnectionManager, ITransportListener, IConnectionContext
     {
         public Queue<MessageAndCallback> PendingMessages { get; }
         //internal readonly AsyncContextThread AsyncContextThread = new AsyncContextThread();
@@ -57,10 +58,11 @@ namespace IO.Ably.Transport
             }
         }
 
-        public ConnectionManager(Connection connection)
+        public ConnectionManager(Connection connection, INowProvider nowProvider)
         {
+            NowProvider = nowProvider;
             PendingMessages = new Queue<MessageAndCallback>();
-            AttemptsInfo = new ConnectionAttemptsInfo(connection);
+            AttemptsInfo = new ConnectionAttemptsInfo(connection, nowProvider);
             Connection = connection;
             AckProcessor = new AcknowledgementProcessor(connection);
 

--- a/src/IO.Ably.Tests/AuthTests/AuthorisationTests.cs
+++ b/src/IO.Ably.Tests/AuthTests/AuthorisationTests.cs
@@ -204,7 +204,7 @@ namespace IO.Ably.Tests
             [Trait("spec", "RSA9d")]
             public async Task WithQueryTimeQueriesForTimestamp()
             {
-                var currentTime = Config.Now();
+                var currentTime = TestHelpers.Now();
                 var client = GetRestClient(x => ("[" + currentTime.ToUnixTimeInMilliseconds() + "]").ToAblyJsonResponse());
 
                 var data = await CreateTokenRequest(client, null, new AuthOptions() { QueryTime = true });

--- a/src/IO.Ably.Tests/AuthTests/AuthoriseTests.cs
+++ b/src/IO.Ably.Tests/AuthTests/AuthoriseTests.cs
@@ -19,7 +19,7 @@ namespace IO.Ably.Tests.AuthTests
         [Trait("spec", "RSA10a")]
         public async Task Authorise_WithNotExpiredCurrentTokenAndForceFalse_ReturnsCurrentToken()
         {
-            var client = GetRestClient(null, opts => opts.TokenDetails = new TokenDetails() { Expires = Config.Now().AddHours(1) });
+            var client = GetRestClient(null, opts => opts.TokenDetails = new TokenDetails() { Expires = TestHelpers.Now().AddHours(1) });
 
             var token = await client.Auth.AuthoriseAsync();
 
@@ -62,7 +62,7 @@ namespace IO.Ably.Tests.AuthTests
         public async Task Authorise_WithNotExpiredCurrentTokenAndForceTrue_RequestsNewToken()
         {
             var client = GetRestClient();
-            var initialToken = new TokenDetails() { Expires = Config.Now().AddHours(1) };
+            var initialToken = new TokenDetails() { Expires = TestHelpers.Now().AddHours(1) };
             client.AblyAuth.CurrentToken = initialToken;
 
             var token = await client.Auth.AuthoriseAsync(new TokenParams() { ClientId = "123", Capability = new Capability() }, new AuthOptions { Force = true});
@@ -76,7 +76,7 @@ namespace IO.Ably.Tests.AuthTests
         public async Task Authorise_WithExpiredCurrentToken_RequestsNewToken()
         {
             var client = GetRestClient();
-            var initialToken = new TokenDetails() { Expires = Config.Now().AddHours(-1) };
+            var initialToken = new TokenDetails() { Expires = TestHelpers.Now().AddHours(-1) };
             client.AblyAuth.CurrentToken = initialToken;
 
             var token = await client.Auth.AuthoriseAsync();

--- a/src/IO.Ably.Tests/Infrastructure/AblySpecs.cs
+++ b/src/IO.Ably.Tests/Infrastructure/AblySpecs.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using IO.Ably.Shared;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -50,13 +51,26 @@ namespace IO.Ably.Tests
         public ITestOutputHelper Output { get; }
         public const string ValidKey = "1iZPfA.BjcI_g:wpNhw5RCw6rDjisl";
 
-        public DateTimeOffset Now { get; set; }
+        public DateTimeOffset Now
+        {
+            get => NowProvider.Now();
+            set { throw new NotImplementedException(); }
+        }
+
+        public INowProvider NowProvider { get; set; }
 
         public AblySpecs(ITestOutputHelper output)
         {
-            Now = Config.Now();
-            Config.Now = () => Now;    
+            NowProvider = new AblySpecsNowProvider();
             Output = output;
+        }
+
+        internal class AblySpecsNowProvider : INowProvider
+        {
+            public DateTimeOffset Now()
+            {
+                return TestHelpers.Now();
+            }
         }
     }
 }

--- a/src/IO.Ably.Tests/Infrastructure/AblySpecs.cs
+++ b/src/IO.Ably.Tests/Infrastructure/AblySpecs.cs
@@ -51,15 +51,23 @@ namespace IO.Ably.Tests
         public ITestOutputHelper Output { get; }
         public const string ValidKey = "1iZPfA.BjcI_g:wpNhw5RCw6rDjisl";
 
-        public DateTimeOffset Now
-        {
-            get => NowProvider.Now();
-            set { throw new NotImplementedException(); }
-        }
+        public DateTimeOffset Now => NowProvider.Now();
 
         public INowProvider NowProvider { get; set; }
 
-        public AblySpecs(ITestOutputHelper output)
+        public void SetNowFunc(Func<DateTimeOffset> nowFunc) => ((AblySpecsNowProvider) NowProvider).NowFunc = nowFunc;
+
+        public void NowAddSeconds(int s)
+        {
+            NowAdd(TimeSpan.FromSeconds(s));
+        }
+        public void NowAdd(TimeSpan ts)
+        {
+            var n = Now.Add(ts);
+            SetNowFunc(() => n);
+        }
+        
+        protected AblySpecs(ITestOutputHelper output)
         {
             NowProvider = new AblySpecsNowProvider();
             Output = output;
@@ -67,10 +75,16 @@ namespace IO.Ably.Tests
 
         internal class AblySpecsNowProvider : INowProvider
         {
+            public AblySpecsNowProvider()
+            {
+                NowFunc = TestHelpers.Now;
+            }
             public DateTimeOffset Now()
             {
-                return TestHelpers.Now();
+                return NowFunc();
             }
+
+            public Func<DateTimeOffset> NowFunc { get; set; }
         }
     }
 }

--- a/src/IO.Ably.Tests/Infrastructure/FakeConnectionContext.cs
+++ b/src/IO.Ably.Tests/Infrastructure/FakeConnectionContext.cs
@@ -24,7 +24,7 @@ namespace IO.Ably.Tests
 
         public FakeConnectionContext()
         {
-            Connection = new Connection(null);
+            Connection = new Connection(null, TestHelpers.NowProvider());
         }
 
         public ConnectionStateBase LastSetState { get; set; }

--- a/src/IO.Ably.Tests/Infrastructure/TestHelpers.cs
+++ b/src/IO.Ably.Tests/Infrastructure/TestHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using IO.Ably.Shared;
 using Xunit;
 
 namespace IO.Ably.Tests
@@ -10,6 +11,16 @@ namespace IO.Ably.Tests
             Assert.True(request.QueryParameters.ContainsKey(key),
                 String.Format("Header '{0}' doesn't exist in request", key));
             Assert.Equal(value, request.QueryParameters[key]);
+        }
+
+        public static DateTimeOffset Now()
+        {
+            return NowProvider().Now();
+        }
+
+        public static INowProvider NowProvider()
+        {
+            return Defaults.NowProvider;
         }
     }
 }

--- a/src/IO.Ably.Tests/Infrastructure/TestHelpers.cs
+++ b/src/IO.Ably.Tests/Infrastructure/TestHelpers.cs
@@ -20,7 +20,7 @@ namespace IO.Ably.Tests
 
         public static INowProvider NowProvider()
         {
-            return Defaults.NowProvider;
+            return Defaults.NowProvider();
         }
     }
 }

--- a/src/IO.Ably.Tests/MessageEncodes/MessageEncodersAcceptanceTests.cs
+++ b/src/IO.Ably.Tests/MessageEncodes/MessageEncodersAcceptanceTests.cs
@@ -42,7 +42,7 @@ namespace IO.Ably.AcceptanceTests
                 {
                     yield return new object[] { new Message("int", 1) };
                     yield return new object[] { new Message("float", 1.1) };
-                    yield return new object[] { new Message("date", Config.Now()) };
+                    yield return new object[] { new Message("date", TestHelpers.Now()) };
                 }
             }
 

--- a/src/IO.Ably.Tests/Realtime/AckProtocolTests.cs
+++ b/src/IO.Ably.Tests/Realtime/AckProtocolTests.cs
@@ -137,7 +137,7 @@ namespace IO.Ably.Tests.Realtime
         {
             // Arrange
             var ackProcessor = GetAckProcessor();
-            AcknowledgementProcessor target = new AcknowledgementProcessor(new Connection(new AblyRealtime(ValidKey)));
+            AcknowledgementProcessor target = new AcknowledgementProcessor(new Connection(new AblyRealtime(ValidKey), TestHelpers.NowProvider()));
             List<Tuple<bool, ErrorInfo>> callbacks = new List<Tuple<bool, ErrorInfo>>();
 
             // Act
@@ -203,7 +203,7 @@ namespace IO.Ably.Tests.Realtime
 
         private AcknowledgementProcessor GetAckProcessor()
         {
-            var connection = new Connection(new AblyRealtime(ValidKey));
+            var connection = new Connection(new AblyRealtime(ValidKey), TestHelpers.NowProvider());
             connection.Initialise();
             return new AcknowledgementProcessor(connection);
         }

--- a/src/IO.Ably.Tests/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ChannelSpecs.cs
@@ -313,7 +313,14 @@ namespace IO.Ably.Tests.Realtime
                 _client.Options.RealtimeRequestTimeout = TimeSpan.FromMilliseconds(100);
                 _channel.Attach();
 
-                await Task.Delay(150);
+                await Task.Delay(120);
+                for (int i = 0; i < 10; i++)
+                {
+                    if (_channel.State != previousState)
+                        await Task.Delay(50);
+                    else
+                        break;
+                }
 
 
                 _channel.State.Should().Be(previousState);

--- a/src/IO.Ably.Tests/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ChannelSpecs.cs
@@ -950,6 +950,9 @@ namespace IO.Ably.Tests.Realtime
             [Fact]
             public async Task WithProtocolMessage_ShouldSetMessageTimestampWhenNotThere()
             {
+                SetNowFunc(() => DateTimeOffset.UtcNow);
+                var timeStamp = Now;
+
                 var channel = _client.Channels.Get("test");
 
                 SetState(channel, ChannelState.Attached);
@@ -960,16 +963,16 @@ namespace IO.Ably.Tests.Realtime
                     receivedMessages.Add(msg);
                 });
 
-                var protocolMessage = SetupTestProtocolmessage(timestamp: Now, messages: new[]
+                var protocolMessage = SetupTestProtocolmessage(timestamp: timeStamp, messages: new[]
                 {
                     new Message("message1", "data"),
-                    new Message("message1", "data") {Timestamp = Now.AddMinutes(1)},
+                    new Message("message1", "data") {Timestamp = timeStamp.AddMinutes(1)},
                 });
 
                 await _client.FakeProtocolMessageReceived(protocolMessage);
 
-                receivedMessages.First().Timestamp.Should().Be(Now);
-                receivedMessages.Last().Timestamp.Should().Be(Now.AddMinutes(1));
+                receivedMessages.First().Timestamp.Should().Be(timeStamp);
+                receivedMessages.Last().Timestamp.Should().Be(timeStamp.AddMinutes(1));
             }
 
             private ProtocolMessage SetupTestProtocolmessage(string connectionId = null, DateTimeOffset? timestamp = null,  Message[] messages = null)

--- a/src/IO.Ably.Tests/Realtime/ConnectionAttempsInfoSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ConnectionAttempsInfoSpecs.cs
@@ -32,22 +32,26 @@ namespace IO.Ably.Tests.Realtime
         [Fact]
         public void ShouldSuspend_WhenFirstAttemptIsWithinConnectionStateTtl_ShouldReturnFalse()
         {
-            _info.Attempts.Add(new ConnectionAttempt(TestHelpers.Now()));
+            SetNowFunc(() => DateTimeOffset.UtcNow);
+            _info.Attempts.Add(new ConnectionAttempt(Now));
             //Move now to default ConnetionStatettl - 1 second
-            Now = Now.Add(Defaults.ConnectionStateTtl.Add(TimeSpan.FromSeconds(-1)));
+            NowAdd(Defaults.ConnectionStateTtl.Add(TimeSpan.FromSeconds(-1)));
             _info.ShouldSuspend().Should().BeFalse();
         }
         [Fact]
         public void ShouldSuspend_WhenFirstAttemptEqualOrGreaterThanConnectionStateTtl_ShouldReturnTrue()
         {
-            _info.Reset();
-            Now = DateTimeOffset.Now;
-            _info.Attempts.Add(new ConnectionAttempt(Now));
+            SetNowFunc(() => DateTimeOffset.UtcNow);
+            var connection = new Connection(GetRealtime(), NowProvider);
+            var info = new ConnectionAttemptsInfo(connection);
+
+            //_info.Reset();
+            info.Attempts.Add(new ConnectionAttempt(Now));
             //Move now to default ConnetionStatettl - 1 second
-            Now = Now.Add(Defaults.ConnectionStateTtl);
-            _info.ShouldSuspend().Should().BeTrue("When time is equal"); // =
-            Now = Now.AddSeconds(60);
-            _info.ShouldSuspend().Should().BeTrue("When time is greater than"); // >
+            NowAdd(Defaults.ConnectionStateTtl);
+            info.ShouldSuspend().Should().BeTrue("When time is equal"); // =
+            NowAddSeconds(60);
+            info.ShouldSuspend().Should().BeTrue("When time is greater than"); // >
         }
 
         [Fact]

--- a/src/IO.Ably.Tests/Realtime/ConnectionAttempsInfoSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ConnectionAttempsInfoSpecs.cs
@@ -32,7 +32,7 @@ namespace IO.Ably.Tests.Realtime
         [Fact]
         public void ShouldSuspend_WhenFirstAttemptIsWithinConnectionStateTtl_ShouldReturnFalse()
         {
-            _info.Attempts.Add(new ConnectionAttempt(Config.Now()));
+            _info.Attempts.Add(new ConnectionAttempt(TestHelpers.Now()));
             //Move now to default ConnetionStatettl - 1 second
             Now = Now.Add(Defaults.ConnectionStateTtl.Add(TimeSpan.FromSeconds(-1)));
             _info.ShouldSuspend().Should().BeFalse();
@@ -40,12 +40,13 @@ namespace IO.Ably.Tests.Realtime
         [Fact]
         public void ShouldSuspend_WhenFirstAttemptEqualOrGreaterThanConnectionStateTtl_ShouldReturnTrue()
         {
+            _info.Reset();
             Now = DateTimeOffset.Now;
             _info.Attempts.Add(new ConnectionAttempt(Now));
             //Move now to default ConnetionStatettl - 1 second
             Now = Now.Add(Defaults.ConnectionStateTtl);
             _info.ShouldSuspend().Should().BeTrue("When time is equal"); // =
-            Now = Now.AddSeconds(10);
+            Now = Now.AddSeconds(60);
             _info.ShouldSuspend().Should().BeTrue("When time is greater than"); // >
         }
 
@@ -83,12 +84,12 @@ namespace IO.Ably.Tests.Realtime
 
         private ConnectionAttemptsInfo Create(Action<ClientOptions> optionsAction = null)
         {
-            return new ConnectionAttemptsInfo(new Connection(GetRealtime(optionsAction)));
+            return new ConnectionAttemptsInfo(new Connection(GetRealtime(optionsAction), TestHelpers.NowProvider()));
         }
 
         public ConnectionAttemptsInfoSpecs(ITestOutputHelper output) : base(output)
         {
-            _connection = new Connection(GetRealtime());
+            _connection = new Connection(GetRealtime(), TestHelpers.NowProvider());
             _info = new ConnectionAttemptsInfo(_connection);
         }
 

--- a/src/IO.Ably.Tests/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ConnectionSandBoxSpecs.cs
@@ -197,7 +197,7 @@ namespace IO.Ably.Tests.Realtime
             _resetEvent.WaitOne(10000);
 
             realtimeClient.RestClient.AblyAuth.CurrentToken.Expires.Should()
-                .BeAfter(Config.Now(), "The token should be valid and expire in the future.");
+                .BeAfter(TestHelpers.Now(), "The token should be valid and expire in the future.");
             error.Should().BeNull("No error should be raised!");
         }
 

--- a/src/IO.Ably.Tests/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
@@ -15,7 +15,7 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
 {
     public class ConnectingFailureSpecs : ConnectionSpecsBase
     {
-        private TokenDetails _returnedDummyTokenDetails = new TokenDetails("123") { Expires = Config.Now().AddDays(1), ClientId = "123" };
+        private TokenDetails _returnedDummyTokenDetails = new TokenDetails("123") { Expires = TestHelpers.Now().AddDays(1), ClientId = "123" };
         private int _tokenErrorCode = 40140;
 
         [Fact]

--- a/src/IO.Ably.Tests/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
@@ -233,6 +233,7 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
                 opts.AutoConnect = false;
                 opts.DisconnectedRetryTimeout = TimeSpan.FromMilliseconds(10);
                 opts.SuspendedRetryTimeout = TimeSpan.FromMilliseconds(100);
+                opts.NowProvider = NowProvider;
             });
 
             client.Connect();

--- a/src/IO.Ably.Tests/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
@@ -15,7 +15,7 @@ namespace IO.Ably.Tests.Realtime
     [Trait("spec", "RTN15")]
     public class ConnectionFailuresOnceConnectedSpecs : ConnectionSpecsBase
     {
-        private TokenDetails _returnedDummyTokenDetails = new TokenDetails("123") { Expires = Config.Now().AddDays(1), ClientId = "123" };
+        private TokenDetails _returnedDummyTokenDetails = new TokenDetails("123") { Expires = TestHelpers.Now().AddDays(1), ClientId = "123" };
         private int _tokenErrorCode = 40140;
         private bool _renewTokenCalled;
         private TokenDetails _validToken;

--- a/src/IO.Ably.Tests/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
@@ -289,7 +289,7 @@ namespace IO.Ably.Tests.Realtime
 
         public ConnectionFailuresOnceConnectedSpecs(ITestOutputHelper output) : base(output)
         {
-            Now = DateTimeOffset.Now;
+            SetNowFunc(() => DateTimeOffset.UtcNow);
             _validToken = new TokenDetails("id") { Expires = Now.AddHours(1) };
             _renewTokenCalled = false;
             _tokenErrorInfo = new ErrorInfo() { Code = _tokenErrorCode, StatusCode = HttpStatusCode.Unauthorized };

--- a/src/IO.Ably.Tests/Realtime/ConnectionSpecs/ConnectionFallbackSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ConnectionSpecs/ConnectionFallbackSpecs.cs
@@ -213,15 +213,15 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
             };
 
             List<string> retryHosts = new List<string>();
+            retryHosts.Add(LastCreatedTransport.Parameters.Host);
 
             await client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Error)
             {
                 Error = new ErrorInfo() { StatusCode = HttpStatusCode.GatewayTimeout }
             });
-
             for (int i = 0; i < 5; i++)
             {
-                Now = Now.AddSeconds(60);
+                SetNowFunc(() => DateTimeOffset.UtcNow.AddSeconds(60));
                 if (client.Connection.State == ConnectionState.Connecting)
                 {
                     retryHosts.Add(LastCreatedTransport.Parameters.Host);

--- a/src/IO.Ably.Tests/Realtime/ConnectionSpecs/ConnectionPingSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ConnectionSpecs/ConnectionPingSpecs.cs
@@ -28,12 +28,13 @@ namespace IO.Ably.Tests.Realtime
         [Trait("spec", "RTN13a")]
         public async Task OnHeartBeatMessageReceived_ShouldReturnElapsedTime()
         {
-            Now = DateTimeOffset.UtcNow;
+            SetNowFunc(() => DateTimeOffset.UtcNow);
             var client = GetConnectedClient();
 
             _fakeTransportFactory.LastCreatedTransport.SendAction = async message =>
             {
-                Now = Now.AddMilliseconds(100);
+
+                NowAdd(TimeSpan.FromMilliseconds(100));
                 if (message.Original.Action == ProtocolMessage.MessageAction.Heartbeat)
                 {
                     await Task.Delay(1);

--- a/src/IO.Ably.Tests/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/PresenceSandboxSpecs.cs
@@ -207,7 +207,7 @@ namespace IO.Ably.Tests.Realtime
                                     {
                                         ConnectionId = $"{client.Connection.Id}",
                                         Id = $"{client.Connection.Id}-#{clientId}:0",
-                                        Timestamp = Config.Now(),
+                                        Timestamp = TestHelpers.Now(),
                                     }
                                 }
                             };

--- a/src/IO.Ably.Tests/Rest/RestSpecs.cs
+++ b/src/IO.Ably.Tests/Rest/RestSpecs.cs
@@ -490,7 +490,7 @@ namespace IO.Ably.Tests
                     () =>
                     {
                         //Tweak time to pretend 10 seconds have ellapsed
-                        Now += TimeSpan.FromSeconds(10);
+                        NowAddSeconds(10);
                     });
 
                 client.HttpClient.CreateInternalHttpClient(TimeSpan.FromSeconds(6), handler);

--- a/src/IO.Ably.Tests/Rest/RestSpecs.cs
+++ b/src/IO.Ably.Tests/Rest/RestSpecs.cs
@@ -141,7 +141,7 @@ namespace IO.Ably.Tests
             [Trait("intermittent", "true")]
             public async Task WhenErrorCodeIsTokenSpecific_ShouldAutomaticallyTryToRenewTokenIfRequestFails(int errorCode)
             {
-                Now = DateTimeOffset.Now;
+                //Now = DateTimeOffset.Now;
                 var tokenDetails = new TokenDetails("id") { Expires = Now.AddHours(1) };
                 //Had to inline the method otherwise the tests intermittently fail.
                 bool firstAttempt = true;
@@ -600,7 +600,6 @@ namespace IO.Ably.Tests
         [Fact]
         public async Task ClientWithExpiredTokenAutomaticallyCreatesANewOne()
         {
-            Config.Now = () => DateTimeOffset.UtcNow;
             bool newTokenRequested = false;
             var options = new ClientOptions
             {
@@ -612,7 +611,8 @@ namespace IO.Ably.Tests
                         Expires = DateTimeOffset.UtcNow.AddDays(1)
                     });
                 },
-                UseBinaryProtocol = false
+                UseBinaryProtocol = false,
+                NowProvider = TestHelpers.NowProvider()
             };
             var rest = new AblyRest(options);
             rest.ExecuteHttpRequest = request => "[{}]".ToAblyResponse();
@@ -630,7 +630,8 @@ namespace IO.Ably.Tests
             {
                 ClientId = "test",
                 Key = "best",
-                UseBinaryProtocol = false
+                UseBinaryProtocol = false,
+                NowProvider = TestHelpers.NowProvider()
             };
             var rest = new AblyRest(options);
             var token = new TokenDetails("123") { Expires = DateTimeOffset.UtcNow.AddHours(1) };

--- a/src/IO.Ably.Tests/Rest/SandboxSpec.cs
+++ b/src/IO.Ably.Tests/Rest/SandboxSpec.cs
@@ -20,7 +20,7 @@ namespace IO.Ably.Tests
             Fixture = fixture;
             Output = output;
             //Reset time in case other tests have changed it
-            Config.Now = () => DateTimeOffset.UtcNow;
+            //Config.Now = () => DateTimeOffset.UtcNow;
 
             // Very useful for debugging failing tests.
             //Logger.LoggerSink = new OutputLoggerSink(output);

--- a/src/IO.Ably.Tests/TokenRequestDataTests.cs
+++ b/src/IO.Ably.Tests/TokenRequestDataTests.cs
@@ -1,12 +1,27 @@
 ﻿using System;
 using FluentAssertions;
 using IO.Ably.Encryption;
+using IO.Ably.Shared;
 using Xunit;
 
 namespace IO.Ably.Tests
 {
     public class TokenRequestPopulateTests
     {
+        internal class NowProvider : INowProvider
+        {
+            private DateTimeOffset _now;
+            public NowProvider(DateTimeOffset now)
+            {
+                _now = now;
+            }
+            public DateTimeOffset Now()
+            {
+                return _now;
+            }
+        }
+
+
         private const string ApiKey = "123.456:789";
         public readonly DateTimeOffset Now = DateHelper.CreateDate(2012, 12, 12, 10, 10, 10);
 
@@ -37,8 +52,7 @@ namespace IO.Ably.Tests
         /// </summary>
         public TokenRequestPopulateTests()
         {
-            Config.Now = () => Now;
-            _request = new TokenRequest();
+            _request = new TokenRequest(new NowProvider(Now));
         }
 
         [Fact]


### PR DESCRIPTION
To enabled more reliable testing I have replaced the usage of the static Config.Now() with a local Now() method for each class that needs it.

The Now() method implementation is passed in to the constructor as an implementation of an INowProvider. 

An INowProvider implementation can be passed in externally via ClientOptions, if not specified then the existing default behaviour is used (DateTimeOffset.UtcNow)

For classes that need access to Now(), I have added a class called NowProviderConcern. This is designed to be inherited (or on classes that are already inheriting, instanced and composed implementing the INowProvider interface). I am not entirely convinced by the name 'NowProviderConcern' but the idea is that is is used by classed that are concerned with providing Now(), I am open to alternate suggestions.

For a specific examples of why this is useful see the tests 'ShouldSuspend_WhenFirstAttemptEqualOrGreaterThanConnectionStateTtl_ShouldReturnTrue' or 'WhenInSuspendedState_ShouldTryAndReconnectAfterSuspendRetryTimeoutIsReached'
