### PR TITLE
simplified the message queue logic in ConnectionManager

### DIFF
--- a/src/IO.Ably.Shared/Transport/ConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionManager.cs
@@ -451,10 +451,7 @@ namespace IO.Ably.Transport
 
         private async Task ProcessQueuedMessages()
         {
-            if(_queuedTransportMessages == null)
-                return;
-
-            while (_queuedTransportMessages.TryDequeue(out var message))
+            while (_queuedTransportMessages != null && _queuedTransportMessages.TryDequeue(out var message))
             {
                 if (Logger.IsDebug) Logger.Debug("Proccessing queued message: " + message);
                 await ProcessTransportMessage(message);

--- a/src/IO.Ably.Shared/Transport/ConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionManager.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using IO.Ably.MessageEncoders;
@@ -39,7 +40,7 @@ namespace IO.Ably.Transport
         private readonly object _pendingQueueLock = new object();
         private volatile ConnectionStateBase _inTransitionToState;
 
-        private List<ProtocolMessage> _queuedTransportMessages = new List<ProtocolMessage>();
+        private ConcurrentQueue<ProtocolMessage> _queuedTransportMessages = new ConcurrentQueue<ProtocolMessage>();
 
         public void ClearAckQueueAndFailMessages(ErrorInfo error) => AckProcessor.ClearQueueAndFailMessages(error);
 
@@ -133,7 +134,7 @@ namespace IO.Ably.Transport
                     Logger.Error("Error attaching to context", ex);
 
                     lock (_transportQueueLock)
-                        _queuedTransportMessages.Clear();
+                        _queuedTransportMessages = new ConcurrentQueue<ProtocolMessage>();
 
                     Connection.UpdateState(newState);
 
@@ -406,11 +407,8 @@ namespace IO.Ably.Transport
 
         void ITransportListener.OnTransportDataReceived(RealtimeTransportData data)
         {
-            ExecuteOnManagerThread(() =>
-            {
-                var message = Handler.ParseRealtimeData(data);
-                return OnTransportMessageReceived(message);
-            });
+            var message = Handler.ParseRealtimeData(data);
+            OnTransportMessageReceived(message).WaitAndUnwrapException();
         }
 
         public Task Execute(Action action)
@@ -446,36 +444,20 @@ namespace IO.Ably.Transport
 
         public async Task OnTransportMessageReceived(ProtocolMessage message)
         {
-            if (_inTransitionToState != null)
-            {
-                if (Logger.IsDebug)
-                {
-                    Logger.Debug($"InState transition to '{_inTransitionToState}'. Queuing tranport message until state updates");
-                }
+            _queuedTransportMessages.Enqueue(message);
 
-                lock (_transportQueueLock)
-                    _queuedTransportMessages.Add(message);
-            }
-            else
-            {
-                await ProcessTransportMessage(message);
-            }
+            if (_inTransitionToState == null)
+                await ProcessQueuedMessages();
+            
         }
 
         private async Task ProcessQueuedMessages()
         {
-            List<ProtocolMessage> copy;
-            lock (_transportQueueLock)
-            {
-                copy = _queuedTransportMessages;
-                _queuedTransportMessages = new List<ProtocolMessage>();
-            }
-
-            foreach (var message in copy)
+            while (_queuedTransportMessages.TryDequeue(out var message))
             {
                 if (Logger.IsDebug) Logger.Debug("Proccessing queued message: " + message);
-
                 await ProcessTransportMessage(message);
+                message = null;
             }
         }
 


### PR DESCRIPTION
Previously messages would be added to a list if the Connection Manager was transitioning to a new state, but processed immediately if not. 
If found this logic quite hard to follow when looking for possible race conditions but I could see the intent, so I have changed it so all messages are queued using a ConcurrentQueue and if the state is not transitioning when the message is received, the queue is processed. 

Additionally I have changed the way OnTransportDataReceived is executed, previously this was wrapped in Task that had task.ConfigureAwait(false) called on it, this has the effect of running the task on a new thread (from the thread pool) and returning immediately (essentially fire and forget), which has the potential to jumble the message ordering. 
I could not see any benefit to this being async/parallel so I change the task to use WaitAndUnwrappedExceptions().

These changes have made the echo message ordering problem go away, without any noticeable side effects.