### PR TITLE
TR2

### DIFF
--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -482,7 +482,7 @@ namespace IO.Ably.Realtime
 
                     if (protocolMessage != null)
                     {
-                        if (protocolMessage.HasPresenceFlag)
+                        if (protocolMessage.HasFlag(ProtocolMessage.Flag.HasPresence))
                         {
                             if (Logger.IsDebug)
                             {

--- a/src/IO.Ably.Shared/Types/ProtocolMessage.cs
+++ b/src/IO.Ably.Shared/Types/ProtocolMessage.cs
@@ -28,7 +28,8 @@ namespace IO.Ably.Types
             Detached,
             Presence,
             Message,
-            Sync
+            Sync,
+            Auth
         }
 
         public class MessageFlags

--- a/src/IO.Ably.Shared/Types/ProtocolMessage.cs
+++ b/src/IO.Ably.Shared/Types/ProtocolMessage.cs
@@ -10,7 +10,7 @@ namespace IO.Ably.Types
     {
         private string _connectionKey;
 
-        public enum MessageAction : int
+        public enum MessageAction
         {
             Heartbeat = 0,
             Ack,
@@ -32,20 +32,27 @@ namespace IO.Ably.Types
             Auth
         }
 
-        public class MessageFlags
+        public enum Flag
         {
-            public const int Presence = 1;
-            public const int Backlog = 1 << 1;
+            HasPresence = 1 << 0,
+            HasBacklog = 1 << 1,
+            Resumed = 1 << 2,
+            HasLocalPresence = 1 << 3,
+            Transient = 1 << 4,
+            Presence = 1 << 16,
+            Publish = 1 << 17,
+            Subscribe = 1 << 18,
+            PresenceSubscribe = 1 << 19
+        }
 
-            public static bool HasFlag(int? value, int flag)
+        public static bool HasFlag(int? value, Flag flag)
+        {
+            if (value == null)
             {
-                if (value == null)
-                {
-                    return false;
-                }
-
-                return (value.Value & flag) != 0;
+                return false;
             }
+
+            return (value.Value & (int)flag) != 0;
         }
 
         public ProtocolMessage()
@@ -71,12 +78,6 @@ namespace IO.Ably.Types
 
         [JsonProperty("flags")]
         public int? Flags { get; set; }
-
-        [JsonIgnore]
-        public bool HasPresenceFlag => MessageFlags.HasFlag(Flags, MessageFlags.Presence);
-
-        [JsonIgnore]
-        public bool HasBacklogFlag => MessageFlags.HasFlag(Flags, MessageFlags.Backlog);
 
         [JsonProperty("count")]
         public int? Count { get; set; }
@@ -155,6 +156,10 @@ namespace IO.Ably.Types
             {
                 Presence = null;
             }
+        }
+        public bool HasFlag(Flag flag)
+        {
+            return ProtocolMessage.HasFlag(Flags, flag);
         }
 
         public override string ToString()

--- a/src/IO.Ably.Tests.Shared/IO.Ably.Tests.Shared.projitems
+++ b/src/IO.Ably.Tests.Shared/IO.Ably.Tests.Shared.projitems
@@ -89,6 +89,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Realtime\CountDownTimerSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Realtime\MockHttpRealtimeSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Realtime\PresenceSandboxSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Realtime\ProtocolMessageSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Realtime\RealtimeSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RestProtocolTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\AblyHttpClientSpecs.cs" />

--- a/src/IO.Ably.Tests.Shared/Realtime/ProtocolMessageSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ProtocolMessageSpecs.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using IO.Ably.Types;
+using Xunit;
+
+namespace IO.Ably.Tests.Shared.Realtime
+{
+    public class ProtocolMessageTests
+    {
+
+
+        [Fact]
+        [Trait("spec", "TR3")]
+        public void ProtocolMessageFlagHaveCorrectValues()
+        {
+            // TR3a to TR3e
+            ((int)ProtocolMessage.Flag.HasPresence).Should().Be(1 << 0);
+            ((int)ProtocolMessage.Flag.HasBacklog).Should().Be(1 << 1);
+            ((int)ProtocolMessage.Flag.Resumed).Should().Be(1 << 2);
+            ((int)ProtocolMessage.Flag.HasLocalPresence).Should().Be(1 << 3);
+            ((int)ProtocolMessage.Flag.Transient).Should().Be(1 << 4);
+
+            // TR3q to TR3t
+            ((int)ProtocolMessage.Flag.Presence).Should().Be(1 << 16);
+            ((int)ProtocolMessage.Flag.Publish).Should().Be(1 << 17);
+            ((int)ProtocolMessage.Flag.Subscribe).Should().Be(1 << 18);
+            ((int)ProtocolMessage.Flag.PresenceSubscribe).Should().Be(1 << 19);
+        }
+
+        [Fact]
+        [Trait("spec", "TR4i")]
+        public void FlagsContainsBitFlags()
+        {
+            string messageStr = $"{{\"flags\":{(int)ProtocolMessage.Flag.HasPresence + (int)ProtocolMessage.Flag.Resumed + (int)ProtocolMessage.Flag.PresenceSubscribe}}}";
+
+            var pm = JsonHelper.Deserialize<ProtocolMessage>(messageStr);
+
+            pm.HasFlag(ProtocolMessage.Flag.HasPresence).Should().BeTrue();
+            pm.HasFlag(ProtocolMessage.Flag.HasBacklog).Should().BeFalse();
+            pm.HasFlag(ProtocolMessage.Flag.Resumed).Should().BeTrue();
+            pm.HasFlag(ProtocolMessage.Flag.HasLocalPresence).Should().BeFalse();
+            pm.HasFlag(ProtocolMessage.Flag.Transient).Should().BeFalse();
+            pm.HasFlag(ProtocolMessage.Flag.Presence).Should().BeFalse();
+            pm.HasFlag(ProtocolMessage.Flag.Publish).Should().BeFalse();
+            pm.HasFlag(ProtocolMessage.Flag.Subscribe).Should().BeFalse();
+            pm.HasFlag(ProtocolMessage.Flag.PresenceSubscribe).Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
`(TR2) ProtocolMessage Action enum has the following values in order from zero: HEARTBEAT, ACK, NACK, CONNECT, CONNECTED, DISCONNECT, DISCONNECTED, CLOSE, CLOSED, ERROR, ATTACH, ATTACHED, DETACH, DETACHED, PRESENCE, MESSAGE, SYNC, AUTH`

Required the `Auth` enum to bring up to spec.