### PR TITLE
RTE4

### DIFF
--- a/src/IO.Ably.Shared/EventEmitter.cs
+++ b/src/IO.Ably.Shared/EventEmitter.cs
@@ -119,18 +119,16 @@ namespace IO.Ably
             _lock.EnterUpgradeableReadLock();
             try
             {
-                if (_emitters.Any(x => x.Action == listener) == false)
+                _lock.EnterWriteLock();
+                try
                 {
-                    _lock.EnterWriteLock();
-                    try
-                    {
-                        _emitters.Add(new Emitter<TState, TArgs>(listener, once: true));
-                    }
-                    finally
-                    {
-                        _lock.ExitWriteLock();
-                    }
+                    _emitters.Add(new Emitter<TState, TArgs>(listener, once: true));
                 }
+                finally
+                {
+                    _lock.ExitWriteLock();
+                }
+                
             }
             finally
             {
@@ -143,17 +141,14 @@ namespace IO.Ably
             _lock.EnterUpgradeableReadLock();
             try
             {
-                if (_emitters.Any(x => x.AsyncAction == listener) == false)
+                _lock.EnterWriteLock();
+                try
                 {
-                    _lock.EnterWriteLock();
-                    try
-                    {
-                        _emitters.Add(new Emitter<TState, TArgs>(listener, once: true));
-                    }
-                    finally
-                    {
-                        _lock.ExitWriteLock();
-                    }
+                    _emitters.Add(new Emitter<TState, TArgs>(listener, once: true));
+                }
+                finally
+                {
+                    _lock.ExitWriteLock();
                 }
             }
             finally

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/EventEmitterSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/EventEmitterSpecs.cs
@@ -169,57 +169,59 @@ namespace IO.Ably.Tests.Realtime
                 tt = false;
             }
 
-            // no event/state argument, catch all
-            em.Once(args =>
+            void Handler1(TestEventEmitterArgs args)
             {
                 counter++;
                 message = args.Message;
                 t = true;
-            });
-            em.DoDummyEmit(1, "once");
-            var success = t;
-            success.Should().BeTrue();
-            message.Should().Be("once");
+            }
 
-            // currently one listener
-            counter.Should().Be(1);
-            Reset();
-
-            // only catch 1 events
-            em.Once(1, args =>
+            void Handler2(TestEventEmitterArgs args)
             {
                 counter++;
                 message = args.Message;
                 tt = true;
-            });
+            }
+
+            // no event/state argument, catch all
+            em.Once((Action<TestEventEmitterArgs>)Handler1);
+            em.Once((Action<TestEventEmitterArgs>)Handler1);
+            em.DoDummyEmit(1, "once");
+            t.Should().BeTrue();
+            message.Should().Be("once");
+            counter.Should().Be(2);
+            Reset();
+
+            // only catch 1 events
+            em.Once(1, (Action<TestEventEmitterArgs>)Handler2);
             em.DoDummyEmit(2, "on");
 
-            // t & tt should timeout and return false here
-            success = !t && !tt;
-            success.Should().BeTrue();
+            // no events should be handled, t & tt should be false here
+            t.Should().BeFalse();
+            tt.Should().BeFalse();
 
             // there are 2 listeners and the first is catch all
             // but the first should have already handled an event and deregistered
             // so the count remains the same
-            counter.Should().Be(1);
+            counter.Should().Be(2);
             Reset();
             em.DoDummyEmit(1, "on");
 
-            // t should not complete again, tt should complete for the first time
-            success = !t && !t;
-            success.Should().BeTrue();
+            // t should not have been set, tt should complete for the first time
+            t.Should().BeFalse();
+            tt.Should().BeTrue();
 
             // still 2 listeners and we sent a 1 event which second should handle
-            counter.Should().Be(2);
+            counter.Should().Be(3);
             Reset();
             em.DoDummyEmit(1, "on");
 
-            // t & tt should both timeout
-            success = !t && !t;
-            success.Should().BeTrue();
+            // t & tt should both be false
+            t.Should().BeFalse();
+            tt.Should().BeFalse();
 
             // handlers should be deregistered so the count should remain at 2
-            counter.Should().Be(2);
+            counter.Should().Be(3);
         }
 
         public EventEmitterSpecs(ITestOutputHelper output) : base(output)


### PR DESCRIPTION
added test for RTE4

`(RTE4) EventEmitter#once registers the provided listener for either the first event that is emitted when no event argument is provided, or for only the first occurrence of a single named event when an event argument is provided. If once is called more than once with the same listener, the listener is added multiple times to its listener registry. Therefore, as an example, assuming the same listener is registered twice using once, and an event is emitted once, the listener would be invoked twice. However, all subsequent events emitted would not invoke the listener as once ensures that each registration is only invoked once`