### PR TITLE
Issue #114 - Should be removing Absent members instead of Present members

### DIFF
--- a/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
+++ b/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
@@ -9,7 +9,24 @@
 
         public static bool IsNewerThan(this PresenceMessage oldMessage, PresenceMessage newMessage)
         {
-            return oldMessage.CompareTo(newMessage) > 0;
+            if (oldMessage.IsSynthesized() || newMessage.IsSynthesized())
+            {
+                if (oldMessage.Timestamp > newMessage.Timestamp) return true;
+            }
+            
+            var thisValues = oldMessage.Id.Split(':');
+            var otherValues = newMessage.Id.Split(':');
+            var msgSerialThis = int.Parse(thisValues[1]);
+            var msgSerialOther = int.Parse(otherValues[1]);
+            var indexThis = int.Parse(thisValues[2]);
+            var indexOther = int.Parse(otherValues[2]);
+
+            if (msgSerialThis == msgSerialOther)
+            {
+                if (indexThis > indexOther) return true;
+            }
+            
+            if (msgSerialThis > msgSerialOther) return true;
         }
     }
 }

--- a/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
+++ b/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
@@ -7,26 +7,26 @@
             return !msg.Id.StartsWith(msg.ConnectionId);
         }
 
-        public static bool IsNewerThan(this PresenceMessage oldMessage, PresenceMessage newMessage)
+        public static bool IsNewerThan(this PresenceMessage thisMessage, PresenceMessage thatMessage)
         {
-            if (oldMessage.IsSynthesized() || newMessage.IsSynthesized())
+            if (thisMessage.IsSynthesized() || thatMessage.IsSynthesized())
             {
-                if (oldMessage.Timestamp > newMessage.Timestamp) return true;
+                return thisMessage.Timestamp > thatMessage.Timestamp;
             }
             
-            var thisValues = oldMessage.Id.Split(':');
-            var otherValues = newMessage.Id.Split(':');
+            var thisValues = thisMessage.Id.Split(':');
+            var thatValues = thatMessage.Id.Split(':');
             var msgSerialThis = int.Parse(thisValues[1]);
-            var msgSerialOther = int.Parse(otherValues[1]);
+            var msgSerialThat = int.Parse(thatValues[1]);
             var indexThis = int.Parse(thisValues[2]);
-            var indexOther = int.Parse(otherValues[2]);
+            var indexThat = int.Parse(thatValues[2]);
 
-            if (msgSerialThis == msgSerialOther)
+            if (msgSerialThis == msgSerialThat)
             {
-                if (indexThis > indexOther) return true;
+                return indexThis > indexThat;
             }
             
-            if (msgSerialThis > msgSerialOther) return true;
+            return msgSerialThis > msgSerialThat;
         }
     }
 }

--- a/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
+++ b/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace IO.Ably
+{
+    internal static class PresenceExtensions
+    {
+        public static bool IsSynthesized(this PresenceMessage msg)
+        {
+            return !msg.Id.StartsWith(msg.ConnectionId);
+        }
+
+        public static bool IsNewerThan(this PresenceMessage oldMessage, PresenceMessage newMessage)
+        {
+            return oldMessage.CompareTo(newMessage) > 0;
+        }
+    }
+}

--- a/src/IO.Ably.Shared/IO.Ably.Shared.projitems
+++ b/src/IO.Ably.Shared/IO.Ably.Shared.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CipherParams.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CustomSerialisers\GeneratedSerializers\IO_Ably_TokenRequestSerializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EventEmitter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\PresenceExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\TaskExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpUtility.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IChannelCommands.cs" />

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -328,7 +328,8 @@ namespace IO.Ably.Realtime
                     if (Logger.IsDebug) Logger.Debug(ex.Message);
                 }
 
-                switch(item.Action){
+                switch(item.Action)
+                {
                     case PresenceAction.Enter:
                     case PresenceAction.Update:
                         item.Action = PresenceAction.Present;

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -321,6 +321,13 @@ namespace IO.Ably.Realtime
                 {
                     return false;
                 }
+                
+                switch(item.Action){
+                    case PresenceAction.Enter:
+                    case PresenceAction.Update:
+                        item.Action = PresenceAction.Present;
+                        break;
+                }
 
                 members[item.MemberKey] = item;
 

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -325,6 +325,32 @@ namespace IO.Ably.Realtime
                 return true;
             }
 
+            private bool CompareForNewness(PresenceMessage oldMsg, PresenceMessage newMsg)
+            {
+                try 
+                {
+                    if(oldMsg.Id.StartsWith(oldMsg.ConnectionId)
+                        && newMsg.Id.StartsWith(newMsg.ConnectionId))
+                    {
+                        //RTP2b1
+                        return newMsg.Timestamp < oldMsg.Timestamp;
+                    } else {
+                        //RTP2b2
+                        var oldValues = oldMsg.Id.Split(':');
+                        var newValues = newMsg.Id.Split(':');
+                        var msgSerialOld = int.Parse(oldValues[1]);
+                        var msgSerialNew = int.Parse(newValues[1]);
+                        var indexOld = int.Parse(oldValues[2]);
+                        var indexNew = int.Parse(newValues[2]);
+
+                        return (msgSerialOld == msgSerialNew && indexNew < indexOld)
+                            || msgSerialNew < msgSerialOld;
+                    }
+                } catch {
+                    return false;
+                }
+            }
+
             public bool Remove(PresenceMessage item)
             {
                 bool result = true;

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -332,6 +332,7 @@ namespace IO.Ably.Realtime
                 {
                     case PresenceAction.Enter:
                     case PresenceAction.Update:
+                        item = item.ShallowClone();
                         item.Action = PresenceAction.Present;
                         break;
                 }

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -366,7 +366,7 @@ namespace IO.Ably.Realtime
                     // We can now strip out the ABSENT members, as we have
                     // received all of the out-of-order sync messages
                     foreach (var member in members.ToArray())
-                        if (member.Value.Action == PresenceAction.Present)
+                        if (member.Value.Action == PresenceAction.Absent)
                             members.TryRemove(member.Key, out PresenceMessage _);
 
                     lock (_lock)

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -371,12 +371,18 @@ namespace IO.Ably.Realtime
                     return false;
                 }
 
-                members.TryRemove(item.MemberKey, out PresenceMessage _);
-
                 if (existingItem?.Action == PresenceAction.Absent)
                 {
                     result = false;
                 }
+                
+                if(IsSyncInProgress){
+                    item.Action = PresenceAction.Absent;
+                    members[item.MemberKey] = item;
+                } else {
+                    members.TryRemove(item.MemberKey, out PresenceMessage _);
+                }
+                
                 return result;
             }
 

--- a/src/IO.Ably.Shared/Types/PresenceMessage.cs
+++ b/src/IO.Ably.Shared/Types/PresenceMessage.cs
@@ -51,6 +51,5 @@ namespace IO.Ably
 
         [JsonIgnore]
         public string MemberKey => $"{ClientId}:{ConnectionId}";
-
     }
 }

--- a/src/IO.Ably.Shared/Types/PresenceMessage.cs
+++ b/src/IO.Ably.Shared/Types/PresenceMessage.cs
@@ -12,7 +12,7 @@ namespace IO.Ably
         Update
     }
 
-    public class PresenceMessage : IMessage, IComparable<PresenceMessage>
+    public class PresenceMessage : IMessage
     {
         public PresenceMessage()
         { }
@@ -52,29 +52,5 @@ namespace IO.Ably
         [JsonIgnore]
         public string MemberKey => $"{ClientId}:{ConnectionId}";
 
-        public int CompareTo(PresenceMessage other)
-        {
-            if (this.IsSynthesized() || other.IsSynthesized())
-            {
-                if (this.Timestamp > other.Timestamp) return -1;
-                return this.Timestamp == other.Timestamp ? 0 : 1;
-            }
-            
-            var thisValues = this.Id.Split(':');
-            var otherValues = other.Id.Split(':');
-            var msgSerialThis = int.Parse(thisValues[1]);
-            var msgSerialOther = int.Parse(otherValues[1]);
-            var indexThis = int.Parse(thisValues[2]);
-            var indexOther = int.Parse(otherValues[2]);
-
-            if (msgSerialThis == msgSerialOther)
-            {
-                if (indexThis > indexOther) return -1;
-                return indexThis == indexOther ? 0 : 1;
-            }
-            
-            if (msgSerialThis > msgSerialOther) return -1;
-            return msgSerialThis == msgSerialOther ? 0 : 1;
-        }
     }
 }

--- a/src/IO.Ably.Shared/Types/PresenceMessage.cs
+++ b/src/IO.Ably.Shared/Types/PresenceMessage.cs
@@ -12,7 +12,7 @@ namespace IO.Ably
         Update
     }
 
-    public class PresenceMessage : IMessage
+    public class PresenceMessage : IMessage, IComparable<PresenceMessage>
     {
         public PresenceMessage()
         { }
@@ -51,5 +51,30 @@ namespace IO.Ably
 
         [JsonIgnore]
         public string MemberKey => $"{ClientId}:{ConnectionId}";
+
+        public int CompareTo(PresenceMessage other)
+        {
+            if (this.IsSynthesized() || other.IsSynthesized())
+            {
+                if (this.Timestamp > other.Timestamp) return -1;
+                return this.Timestamp == other.Timestamp ? 0 : 1;
+            }
+            
+            var thisValues = this.Id.Split(':');
+            var otherValues = other.Id.Split(':');
+            var msgSerialThis = int.Parse(thisValues[1]);
+            var msgSerialOther = int.Parse(otherValues[1]);
+            var indexThis = int.Parse(thisValues[2]);
+            var indexOther = int.Parse(otherValues[2]);
+
+            if (msgSerialThis == msgSerialOther)
+            {
+                if (indexThis > indexOther) return -1;
+                return indexThis == indexOther ? 0 : 1;
+            }
+            
+            if (msgSerialThis > msgSerialOther) return -1;
+            return msgSerialThis == msgSerialOther ? 0 : 1;
+        }
     }
 }

--- a/src/IO.Ably.Shared/Types/PresenceMessage.cs
+++ b/src/IO.Ably.Shared/Types/PresenceMessage.cs
@@ -51,5 +51,10 @@ namespace IO.Ably
 
         [JsonIgnore]
         public string MemberKey => $"{ClientId}:{ConnectionId}";
+
+        public PresenceMessage ShallowClone()
+        {
+            return (PresenceMessage) this.MemberwiseClone();
+        }
     }
 }


### PR DESCRIPTION
This is to fix an underlying problem with #114. Currently, members that are `Present` get removed from the members dictionary. I believe the correct behavior is to remove `Absent` members.

One concern I have with this is I don't see when/where a member becomes `Absent`. I've yet to receive an `Absent` action on a channel so it's possible that we should be removing members with the last action of `Leave` or possibly (`Leave` or `Absent`) if `Absent` is used in situations that I've yet to observe.

It looks like there are some tests that might cover this, but they are currently set to `Skip`. If you want me to enable them and update this PR, just say the word 👍 