### PR TITLE
Build script detects xunit runner

### DIFF
--- a/default.ps1
+++ b/default.ps1
@@ -65,6 +65,7 @@ task Package -depends Build {
 task Unit_Tests {
 
 	$base_dir = "$build_script_dir\$sln_dir\IO.Ably.Tests\bin\$configuration"
+	$packages_dir = "$build_script_dir\$sln_dir\packages\"
 
 	setup_folder $build_output_dir
 
@@ -81,8 +82,14 @@ task Unit_Tests {
 			Remove-Item $sandbox_test_results -Force
 		}
 
-		$xunit_console = "$tools_dir\xunit\xunit.console.exe"
-		
+		Write-Host $packages_dir
+
+		$xunit_console = Get-ChildItem -Path ".\src\packages\" -Filter xunit.console.exe -Recurse -ErrorAction SilentlyContinue -Force | Select FullName | Select-Object -First 1 | Select -ExpandProperty FullName
+		if($xunit_console -eq "") {
+			$xunit_console = "$tools_dir\xunit\xunit.console.exe"
+		}
+		Write-Host "Using xunit.console at path '$xunit_console'"
+		Write-Host "$xunit_console $testDll -noappdomain -nunit $unit_test_results -notrait requires=sandbox"
 		#Run all the unit tests first
 		& "$xunit_console" $testDll -noappdomain -nunit "$unit_test_results" -notrait "requires=sandbox"
 		#& "$xunit_console" $testDll -diagnostics -nunit "$sandbox_test_results" -trait "requires=sandbox"

--- a/default.ps1
+++ b/default.ps1
@@ -82,14 +82,10 @@ task Unit_Tests {
 			Remove-Item $sandbox_test_results -Force
 		}
 
-		Write-Host $packages_dir
-
 		$xunit_console = Get-ChildItem -Path ".\src\packages\" -Filter xunit.console.exe -Recurse -ErrorAction SilentlyContinue -Force | Select FullName | Select-Object -First 1 | Select -ExpandProperty FullName
 		if($xunit_console -eq "") {
 			$xunit_console = "$tools_dir\xunit\xunit.console.exe"
 		}
-		Write-Host "Using xunit.console at path '$xunit_console'"
-		Write-Host "$xunit_console $testDll -noappdomain -nunit $unit_test_results -notrait requires=sandbox"
 		#Run all the unit tests first
 		& "$xunit_console" $testDll -noappdomain -nunit "$unit_test_results" -notrait "requires=sandbox"
 		#& "$xunit_console" $testDll -diagnostics -nunit "$sandbox_test_results" -trait "requires=sandbox"

--- a/default.ps1
+++ b/default.ps1
@@ -33,12 +33,17 @@ task Init {
 
 task Assembly_Info {
 
-    $major_version = & gitversion /output json /showvariable Major
-    $minor_version = & gitversion /output json /showvariable Minor
-    $patch_version = & gitversion /output json /showvariable Patch    
+	$gitversion = Get-ChildItem -Path ".\src\packages\" -Filter GitVersion.exe -Recurse -ErrorAction SilentlyContinue -Force | Select FullName | Select-Object -First 1 | Select -ExpandProperty FullName
+
+    $major_version = & "$gitversion" /output json /showvariable Major
+    $minor_version = & "$gitversion" /output json /showvariable Minor
+    $patch_version = & "$gitversion" /output json /showvariable Patch   
 
     $main_version = "$major_version.$minor_version"
 	$build_number = "$major_version.$minor_version.$patch_version"
+
+
+    Write-Host "Build Number: $build_number" 
 
 	$base_dir = "$build_script_dir\$sln_dir"
 	generate_assembly_info `

--- a/functions.ps1
+++ b/functions.ps1
@@ -100,6 +100,6 @@ using System.Runtime.InteropServices;
 		Write-Host "Creating directory $dir"
 		[System.IO.Directory]::CreateDirectory($dir)
 	}
-	Write-Host "Generating assembly info file: $file. Version: $version"
+	Write-Host "Generating assembly info file: $file. Version: $full_version"
 	Write-Output $asmInfo > $file
 }

--- a/src/IO.Ably.Tests/packages.config
+++ b/src/IO.Ably.Tests/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Castle.Core" version="4.1.0" targetFramework="net45" />
   <package id="FluentAssertions" version="4.19.2" targetFramework="net45" />
+  <package id="GitVersion.CommandLine" version="3.6.5" targetFramework="net46" developmentDependency="true" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />


### PR DESCRIPTION
A tweak to the build script so that it will look for xunit.console.exe in the solutions packages folder and use that to run tests if possible.