### PR TITLE
Test improvements

### DIFF
--- a/src/IO.Ably.Shared/EventEmitter.cs
+++ b/src/IO.Ably.Shared/EventEmitter.cs
@@ -25,7 +25,7 @@ namespace IO.Ably
         {
             Logger = logger ?? IO.Ably.DefaultLogger.LoggerInstance;
         }
-        internal ILogger Logger { get; private set; }
+        internal ILogger Logger { get; set; }
 
         readonly List<Emitter<TState, TArgs>> _emitters = new List<Emitter<TState, TArgs>>();
         private readonly ReaderWriterLockSlim _lock = new ReaderWriterLockSlim();

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -49,7 +49,7 @@ namespace IO.Ably.Realtime
         public ChannelState State
         {
             get => _state;
-            private set
+            internal set
             {
                 if (value != _state)
                 {
@@ -80,19 +80,20 @@ namespace IO.Ably.Realtime
             ConnectionManager.Connection.InternalStateChanged += InternalOnInternalStateChanged;
         }
 
-        private void InternalOnInternalStateChanged(object sender, ConnectionStateChange connectionStateChange)
+        internal void InternalOnInternalStateChanged(object sender, ConnectionStateChange connectionStateChange)
         {
             switch (connectionStateChange.Current)
             {
+                //case ConnectionState.Connected:
                 case ConnectionState.Disconnected:
                     if (State == ChannelState.Attaching)
                     {
-                        if (Logger.IsDebug) Logger.Debug($"#{Name} Resending Attach because connection became disconnected while the channel was attaching.");
+                        if (Logger.IsDebug) Logger.Debug($"#{Name} Resending Attach because connection became {State} while the channel was {ChannelState.Attaching}.");
                         SendMessage(new ProtocolMessage(ProtocolMessage.MessageAction.Attach, Name));
                     }
                     if (State == ChannelState.Detaching)
                     {
-                        if (Logger.IsDebug) Logger.Debug($"#{Name} Resending Detach because connection became disconnected while the channel was attaching.");
+                        if (Logger.IsDebug) Logger.Debug($"#{Name} Resending Detach because connection became {State} while the channel was {ChannelState.Detaching}.");
                         SendMessage(new ProtocolMessage(ProtocolMessage.MessageAction.Detach, Name));
                     }
                     break;
@@ -536,6 +537,7 @@ namespace IO.Ably.Realtime
 
         private void SendMessage(ProtocolMessage protocolMessage, Action<bool, ErrorInfo> callback = null)
         {
+            if(Logger.IsDebug) Logger.Debug($"RealtimeChannel.SendMessage:{protocolMessage.Action}");
             ConnectionManager.Send(protocolMessage, callback, Options);
         }
     }

--- a/src/IO.Ably.Shared/Transport/TransportParams.cs
+++ b/src/IO.Ably.Shared/Transport/TransportParams.cs
@@ -56,7 +56,7 @@ namespace IO.Ably.Transport
             result.FallbackHosts = Defaults.FallbackHosts;
             result.UseBinaryProtocol = options.UseBinaryProtocol;
             result.RecoverValue = options.Recover;
-            result.Logger = logger ?? IO.Ably.DefaultLogger.LoggerInstance;
+            result.Logger = logger ?? options.Logger;
             return result;
         }
 

--- a/src/IO.Ably.Tests/AuthTests/AuthorisationTests.cs
+++ b/src/IO.Ably.Tests/AuthTests/AuthorisationTests.cs
@@ -144,7 +144,7 @@ namespace IO.Ably.Tests
                 request.Capability.Should().Be(Capability.Empty);
                 request.ClientId.Should().Be("999");
                 request.Ttl.Should().Be(TimeSpan.FromHours(1));
-                request.Timestamp.Value.Should().BeCloseTo(Now.AddMinutes(10));
+                request.Timestamp.Value.Should().BeCloseTo(Now.AddMinutes(10), 200);
                 request.Nonce.Should().Be("overrideNonce");
             }
 

--- a/src/IO.Ably.Tests/AuthTests/RequestTokenTests.cs
+++ b/src/IO.Ably.Tests/AuthTests/RequestTokenTests.cs
@@ -128,7 +128,7 @@ namespace IO.Ably.Tests.AuthTests
             date.Should().BeCloseTo(data.Timestamp.Value);
         }
 
-        [Fact]
+        [Retry]
         public async Task RequestToken_WithoutTimeStamp_SetsCurrentTimeOnTheRequest()
         {
             var tokenParams = new TokenParams();
@@ -137,7 +137,7 @@ namespace IO.Ably.Tests.AuthTests
             await client.Auth.RequestTokenAsync(tokenParams, null);
 
             var data = LastRequest.PostData as TokenRequest;
-            Now.Should().BeCloseTo(data.Timestamp.Value);
+            Now.Should().BeCloseTo(data.Timestamp.Value, 200);
         }
 
         [Fact]

--- a/src/IO.Ably.Tests/IO.Ably.Tests.csproj
+++ b/src/IO.Ably.Tests/IO.Ably.Tests.csproj
@@ -189,6 +189,9 @@
     <Reference Include="xunit.execution.desktop, Version=2.3.0.3705, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.extensibility.execution.2.3.0-beta3-build3705\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
+    <Reference Include="XunitRetry, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XunitRetry.2.0.0\lib\net451\XunitRetry.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AblyResponseTests.cs" />

--- a/src/IO.Ably.Tests/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ChannelSandboxSpecs.cs
@@ -173,14 +173,21 @@ namespace IO.Ably.Tests.Realtime
         [Trait("spec", "RTL7f")]
         public async Task TestAttachChannel_SendingMessage_Doesnt_EchoesItBack(Protocol protocol)
         {
-            var channelName = "test_attach".AddRandomSuffix();
+            var channelName = "echo_off_test";
+
+            // this should be logged in MsWebSocketTrasnport.CreateSocket
+            var testLogger = new TestLogger("Connecting to web socket on url:");
             // Arrange
             var client = await GetRealtimeClient(protocol, (o, _) =>
             {
                 o.EchoMessages = false;
-                o.CaptureCurrentSynchronizationContext = true;
+                o.Logger = testLogger;
             });
             await client.WaitForState();
+            client.Options.EchoMessages.Should().Be(false);
+            testLogger.MessageSeen.Should().Be(true);
+            testLogger.FullMessage.Contains("echo=false").Should().Be(true);
+
             var channel = client.Channels.Get(channelName);
 
             channel.Attach();

--- a/src/IO.Ably.Tests/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ChannelSpecs.cs
@@ -522,7 +522,7 @@ namespace IO.Ably.Tests.Realtime
                 Assert.True(called);
             }
 
-            [Fact]
+            [Retry] //replaces fact
             [Trait("spec", "RTL5e")]
             public async Task WithACallback_ShouldCallCallbackWithErrorIfDetachFails()
             {
@@ -838,7 +838,7 @@ namespace IO.Ably.Tests.Realtime
                 channel.State.Should().Be(ChannelState.Attaching);
             }
 
-            [Fact]
+            [Retry(3)]
             [Trait("spec", "RTL7d")]
             public async Task WithAMessageThatFailDecryption_ShouldDeliverMessageButEmmitErrorOnTheChannel()
             {

--- a/src/IO.Ably.Tests/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ConnectionSandBoxSpecs.cs
@@ -374,6 +374,7 @@ namespace IO.Ably.Tests.Realtime
             }
 
             stateChanges.Count(x => x == ConnectionState.Connected).Should().BeGreaterThan(2);
+            await client.WaitForState();
             client.Connection.State.Should().Be(ConnectionState.Connected);
         }
 
@@ -440,7 +441,8 @@ namespace IO.Ably.Tests.Realtime
 
             await client.WaitForState(ConnectionState.Connected);
 
-            var channel = client.Channels.Get("test-channel");
+
+            var channel = client.Channels.Get(channelName);
             channel.Once(ChannelState.Detaching, change => client.GetTestTransport().Close(false));
             channel.Attach();
             channel.Detach();

--- a/src/IO.Ably.Tests/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ConnectionSandBoxSpecs.cs
@@ -442,7 +442,7 @@ namespace IO.Ably.Tests.Realtime
             await client.WaitForState(ConnectionState.Connected);
 
 
-            var channel = client.Channels.Get(channelName);
+            var channel = client.Channels.Get("test-channel");
             channel.Once(ChannelState.Detaching, change => client.GetTestTransport().Close(false));
             channel.Attach();
             channel.Detach();

--- a/src/IO.Ably.Tests/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/ConnectionSandBoxSpecs.cs
@@ -393,7 +393,8 @@ namespace IO.Ably.Tests.Realtime
          * the respective ATTACH or DETACH message should be resent to Ably
          */
 
-        [Theory]
+
+        [Retry(3)]
         [ProtocolData]
         [Trait("spec", "RTN19b")]
         public async Task
@@ -424,7 +425,7 @@ namespace IO.Ably.Tests.Realtime
             channel.State.Should().Be(ChannelState.Attached);
         }
 
-        [Theory]
+        [Retry]
         [ProtocolData]
         [Trait("spec", "RTN19b")]
         public async Task

--- a/src/IO.Ably.Tests/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/PresenceSandboxSpecs.cs
@@ -497,7 +497,7 @@ namespace IO.Ably.Tests.Realtime
              * and once sync is complete, all 250 members should be present in a Presence#get request
              */
 
-            [Theory]
+            [Retry]
             [ProtocolData]
             [Trait("spec", "RTP4")]
             public async Task WhenAClientAttachedToPresenceChannel_ShouldEmitPresentForEachMember(Protocol protocol)

--- a/src/IO.Ably.Tests/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/PresenceSandboxSpecs.cs
@@ -497,7 +497,7 @@ namespace IO.Ably.Tests.Realtime
              * and once sync is complete, all 250 members should be present in a Presence#get request
              */
 
-            [Retry]
+            [Theory]
             [ProtocolData]
             [Trait("spec", "RTP4")]
             public async Task WhenAClientAttachedToPresenceChannel_ShouldEmitPresentForEachMember(Protocol protocol)

--- a/src/IO.Ably.Tests/Rest/SandboxSpec.cs
+++ b/src/IO.Ably.Tests/Rest/SandboxSpec.cs
@@ -94,6 +94,61 @@ namespace IO.Ably.Tests
                 await Task.Delay(1000);
             }
         }
+
+        /// <summary>
+        /// A test logger to check if a message has been logged.
+        /// Uses string.StartsWith, so partial matches on the start of a string are valid.
+        /// </summary>
+        internal class TestLogger : ILogger
+        {
+            public string MessageToTest { get; set; }
+
+            public string FullMessage { get; private set; }
+
+            /// <summary>
+            /// 
+            /// </summary>
+            /// <param name="messageToTest"></param>
+            public TestLogger(string messageToTest)
+            {
+                LogLevel = LogLevel.Debug;
+                MessageToTest = messageToTest;
+            }
+
+            public bool MessageSeen { get; private set; }
+
+            public LogLevel LogLevel { get; set; }
+            public bool IsDebug => LogLevel == LogLevel.Debug;
+            public ILoggerSink LoggerSink { get; set; }
+            public void Error(string message, Exception ex)
+            {
+                Test(message);
+            }
+
+            public void Error(string message, params object[] args)
+            {
+                Test(message);
+            }
+
+            public void Warning(string message, params object[] args)
+            {
+                Test(message);
+            }
+
+            public void Debug(string message, params object[] args)
+            {
+                Test(message);
+            }
+
+            private void Test(string message)
+            {
+                if (message.StartsWith(MessageToTest))
+                {
+                    MessageSeen = true;
+                    FullMessage = message;
+                }
+            }
+        }
     }
 
     

--- a/src/IO.Ably.Tests/packages.config
+++ b/src/IO.Ably.Tests/packages.config
@@ -65,4 +65,5 @@
   <package id="xunit.extensibility.execution" version="2.3.0-beta3-build3705" targetFramework="net46" />
   <package id="xunit.runner.console" version="2.2.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net45" developmentDependency="true" />
+  <package id="XunitRetry" version="2.0.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
This PR contains updates and fixes that were done whilst working on PR #157, but that were not directly related to that work, so rather than pollute that PR I have extracted that work here. I would suggest that PR #157 is reviewed before dealing with this one.

Essentially some helpers and improvements to make some test more reliable along with a bug fix.

The headline changes are 

1. I have changed some accessors from private to internal, this allows properties to be accessed from the tests without exposing them publicly.

2. I fixed a bug where the Logger would not be set by from the ClientOptions - This would have no affect on customers as we don't allow them to set the logger in ClientOptions at the moment, but the behaviour was incorrect, as revealed by a failing test.
