### PR TITLE
RTE5

### DIFF
--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
@@ -241,13 +241,13 @@ namespace IO.Ably.Tests.AuthTests
 
 #pragma warning disable CS0618 // Type or member is obsolete
             /* Check for logged warning */
-            var testLogger1 = new SandboxSpecs.TestLogger("AuthoriseAsync is deprecated and will be removed in the future, please replace with a call to AuthorizeAsync");
+            var testLogger1 = new TestLogger("AuthoriseAsync is deprecated and will be removed in the future, please replace with a call to AuthorizeAsync");
             var client = GetRestClient(setOptionsAction: options => { options.Logger = testLogger1; });
             var testAblyAuth = new TestAblyAuth(client.Options, client);
             await testAblyAuth.AuthoriseAsync();
             testLogger1.MessageSeen.Should().BeTrue();
 
-            var testLogger2 = new SandboxSpecs.TestLogger("Authorise is deprecated and will be removed in the future, please replace with a call to Authorize");
+            var testLogger2 = new TestLogger("Authorise is deprecated and will be removed in the future, please replace with a call to Authorize");
             client = GetRestClient(setOptionsAction: options => { options.Logger = testLogger2; });
             testAblyAuth = new TestAblyAuth(client.Options, client);
             testAblyAuth.Authorise();

--- a/src/IO.Ably.Tests.Shared/IO.Ably.Tests.Shared.projitems
+++ b/src/IO.Ably.Tests.Shared/IO.Ably.Tests.Shared.projitems
@@ -103,6 +103,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Rest\SandboxSpec.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\StatsSandBoxSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\StatsSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Infrastructure\TestLogger.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Samples\DocumentationSamples.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Samples\RealtimeSamples.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StatsParsingTests.cs" />

--- a/src/IO.Ably.Tests.Shared/Infrastructure/TestLogger.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/TestLogger.cs
@@ -1,0 +1,68 @@
+using System;
+
+namespace IO.Ably.Tests
+{
+    /// <summary>
+    /// A test logger to check if a message has been logged.
+    /// Uses string.StartsWith, so partial matches on the start of a string are valid.
+    /// </summary>
+    internal class TestLogger : ILogger
+    {
+        public int SeenCount { get; set; }
+
+        public string MessageToTest { get; set; }
+
+        public string FullMessage { get; private set; }
+
+        public TestLogger(string messageToTest)
+        {
+            LogLevel = LogLevel.Debug;
+            MessageToTest = messageToTest;
+            SeenCount = 0;
+        }
+
+        public bool MessageSeen { get; private set; }
+
+        public LogLevel LogLevel { get; set; }
+
+        public bool IsDebug => LogLevel == LogLevel.Debug;
+
+        public ILoggerSink LoggerSink { get; set; }
+
+        public void Error(string message, Exception ex)
+        {
+            Test(message);
+            Test(ex.Message);
+        }
+
+        public void Error(string message, params object[] args)
+        {
+            Test(message);
+        }
+
+        public void Warning(string message, params object[] args)
+        {
+            Test(message);
+        }
+
+        public void Debug(string message, params object[] args)
+        {
+            Test(message);
+        }
+
+        private void Test(string message)
+        {
+            if (message.StartsWith(MessageToTest))
+            {
+                MessageSeen = true;
+                FullMessage = message;
+                SeenCount++;
+            }
+        }
+
+        public void Reset()
+        {
+            MessageSeen = false;
+        }
+    }
+}

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/EventEmitterSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/EventEmitterSpecs.cs
@@ -289,12 +289,26 @@ namespace IO.Ably.Tests.Realtime
             em.DoDummyEmit(1, "off");
             message.Should().Be("off");
             counter.Should().Be(1);
-
             Reset();
+
             em.Off();
             em.DoDummyEmit(1, "off");
             em.DoDummyEmit(2, "off");
             em.DoDummyEmit(3, "off");
+            counter.Should().Be(0);
+            Reset();
+
+            em.On(1, (Action<TestEventEmitterArgs>)Listener1);
+            em.On(2, (Action<TestEventEmitterArgs>)Listener2);
+            em.On(1, (Action<TestEventEmitterArgs>)Listener2);
+            em.DoDummyEmit(1, "off");
+            message.Should().Be("off");
+            counter.Should().Be(2);
+            Reset();
+
+            em.Off();
+            em.DoDummyEmit(1, "off");
+            em.DoDummyEmit(2, "off");
             counter.Should().Be(0);
             Reset();
 

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/EventEmitterSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/EventEmitterSpecs.cs
@@ -264,20 +264,22 @@ namespace IO.Ably.Tests.Realtime
             var em = new TestEventEmitter(DefaultLogger.LoggerInstance);
             string message = string.Empty;
             int counter = 0;
-            bool handled = false;
+
+            void Reset()
+            {
+                counter = 0;
+            }
 
             void Listener1(TestEventEmitterArgs args)
             {
                 counter++;
                 message = args.Message;
-                handled = true;
             }
 
             void Listener2(TestEventEmitterArgs args)
             {
                 counter++;
                 message = args.Message;
-                handled = true;
             }
 
             // if called with no arguments, it removes all registrations, for all events and listeners
@@ -285,81 +287,71 @@ namespace IO.Ably.Tests.Realtime
             em.On(2, (Action<TestEventEmitterArgs>)Listener1);
             em.On(3, (Action<TestEventEmitterArgs>)Listener1);
             em.DoDummyEmit(1, "off");
-            handled.Should().BeTrue();
             message.Should().Be("off");
             counter.Should().Be(1);
 
-            handled = false;
+            Reset();
             em.Off();
             em.DoDummyEmit(1, "off");
             em.DoDummyEmit(2, "off");
             em.DoDummyEmit(3, "off");
-            handled.Should().BeFalse();
-            counter.Should().Be(1);
+            counter.Should().Be(0);
+            Reset();
 
             // if called only with a listener, it removes all registrations matching the given listener,
-            // regardless of whether they are associated with an event or not;
-            handled = false;
+            // regardless of whether they are associated with an event or not
             em.On(1, (Action<TestEventEmitterArgs>)Listener1);
             em.On(1, (Action<TestEventEmitterArgs>)Listener2);
             em.DoDummyEmit(1, "off");
-            handled.Should().BeTrue();
-            counter.Should().Be(3);
+            counter.Should().Be(2);
+            Reset();
 
-            handled = false;
             em.Off((Action<TestEventEmitterArgs>)Listener2);
             em.DoDummyEmit(1, "off");
-            handled.Should().BeTrue();
-            counter.Should().Be(4);
+            counter.Should().Be(1);
+            Reset();
 
-            handled = false;
             em.Off((Action<TestEventEmitterArgs>)Listener1);
             em.DoDummyEmit(1, "off");
-            handled.Should().BeFalse();
-            counter.Should().Be(4);
+            counter.Should().Be(0);
 
             // If called with a specific event and a listener,
             // it removes all registrations that match both the given listener and the given event
             em.On(1, (Action<TestEventEmitterArgs>)Listener1);
             em.On(1, (Action<TestEventEmitterArgs>)Listener2);
             em.On(2, (Action<TestEventEmitterArgs>)Listener1);
-            handled = false;
-            em.DoDummyEmit(1, "off");
-            handled.Should().BeTrue();
-            counter.Should().Be(6);
+            Reset();
 
-            handled = false;
+            em.DoDummyEmit(1, "off");
+            counter.Should().Be(2);
+            Reset();
+
             em.DoDummyEmit(2, "off");
-            handled.Should().BeTrue();
-            counter.Should().Be(7);
+            counter.Should().Be(1);
+            Reset();
 
             // no handler for this event, so this should have no effect
-            handled = false;
             em.Off(3, (Action<TestEventEmitterArgs>)Listener1);
             em.DoDummyEmit(1, "off");
-            handled.Should().BeTrue();
-            counter.Should().Be(9);
+            counter.Should().Be(2);
+            Reset();
 
             // no handler for this listener, so this should have no effect
-            handled = false;
             em.Off(2, (Action<TestEventEmitterArgs>)Listener2);
             em.DoDummyEmit(1, "off");
-            handled.Should().BeTrue();
-            counter.Should().Be(11);
+            counter.Should().Be(2);
+            Reset();
 
             // remove handler 1 of 2 remaining
-            handled = false;
             em.Off(1, (Action<TestEventEmitterArgs>)Listener1);
             em.DoDummyEmit(1, "off");
-            handled.Should().BeTrue();
-            counter.Should().Be(12);
+            counter.Should().Be(1);
+            Reset();
 
             // remove the final handler
-            handled = false;
             em.Off(1, (Action<TestEventEmitterArgs>)Listener2);
             em.DoDummyEmit(1, "off");
-            handled.Should().BeFalse();
-            counter.Should().Be(12);
+            counter.Should().Be(0);
         }
 
         public EventEmitterSpecs(ITestOutputHelper output) : base(output)

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/EventEmitterSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/EventEmitterSpecs.cs
@@ -288,6 +288,7 @@ namespace IO.Ably.Tests.Realtime
             handled.Should().BeTrue();
             message.Should().Be("off");
             counter.Should().Be(1);
+
             handled = false;
             em.Off();
             em.DoDummyEmit(1, "off");
@@ -298,19 +299,21 @@ namespace IO.Ably.Tests.Realtime
 
             // if called only with a listener, it removes all registrations matching the given listener,
             // regardless of whether they are associated with an event or not;
+            handled = false;
             em.On(1, (Action<TestEventEmitterArgs>)Listener1);
             em.On(1, (Action<TestEventEmitterArgs>)Listener2);
-            handled = false;
             em.DoDummyEmit(1, "off");
             handled.Should().BeTrue();
             counter.Should().Be(3);
-            em.Off((Action<TestEventEmitterArgs>)Listener2);
+
             handled = false;
+            em.Off((Action<TestEventEmitterArgs>)Listener2);
             em.DoDummyEmit(1, "off");
             handled.Should().BeTrue();
             counter.Should().Be(4);
-            em.Off((Action<TestEventEmitterArgs>)Listener1);
+
             handled = false;
+            em.Off((Action<TestEventEmitterArgs>)Listener1);
             em.DoDummyEmit(1, "off");
             handled.Should().BeFalse();
             counter.Should().Be(4);
@@ -331,29 +334,29 @@ namespace IO.Ably.Tests.Realtime
             counter.Should().Be(7);
 
             // no handler for this event, so this should have no effect
-            em.Off(3, (Action<TestEventEmitterArgs>)Listener1);
             handled = false;
+            em.Off(3, (Action<TestEventEmitterArgs>)Listener1);
             em.DoDummyEmit(1, "off");
             handled.Should().BeTrue();
             counter.Should().Be(9);
 
             // no handler for this listener, so this should have no effect
-            em.Off(2, (Action<TestEventEmitterArgs>)Listener2);
             handled = false;
+            em.Off(2, (Action<TestEventEmitterArgs>)Listener2);
             em.DoDummyEmit(1, "off");
             handled.Should().BeTrue();
             counter.Should().Be(11);
 
             // remove handler 1 of 2 remaining
-            em.Off(1, (Action<TestEventEmitterArgs>)Listener1);
             handled = false;
+            em.Off(1, (Action<TestEventEmitterArgs>)Listener1);
             em.DoDummyEmit(1, "off");
             handled.Should().BeTrue();
             counter.Should().Be(12);
 
             // remove the final handler
-            em.Off(1, (Action<TestEventEmitterArgs>)Listener2);
             handled = false;
+            em.Off(1, (Action<TestEventEmitterArgs>)Listener2);
             em.DoDummyEmit(1, "off");
             handled.Should().BeFalse();
             counter.Should().Be(12);

--- a/src/IO.Ably.Tests.Shared/Rest/SandboxSpec.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/SandboxSpec.cs
@@ -103,64 +103,6 @@ namespace IO.Ably.Tests
             }
         }
 
-        /// <summary>
-        /// A test logger to check if a message has been logged.
-        /// Uses string.StartsWith, so partial matches on the start of a string are valid.
-        /// </summary>
-        internal class TestLogger : ILogger
-        {
-            public int SeenCount { get; set; }
-
-            public string MessageToTest { get; set; }
-
-            public string FullMessage { get; private set; }
-
-            public TestLogger(string messageToTest)
-            {
-                LogLevel = LogLevel.Debug;
-                MessageToTest = messageToTest;
-                SeenCount = 0;
-            }
-
-            public bool MessageSeen { get; private set; }
-
-            public LogLevel LogLevel { get; set; }
-
-            public bool IsDebug => LogLevel == LogLevel.Debug;
-
-            public ILoggerSink LoggerSink { get; set; }
-
-            public void Error(string message, Exception ex)
-            {
-                Test(message);
-            }
-
-            public void Error(string message, params object[] args)
-            {
-                Test(message);
-            }
-
-            public void Warning(string message, params object[] args)
-            {
-                Test(message);
-            }
-
-            public void Debug(string message, params object[] args)
-            {
-                Test(message);
-            }
-
-            private void Test(string message)
-            {
-                if (message.StartsWith(MessageToTest))
-                {
-                    MessageSeen = true;
-                    FullMessage = message;
-                    SeenCount++;
-                }
-            }
-        }
-
         public void Dispose()
         {
             ResetEvent?.Dispose();


### PR DESCRIPTION
test for RTE5

`(RTE5) EventEmitter#off deregisters a listener. If called with a specific event and a listener, it removes all registrations that match both the given listener and the given event; if called only with a listener, it removes all registrations matching the given listener, regardless of whether they are associated with an event or not; if called with no arguments, it removes all registrations, for all events and listeners`