### PR TITLE
Use a regex to check the PATCH portion of the version string,

### DIFF
--- a/src/IO.Ably.Tests/Realtime/ConnectionSpecs/ConnectionParameterSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ConnectionSpecs/ConnectionParameterSpecs.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using FluentAssertions;
 using Xunit;
 using Xunit.Abstractions;
@@ -121,11 +122,9 @@ namespace IO.Ably.Tests.Realtime
         public void ShouldSetTransportLibVersionParamater()
         {
             var client = GetClientWithFakeTransport();
-
-            LastCreatedTransport.Parameters.GetParams()
-                .Should().ContainKey("lib")
-                .WhichValue.Should().Be("dotnet-0.8.5");
-        }
+            LastCreatedTransport.Parameters.GetParams().Should().ContainKey("lib");
+            var v = LastCreatedTransport.Parameters.GetParams()["lib"];
+            Regex.Match(v, @"^dotnet-0.8.(\d)$").Success.ShouldBeEquivalentTo(true);}
 
         public ConnectionParameterSpecs(ITestOutputHelper output) : base(output)
         {


### PR DESCRIPTION
So the tests don't need to be modified for each patch release