### PR TITLE
Added presence features covering RTP2 and others

### DIFF
--- a/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
+++ b/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
@@ -16,15 +16,19 @@
             
             var thisValues = thisMessage.Id.Split(':');
             var thatValues = thatMessage.Id.Split(':');
+            
+            // if any part of the message serial fails to parse then throw an exception
+            if (thisValues.Length != 3 ||
+                !(int.TryParse(thisValues[1], out int msgSerialThis) | int.TryParse(thisValues[2], out int indexThis)))
+            {
+                throw new AblyException($"Parsing error. The Presence Message has an invalid Id '{thisMessage.Id}'.");
+            }
 
-            // if there are not 3 elements then return false
-            if (thisValues.Length != 3 || thatValues.Length != 3) return false;
-
-            // if any part of the message serial fails to parse then exit returning false
-            if (!(int.TryParse(thisValues[1], out int msgSerialThis) |
-                  int.TryParse(thatValues[1], out int msgSerialThat) |
-                  int.TryParse(thisValues[2], out int indexThis) |
-                  int.TryParse(thatValues[2], out int indexThat))) return false;
+            if (thatValues.Length != 3 ||
+                !(int.TryParse(thatValues[1], out int msgSerialThat) | int.TryParse(thatValues[2], out int indexThat)))
+            {
+                throw new AblyException($"Parsing error. The Presence Message has an invalid Id '{thatMessage.Id}'.");
+            }
 
             if (msgSerialThis == msgSerialThat)
             {

--- a/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
+++ b/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
@@ -9,7 +9,24 @@
 
         public static bool IsNewerThan(this PresenceMessage oldMessage, PresenceMessage newMessage)
         {
-            return oldMessage.CompareTo(newMessage) > 0;
+            if (oldMessage.IsSynthesized() || newMessage.IsSynthesized())
+            {
+                if (oldMessage.Timestamp > newMessage.Timestamp) return true;
+            }
+            
+            var thisValues = oldMessage.Id.Split(':');
+            var otherValues = newMessage.Id.Split(':');
+            var msgSerialThis = int.Parse(thisValues[1]);
+            var msgSerialOther = int.Parse(otherValues[1]);
+            var indexThis = int.Parse(thisValues[2]);
+            var indexOther = int.Parse(otherValues[2]);
+
+            if (msgSerialThis == msgSerialOther)
+            {
+                if (indexThis > indexOther) return true;
+            }
+            
+            if (msgSerialThis > msgSerialOther) return true;
         }
     }
 }

--- a/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
+++ b/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
@@ -16,16 +16,20 @@
             
             var thisValues = thisMessage.Id.Split(':');
             var thatValues = thatMessage.Id.Split(':');
-            var msgSerialThis = int.Parse(thisValues[1]);
-            var msgSerialThat = int.Parse(thatValues[1]);
-            var indexThis = int.Parse(thisValues[2]);
-            var indexThat = int.Parse(thatValues[2]);
+
+            // if there are not 3 elements then return false
+            if (thisValues.Length != 3 || thatValues.Length != 3) return false;
+
+            // if any part of the message serial fails to parse then exit returning false
+            if (!(int.TryParse(thisValues[1], out int msgSerialThis) |
+                  int.TryParse(thatValues[1], out int msgSerialThat) |
+                  int.TryParse(thisValues[2], out int indexThis) |
+                  int.TryParse(thatValues[2], out int indexThat))) return false;
 
             if (msgSerialThis == msgSerialThat)
             {
                 return indexThis > indexThat;
             }
-            
             return msgSerialThis > msgSerialThat;
         }
     }

--- a/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
+++ b/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
@@ -7,26 +7,26 @@
             return !msg.Id.StartsWith(msg.ConnectionId);
         }
 
-        public static bool IsNewerThan(this PresenceMessage oldMessage, PresenceMessage newMessage)
+        public static bool IsNewerThan(this PresenceMessage thisMessage, PresenceMessage thatMessage)
         {
-            if (oldMessage.IsSynthesized() || newMessage.IsSynthesized())
+            if (thisMessage.IsSynthesized() || thatMessage.IsSynthesized())
             {
-                if (oldMessage.Timestamp > newMessage.Timestamp) return true;
+                return thisMessage.Timestamp > thatMessage.Timestamp;
             }
             
-            var thisValues = oldMessage.Id.Split(':');
-            var otherValues = newMessage.Id.Split(':');
+            var thisValues = thisMessage.Id.Split(':');
+            var thatValues = thatMessage.Id.Split(':');
             var msgSerialThis = int.Parse(thisValues[1]);
-            var msgSerialOther = int.Parse(otherValues[1]);
+            var msgSerialThat = int.Parse(thatValues[1]);
             var indexThis = int.Parse(thisValues[2]);
-            var indexOther = int.Parse(otherValues[2]);
+            var indexThat = int.Parse(thatValues[2]);
 
-            if (msgSerialThis == msgSerialOther)
+            if (msgSerialThis == msgSerialThat)
             {
-                if (indexThis > indexOther) return true;
+                return indexThis > indexThat;
             }
             
-            if (msgSerialThis > msgSerialOther) return true;
+            return msgSerialThis > msgSerialThat;
         }
     }
 }

--- a/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
+++ b/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
@@ -1,0 +1,15 @@
+﻿namespace IO.Ably
+{
+    internal static class PresenceExtensions
+    {
+        public static bool IsSynthesized(this PresenceMessage msg)
+        {
+            return !msg.Id.StartsWith(msg.ConnectionId);
+        }
+
+        public static bool IsNewerThan(this PresenceMessage oldMessage, PresenceMessage newMessage)
+        {
+            return oldMessage.CompareTo(newMessage) > 0;
+        }
+    }
+}

--- a/src/IO.Ably.Shared/IO.Ably.Shared.projitems
+++ b/src/IO.Ably.Shared/IO.Ably.Shared.projitems
@@ -20,6 +20,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CapabilityResource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CipherParams.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EventEmitter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\PresenceExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\TaskExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpUtility.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IChannelCommands.cs" />

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -59,9 +59,7 @@ namespace IO.Ably.Realtime
             _channel.InternalStateChanged += OnChannelStateChanged;
             _clientId = cliendId;
         }
-
-        //TODO: Validate the logic is correct
-
+        
         internal bool InternalSyncComplete => (!Map.IsSyncInProgress && SyncComplete);
         internal PresenceMap Map { get; }
         internal PresenceMap InternalMap { get; }
@@ -81,8 +79,7 @@ namespace IO.Ably.Realtime
         public Task<IEnumerable<PresenceMessage>> GetAsync(GetOptions options = null)
         {
             var getOptions = options ?? new GetOptions();
-
-            //TODO: waitForSync is not implemented yet
+            
             if (getOptions.WaitForSync)
                 WaitForSync();
 
@@ -111,30 +108,30 @@ namespace IO.Ably.Realtime
                 Task.Delay(10);
             }
 
-            // to be completed when extra states in 1.0 spec are implemented 
-            if (!syncIsComplete)
-            {
-      //          /* invalid channel state */
-      //          int errorCode;
-      //          String errorMessage;
+            // TODO: This code was added when porting from the Java lib but can't completed be until the extra states added in 1.0 spec (specifically ChannelState.Suspended) are implemented 
+            //      if (!syncIsComplete)
+            //      {
+            //          /* invalid channel state */
+            //          int errorCode;
+            //          String errorMessage;
 
-      //          if (_channel.State == ChannelState.Suspended)
-      //          {
-      //              /* (RTP11d) If the Channel is in the SUSPENDED state then the get function will by default,
-					 //* or if waitForSync is set to true, result in an error with code 91005 and a message stating
-					 //* that the presence state is out of sync due to the channel being in a SUSPENDED state */
-      //              errorCode = 91005;
-      //              errorMessage = $"Channel {_channel.Name}: presence state is out of sync due to the channel being in a SUSPENDED state";
-      //          }
-      //          else
-      //          {
-      //              errorCode = 90001;
-      //              errorMessage = $"Channel {_channel.Name}: cannot get presence state because channel is in invalid state";
-      //          }
-      //          if(Logger.IsDebug)
-      //              Logger.Debug($"{errorMessage} (Error Code: {errorCode})");
-      //          throw new AblyException(new ErrorInfo(errorMessage, errorCode));
-            }
+            //          if (_channel.State == ChannelState.Suspended)
+            //          {
+            //              /* (RTP11d) If the Channel is in the SUSPENDED state then the get function will by default,
+					        //* or if waitForSync is set to true, result in an error with code 91005 and a message stating
+					        //* that the presence state is out of sync due to the channel being in a SUSPENDED state */
+            //              errorCode = 91005;
+            //              errorMessage = $"Channel {_channel.Name}: presence state is out of sync due to the channel being in a SUSPENDED state";
+            //          }
+            //          else
+            //          {
+            //              errorCode = 90001;
+            //              errorMessage = $"Channel {_channel.Name}: cannot get presence state because channel is in invalid state";
+            //          }
+            //          if(Logger.IsDebug)
+            //              Logger.Debug($"{errorMessage} (Error Code: {errorCode})");
+            //          throw new AblyException(new ErrorInfo(errorMessage, errorCode));
+            //      }
         }
 
         public void Subscribe(Action<PresenceMessage> handler)
@@ -238,7 +235,7 @@ namespace IO.Ably.Realtime
                 /* Discard incomplete sync if serial has changed */
                 if (Map.IsSyncInProgress && _currentSyncChannelSerial != null && _currentSyncChannelSerial != serial)
                 {
-                    /* TODO: should emit leave messages here? */ 
+                    /* TODO: For v1.0 we should emit leave messages here. See https://github.com/ably/ably-java/blob/159018c30b3ef813a9d3ca3c6bc82f51aacbbc68/lib/src/main/java/io/ably/lib/realtime/Presence.java#L219 for example. */
                     EndSync();
                 }
 
@@ -294,7 +291,7 @@ namespace IO.Ably.Realtime
             }
             Publish(residualMembers);
 
-            /**
+            /*
 		     * (RTP5c2) If a SYNC is initiated as part of the attach, then once the SYNC is complete,
 		     * all members not present in the PresenceMap but present in the internal PresenceMap must
 		     * be re-entered automatically by the client using the clientId and data attributes from
@@ -353,6 +350,7 @@ namespace IO.Ably.Realtime
                 /* Start sync, if hasPresence is not set end sync immediately dropping all the current presence members */
                 Map.StartSync();
                 _syncAsResultOfAttach = true;
+                // TODO: for v1.0 RTP19a (see Java version for example https://github.com/ably/ably-java/blob/159018c30b3ef813a9d3ca3c6bc82f51aacbbc68/lib/src/main/java/io/ably/lib/realtime/Presence.java)
                 //if (!hasPresence)
                 //{
                 //    /*
@@ -562,6 +560,8 @@ namespace IO.Ably.Realtime
                 {
                     if (Logger.IsDebug)
                         Logger.Debug($"EndSync | Channel: {_channelName}, Error: {ex.Message}");
+
+                    
                 }
                 finally
                 {

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -328,7 +328,8 @@ namespace IO.Ably.Realtime
                     if (Logger.IsDebug) Logger.Debug(ex.Message);
                 }
 
-                switch(item.Action){
+                switch(item.Action)
+                {
                     case PresenceAction.Enter:
                     case PresenceAction.Update:
                         item.Action = PresenceAction.Present;

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -192,7 +192,6 @@ namespace IO.Ably.Realtime
         internal void OnPresence(PresenceMessage[] messages, string syncChannelSerial)
         {
             string syncCursor = null;
-            var broadcast = true;
             if (syncChannelSerial != null)
             {
                 syncCursor = syncChannelSerial.Substring(syncChannelSerial.IndexOf(':'));
@@ -202,6 +201,7 @@ namespace IO.Ably.Realtime
 
             foreach (var update in messages)
             {
+                var broadcast = true;
                 switch (update.Action)
                 {
                     case PresenceAction.Enter:

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -321,6 +321,13 @@ namespace IO.Ably.Realtime
                 {
                     return false;
                 }
+                
+                switch(item.Action){
+                    case PresenceAction.Enter:
+                    case PresenceAction.Update:
+                        item.Action = PresenceAction.Present;
+                        break;
+                }
 
                 members[item.MemberKey] = item;
 

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -96,7 +96,7 @@ namespace IO.Ably.Realtime
             return GetAsync(new GetOptions() {ClientId = clientId, WaitForSync = waitForSync});
         }
 
-        internal Task<IEnumerable<PresenceMessage>> GetAsync(string clientId, string connectionId, bool waitForSync = false)
+        internal Task<IEnumerable<PresenceMessage>> GetAsync(string clientId, string connectionId, bool waitForSync = true)
         {
             return GetAsync(new GetOptions() { ClientId = clientId, ConnectionId = connectionId, WaitForSync = waitForSync });
         }

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -325,6 +325,32 @@ namespace IO.Ably.Realtime
                 return true;
             }
 
+            private bool CompareForNewness(PresenceMessage oldMsg, PresenceMessage newMsg)
+            {
+                try 
+                {
+                    if(oldMsg.Id.StartsWith(oldMsg.ConnectionId)
+                        && newMsg.Id.StartsWith(newMsg.ConnectionId))
+                    {
+                        //RTP2b1
+                        return newMsg.Timestamp < oldMsg.Timestamp;
+                    } else {
+                        //RTP2b2
+                        var oldValues = oldMsg.Id.Split(':');
+                        var newValues = newMsg.Id.Split(':');
+                        var msgSerialOld = int.Parse(oldValues[1]);
+                        var msgSerialNew = int.Parse(newValues[1]);
+                        var indexOld = int.Parse(oldValues[2]);
+                        var indexNew = int.Parse(newValues[2]);
+
+                        return (msgSerialOld == msgSerialNew && indexNew < indexOld)
+                            || msgSerialNew < msgSerialOld;
+                    }
+                } catch {
+                    return false;
+                }
+            }
+
             public bool Remove(PresenceMessage item)
             {
                 bool result = true;

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -332,6 +332,7 @@ namespace IO.Ably.Realtime
                 {
                     case PresenceAction.Enter:
                     case PresenceAction.Update:
+                        item = item.ShallowClone();
                         item.Action = PresenceAction.Present;
                         break;
                 }

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -265,13 +265,14 @@ namespace IO.Ably.Realtime
                     if (syncCursor.Length > 1)
                         Map.StartSync();
                 }
-            
+
                 if (syncChannelSerial != null)
                 {
                     int colonPos = syncChannelSerial.IndexOf(':');
                     string serial = colonPos >= 0 ? syncChannelSerial.Substring(0, colonPos) : syncChannelSerial;
                     /* Discard incomplete sync if serial has changed */
-                    if (Map.IsSyncInProgress && _currentSyncChannelSerial != null && _currentSyncChannelSerial != serial)
+                    if (Map.IsSyncInProgress && _currentSyncChannelSerial != null &&
+                        _currentSyncChannelSerial != serial)
                     {
                         /* TODO: For v1.0 we should emit leave messages here. See https://github.com/ably/ably-java/blob/159018c30b3ef813a9d3ca3c6bc82f51aacbbc68/lib/src/main/java/io/ably/lib/realtime/Presence.java#L219 for example. */
                         EndSync();
@@ -314,9 +315,12 @@ namespace IO.Ably.Realtime
             }
             catch (Exception ex)
             {
-                Logger.Error($"An error occurred processing Presence Messages for channel '{_channel.Name}'. Error: {ex.Message}");
-                throw new AblyException(
-                    new ErrorInfo($"An error occurred processing Presence Messages for channel '{_channel.Name}'. See the InnerException for more details."), ex);
+                var errInfo = new ErrorInfo(
+                    $"An error occurred processing Presence Messages for channel '{_channel.Name}'. See the InnerException for more details.");
+                _channel.SetChannelState(ChannelState.Failed, errInfo);
+                Logger.Error($"{errInfo.Message} Error: {ex.Message}");
+                errInfo.Message += " See the InnerException for more details.";
+                throw new AblyException(errInfo, ex);
             }
         }
 

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -366,7 +366,7 @@ namespace IO.Ably.Realtime
                     // We can now strip out the ABSENT members, as we have
                     // received all of the out-of-order sync messages
                     foreach (var member in members.ToArray())
-                        if (member.Value.Action == PresenceAction.Present)
+                        if (member.Value.Action == PresenceAction.Absent)
                             members.TryRemove(member.Key, out PresenceMessage _);
 
                     lock (_lock)

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -371,12 +371,18 @@ namespace IO.Ably.Realtime
                     return false;
                 }
 
-                members.TryRemove(item.MemberKey, out PresenceMessage _);
-
                 if (existingItem?.Action == PresenceAction.Absent)
                 {
                     result = false;
                 }
+                
+                if(IsSyncInProgress){
+                    item.Action = PresenceAction.Absent;
+                    members[item.MemberKey] = item;
+                } else {
+                    members.TryRemove(item.MemberKey, out PresenceMessage _);
+                }
+                
                 return result;
             }
 

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -201,6 +201,7 @@ namespace IO.Ably.Realtime
             }
 
             foreach (var update in messages)
+            {
                 switch (update.Action)
                 {
                     case PresenceAction.Enter:
@@ -212,12 +213,12 @@ namespace IO.Ably.Realtime
                         broadcast &= Map.Remove(update);
                         break;
                 }
+                if (broadcast)
+                    Publish(update);
+            }
             // if this is the last message in a sequence of sync updates, end the sync
             if ((syncChannelSerial == null) || (syncCursor.Length <= 1))
                 Map.EndSync();
-
-            if (broadcast)
-                Publish(messages);
         }
 
         private void Publish(params PresenceMessage[] messages)

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -28,6 +28,22 @@ namespace IO.Ably.Realtime
         private readonly IConnectionManager _connection;
         private readonly List<QueuedPresenceMessage> _pendingPresence;
 
+        private bool _initialSyncCompleted = false;
+        private bool InitialSyncCompleted
+        {
+            get => Map.InitialSyncCompleted | _initialSyncCompleted;
+            set => _initialSyncCompleted = value;
+        }
+
+        /// <summary>
+        /// Called when a protocol message HasPresenceFlag == false. The presence map should be considered in sync immediately
+        /// with no members present on the channel. See [RTP1] for more detail.
+        /// </summary>
+        internal void SkipSync()
+        {
+            InitialSyncCompleted = true;
+        }
+
         internal Presence(IConnectionManager connection, RealtimeChannel channel, string cliendId, ILogger logger)
         {
             Logger = logger;
@@ -41,7 +57,7 @@ namespace IO.Ably.Realtime
 
         //TODO: Validate the logic is correct
 
-        public bool SyncComplete => (!Map.IsSyncInProgress && Map.InitialSyncCompleted);
+        public bool SyncComplete => (!Map.IsSyncInProgress && InitialSyncCompleted);
         internal PresenceMap Map { get; }
 
         public void Dispose()

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -426,8 +426,16 @@ namespace IO.Ably.Realtime
                     {
                         if (protocolMessage.HasPresenceFlag)
                         {
-                            if (Logger.IsDebug) Logger.Debug($"Protocol message has presence flag. Starting Presence SYNC. Flag: {protocolMessage.Flags}");
+                            if (Logger.IsDebug)
+                                Logger.Debug($"Protocol message has presence flag. Starting Presence SYNC. Flag: {protocolMessage.Flags}");
                             Presence.AwaitSync();
+                        }
+                        else
+                        {
+                            /* RTP1 If [HAS_PRESENCE] flag is 0 or there is no flags field,
+                             * the presence map should be considered in sync immediately
+                             * with no members present on the channel */
+                            Presence.SkipSync();
                         }
 
                         AttachedSerial = protocolMessage.ChannelSerial;

--- a/src/IO.Ably.Shared/Types/PresenceMessage.cs
+++ b/src/IO.Ably.Shared/Types/PresenceMessage.cs
@@ -51,6 +51,5 @@ namespace IO.Ably
 
         [JsonIgnore]
         public string MemberKey => $"{ClientId}:{ConnectionId}";
-
     }
 }

--- a/src/IO.Ably.Shared/Types/PresenceMessage.cs
+++ b/src/IO.Ably.Shared/Types/PresenceMessage.cs
@@ -12,7 +12,7 @@ namespace IO.Ably
         Update
     }
 
-    public class PresenceMessage : IMessage, IComparable<PresenceMessage>
+    public class PresenceMessage : IMessage
     {
         public PresenceMessage()
         { }
@@ -52,29 +52,5 @@ namespace IO.Ably
         [JsonIgnore]
         public string MemberKey => $"{ClientId}:{ConnectionId}";
 
-        public int CompareTo(PresenceMessage other)
-        {
-            if (this.IsSynthesized() || other.IsSynthesized())
-            {
-                if (this.Timestamp > other.Timestamp) return -1;
-                return this.Timestamp == other.Timestamp ? 0 : 1;
-            }
-            
-            var thisValues = this.Id.Split(':');
-            var otherValues = other.Id.Split(':');
-            var msgSerialThis = int.Parse(thisValues[1]);
-            var msgSerialOther = int.Parse(otherValues[1]);
-            var indexThis = int.Parse(thisValues[2]);
-            var indexOther = int.Parse(otherValues[2]);
-
-            if (msgSerialThis == msgSerialOther)
-            {
-                if (indexThis > indexOther) return -1;
-                return indexThis == indexOther ? 0 : 1;
-            }
-            
-            if (msgSerialThis > msgSerialOther) return -1;
-            return msgSerialThis == msgSerialOther ? 0 : 1;
-        }
     }
 }

--- a/src/IO.Ably.Shared/Types/PresenceMessage.cs
+++ b/src/IO.Ably.Shared/Types/PresenceMessage.cs
@@ -12,7 +12,7 @@ namespace IO.Ably
         Update
     }
 
-    public class PresenceMessage : IMessage
+    public class PresenceMessage : IMessage, IComparable<PresenceMessage>
     {
         public PresenceMessage()
         { }
@@ -51,5 +51,30 @@ namespace IO.Ably
 
         [JsonIgnore]
         public string MemberKey => $"{ClientId}:{ConnectionId}";
+
+        public int CompareTo(PresenceMessage other)
+        {
+            if (this.IsSynthesized() || other.IsSynthesized())
+            {
+                if (this.Timestamp > other.Timestamp) return -1;
+                return this.Timestamp == other.Timestamp ? 0 : 1;
+            }
+            
+            var thisValues = this.Id.Split(':');
+            var otherValues = other.Id.Split(':');
+            var msgSerialThis = int.Parse(thisValues[1]);
+            var msgSerialOther = int.Parse(otherValues[1]);
+            var indexThis = int.Parse(thisValues[2]);
+            var indexOther = int.Parse(otherValues[2]);
+
+            if (msgSerialThis == msgSerialOther)
+            {
+                if (indexThis > indexOther) return -1;
+                return indexThis == indexOther ? 0 : 1;
+            }
+            
+            if (msgSerialThis > msgSerialOther) return -1;
+            return msgSerialThis == msgSerialOther ? 0 : 1;
+        }
     }
 }

--- a/src/IO.Ably.Shared/Types/PresenceMessage.cs
+++ b/src/IO.Ably.Shared/Types/PresenceMessage.cs
@@ -51,5 +51,10 @@ namespace IO.Ably
 
         [JsonIgnore]
         public string MemberKey => $"{ClientId}:{ConnectionId}";
+
+        public PresenceMessage ShallowClone()
+        {
+            return (PresenceMessage) this.MemberwiseClone();
+        }
     }
 }

--- a/src/IO.Ably.Tests/IO.Ably.Tests.csproj
+++ b/src/IO.Ably.Tests/IO.Ably.Tests.csproj
@@ -201,6 +201,7 @@
     <Compile Include="DateHelper.cs" />
     <Compile Include="EncryptionSpecs.cs" />
     <Compile Include="Infrastructure\TaskCompletionAwaiter.cs" />
+    <Compile Include="Infrastructure\TaskCountAwaiter.cs" />
     <Compile Include="Infrastructure\TestTransportFactory.cs" />
     <Compile Include="Infrastructure\TestTransportWrapper.cs" />
     <Compile Include="Infrastructure\InteropabilityMessagePayloadDataAttribute.cs" />

--- a/src/IO.Ably.Tests/IO.Ably.Tests.csproj
+++ b/src/IO.Ably.Tests/IO.Ably.Tests.csproj
@@ -202,6 +202,7 @@
     <Compile Include="EncryptionSpecs.cs" />
     <Compile Include="Infrastructure\TaskCompletionAwaiter.cs" />
     <Compile Include="Infrastructure\TaskCountAwaiter.cs" />
+    <Compile Include="Infrastructure\TestExtensions.cs" />
     <Compile Include="Infrastructure\TestTransportFactory.cs" />
     <Compile Include="Infrastructure\TestTransportWrapper.cs" />
     <Compile Include="Infrastructure\InteropabilityMessagePayloadDataAttribute.cs" />

--- a/src/IO.Ably.Tests/IO.Ably.Tests.csproj
+++ b/src/IO.Ably.Tests/IO.Ably.Tests.csproj
@@ -200,6 +200,7 @@
     <Compile Include="CapabilityTests.cs" />
     <Compile Include="DateHelper.cs" />
     <Compile Include="EncryptionSpecs.cs" />
+    <Compile Include="Infrastructure\TaskCompletionAwaiter.cs" />
     <Compile Include="Infrastructure\TestTransportFactory.cs" />
     <Compile Include="Infrastructure\TestTransportWrapper.cs" />
     <Compile Include="Infrastructure\InteropabilityMessagePayloadDataAttribute.cs" />

--- a/src/IO.Ably.Tests/Infrastructure/TaskCompletionAwaiter.cs
+++ b/src/IO.Ably.Tests/Infrastructure/TaskCompletionAwaiter.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IO.Ably.Tests.Infrastructure
+{
+    public class TaskCompletionAwaiter : IDisposable
+    {
+        private CancellationTokenSource _cancellationTokenSource;
+        private TaskCompletionSource<bool> _taskCompletionSource;
+
+        public int TimeoutMs { get; private set; }
+
+        public TaskCompletionAwaiter(int timeoutMs = 10000)
+        {
+            TimeoutMs = timeoutMs;
+
+            _cancellationTokenSource = new CancellationTokenSource(TimeoutMs);
+            _taskCompletionSource = new TaskCompletionSource<bool>();
+            _cancellationTokenSource.Token.Register(() => _taskCompletionSource.TrySetResult(false));
+        }
+        
+        public void SetCompleted()
+        {
+            _taskCompletionSource.TrySetResult(true);
+        }
+
+        public void SetFailed()
+        {
+            _taskCompletionSource.TrySetResult(false);
+        }
+
+        public Task<bool> Task => _taskCompletionSource.Task;
+
+        public void Dispose()
+        {
+            _cancellationTokenSource?.Dispose();
+            _taskCompletionSource = null;
+        }
+    }
+}

--- a/src/IO.Ably.Tests/Infrastructure/TaskCountAwaiter.cs
+++ b/src/IO.Ably.Tests/Infrastructure/TaskCountAwaiter.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace IO.Ably.Tests.Infrastructure
+{
+    /// <summary>
+    /// Count a certain number of ticks and complete or timeout
+    /// </summary>
+    class TaskCountAwaiter
+    {
+        private TaskCompletionAwaiter _awaiter;
+        public int Start { get; } = 0;
+        public int Index { get; private set; } = 0;
+
+        public TaskCountAwaiter(int count, int timeoutMs = 10000)
+        {
+            Start = count;
+            if(Start < 1)
+                throw new Exception("count must be 1 or more");
+
+            Index = count;
+            _awaiter = new TaskCompletionAwaiter(timeoutMs);
+        }
+
+        public void Tick()
+        {
+            Index--;
+            if (Index == 0)
+            {
+                _awaiter.SetCompleted();
+            }
+        }
+
+        public Task<bool> Task => _awaiter.Task;
+
+    }
+}

--- a/src/IO.Ably.Tests/Infrastructure/TestExtensions.cs
+++ b/src/IO.Ably.Tests/Infrastructure/TestExtensions.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using IO.Ably.Realtime;
+
+namespace IO.Ably.Tests.Infrastructure
+{
+    public static class TestExtensions
+    {
+        internal static Task WaitForState(this IRealtimeClient realtime, ConnectionState awaitedState = ConnectionState.Connected, TimeSpan? waitSpan = null)
+        {
+            var connectionAwaiter = new ConnectionAwaiter(realtime.Connection, awaitedState);
+            if (waitSpan.HasValue)
+                return connectionAwaiter.Wait(waitSpan.Value);
+            return connectionAwaiter.Wait();
+        }
+
+        internal static Task WaitForState(this IRealtimeChannel channel, ChannelState awaitedState = ChannelState.Attached, TimeSpan? waitSpan = null)
+        {
+            var channelAwaiter = new ChannelAwaiter(channel, awaitedState);
+            if (waitSpan.HasValue)
+                return channelAwaiter.WaitAsync();
+            return channelAwaiter.WaitAsync();
+        }
+    }
+}

--- a/src/IO.Ably.Tests/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/PresenceSandboxSpecs.cs
@@ -172,7 +172,7 @@ namespace IO.Ably.Tests.Realtime
                 received250MessagesBeforeTimeout.ShouldBeEquivalentTo(true);
 
                 // all 250 members should be present in a Presence#get request
-                var messages = await channelB.Presence.GetAsync(new GetOptions{WaitForSync = false});
+                var messages = await channelB.Presence.GetAsync(new GetOptions{WaitForSync = true});
                 var messageList = messages as IList<PresenceMessage> ?? messages.ToList();
                 messageList.Count().ShouldBeEquivalentTo(ExpectedEnterCount);
                 foreach (var m in messageList)

--- a/src/IO.Ably.Tests/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/PresenceSandboxSpecs.cs
@@ -38,6 +38,7 @@ namespace IO.Ably.Tests.Realtime
                 var channel = client.Channels.Get(GetTestChannelName());
 
                 await channel.AttachAsync();
+                await channel.WaitForState(ChannelState.Attached);
 
                 channel.Presence.SyncComplete.Should().BeTrue();
             }

--- a/src/IO.Ably.Tests/Rest/SandboxSpec.cs
+++ b/src/IO.Ably.Tests/Rest/SandboxSpec.cs
@@ -72,6 +72,8 @@ namespace IO.Ably.Tests
             return connectionAwaiter.Wait();
         }
 
+        
+
         protected static async Task WaitFor30sOrUntilTrue(Func<bool> predicate)
         {
             int count = 0;
@@ -84,6 +86,25 @@ namespace IO.Ably.Tests
 
                 await Task.Delay(1000);
             }
+        }
+    }
+
+    public static class SandboxSpecExtension
+    {
+        internal static Task WaitForState(this AblyRealtime realtime, ConnectionState awaitedState = ConnectionState.Connected, TimeSpan? waitSpan = null)
+        {
+            var connectionAwaiter = new ConnectionAwaiter(realtime.Connection, awaitedState);
+            if (waitSpan.HasValue)
+                return connectionAwaiter.Wait(waitSpan.Value);
+            return connectionAwaiter.Wait();
+        }
+
+        internal static Task WaitForState(this IRealtimeChannel channel, ChannelState awaitedState = ChannelState.Attached, TimeSpan? waitSpan = null)
+        {
+            var channelAwaiter = new ChannelAwaiter(channel, awaitedState);
+            if (waitSpan.HasValue)
+                return channelAwaiter.WaitAsync();
+            return channelAwaiter.WaitAsync();
         }
     }
 }

--- a/src/IO.Ably.Tests/Rest/SandboxSpec.cs
+++ b/src/IO.Ably.Tests/Rest/SandboxSpec.cs
@@ -45,6 +45,13 @@ namespace IO.Ably.Tests
             var defaultOptions = settings.CreateDefaultOptions();
             defaultOptions.UseBinaryProtocol = protocol == Defaults.Protocol;
             defaultOptions.TransportFactory = new TestTransportFactory();
+
+            // Prevent the Xunit concurrent context being caputured which is
+            // an implementation of <see cref="SynchronizationContext"/> which runs work on custom threads
+            // rather than in the thread pool, and limits the number of in-flight actions.
+            //
+            // This can create out of order responses that would not normally occur
+            defaultOptions.CaptureCurrentSynchronizationContext = false;
             optionsAction?.Invoke(defaultOptions, settings);
             return new AblyRealtime(defaultOptions);
         }

--- a/src/IO.Ably.Tests/Rest/SandboxSpec.cs
+++ b/src/IO.Ably.Tests/Rest/SandboxSpec.cs
@@ -96,22 +96,5 @@ namespace IO.Ably.Tests
         }
     }
 
-    public static class SandboxSpecExtension
-    {
-        internal static Task WaitForState(this AblyRealtime realtime, ConnectionState awaitedState = ConnectionState.Connected, TimeSpan? waitSpan = null)
-        {
-            var connectionAwaiter = new ConnectionAwaiter(realtime.Connection, awaitedState);
-            if (waitSpan.HasValue)
-                return connectionAwaiter.Wait(waitSpan.Value);
-            return connectionAwaiter.Wait();
-        }
-
-        internal static Task WaitForState(this IRealtimeChannel channel, ChannelState awaitedState = ChannelState.Attached, TimeSpan? waitSpan = null)
-        {
-            var channelAwaiter = new ChannelAwaiter(channel, awaitedState);
-            if (waitSpan.HasValue)
-                return channelAwaiter.WaitAsync();
-            return channelAwaiter.WaitAsync();
-        }
-    }
+    
 }


### PR DESCRIPTION
This is a continuation of the work done on PR #147 by @jeddawson in response to issue #114, the crux of which was that the library was removing Absent members instead of Present members. Fixing that lead on to implementing some of the missing Presence features.

Using the other library implementations as a guide, in particular ably-java, I have added tests to cover the parts of the spec affected by @jeddawsons original work and fixed some issues that were raised by those tests.

The new parts of the spec covered are:

- All of RTP2a/b/c/d/f/g (note RTP2e is missing at the moment)
- RTP6a/b
- RTP18a/b/c

Additionally WaitOnSync is now implemented. 

I have also fixed up the tests for:

- RTP1
- RTP4
