### PR TITLE
TR3

### DIFF
--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -482,7 +482,7 @@ namespace IO.Ably.Realtime
 
                     if (protocolMessage != null)
                     {
-                        if (protocolMessage.HasPresenceFlag)
+                        if (protocolMessage.HasFlag(ProtocolMessage.Flag.HasPresence))
                         {
                             if (Logger.IsDebug)
                             {

--- a/src/IO.Ably.Shared/Types/ProtocolMessage.cs
+++ b/src/IO.Ably.Shared/Types/ProtocolMessage.cs
@@ -32,13 +32,13 @@ namespace IO.Ably.Types
             Auth
         }
 
-        public enum MessageFlag
+        public enum Flag
         {
             // @ProtocolMessage@ @Flag@ enum has the following values, where a flag with value @n@ is defined to be set if the bitwise AND of the @flags@ field with @2ⁿ@ is nonzero
             HasPresence = 1 << 0,
             HasBacklog = 1 << 1,
             Resumed = 1 << 2,
-            LocalPresence = 1 << 3,
+            HasLocalPresence = 1 << 3,
             Transient = 1 << 4,
             Presence = 1 << 16,
             Publish = 1 << 17,
@@ -46,7 +46,7 @@ namespace IO.Ably.Types
             PresenceSubscribe = 1 << 19
         }
 
-        public static bool HasFlag(int? value, MessageFlag flag)
+        public static bool HasFlag(int? value, Flag flag)
         {
             if (value == null)
             {
@@ -79,15 +79,6 @@ namespace IO.Ably.Types
 
         [JsonProperty("flags")]
         public int? Flags { get; set; }
-
-        [JsonIgnore]
-        public bool HasPresenceFlag => HasFlag(Flags, MessageFlag.HasPresence);
-
-        [JsonIgnore]
-        public bool HasBacklogFlag => HasFlag(Flags, MessageFlag.HasBacklog);
-
-        [JsonIgnore]
-        public bool HasResumedFlag => HasFlag(Flags, MessageFlag.Resumed);
 
         [JsonProperty("count")]
         public int? Count { get; set; }
@@ -166,6 +157,10 @@ namespace IO.Ably.Types
             {
                 Presence = null;
             }
+        }
+        public bool HasFlag(Flag flag)
+        {
+            return ProtocolMessage.HasFlag(Flags, flag);
         }
 
         public override string ToString()

--- a/src/IO.Ably.Shared/Types/ProtocolMessage.cs
+++ b/src/IO.Ably.Shared/Types/ProtocolMessage.cs
@@ -34,7 +34,6 @@ namespace IO.Ably.Types
 
         public enum Flag
         {
-            // @ProtocolMessage@ @Flag@ enum has the following values, where a flag with value @n@ is defined to be set if the bitwise AND of the @flags@ field with @2ⁿ@ is nonzero
             HasPresence = 1 << 0,
             HasBacklog = 1 << 1,
             Resumed = 1 << 2,

--- a/src/IO.Ably.Shared/Types/ProtocolMessage.cs
+++ b/src/IO.Ably.Shared/Types/ProtocolMessage.cs
@@ -10,7 +10,7 @@ namespace IO.Ably.Types
     {
         private string _connectionKey;
 
-        public enum MessageAction : int
+        public enum MessageAction
         {
             Heartbeat = 0,
             Ack,
@@ -32,20 +32,28 @@ namespace IO.Ably.Types
             Auth
         }
 
-        public class MessageFlags
+        public enum MessageFlag
         {
-            public const int Presence = 1;
-            public const int Backlog = 1 << 1;
+            // @ProtocolMessage@ @Flag@ enum has the following values, where a flag with value @n@ is defined to be set if the bitwise AND of the @flags@ field with @2ⁿ@ is nonzero
+            HasPresence = 1 << 0,
+            HasBacklog = 1 << 1,
+            Resumed = 1 << 2,
+            LocalPresence = 1 << 3,
+            Transient = 1 << 4,
+            Presence = 1 << 16,
+            Publish = 1 << 17,
+            Subscribe = 1 << 18,
+            PresenceSubscribe = 1 << 19
+        }
 
-            public static bool HasFlag(int? value, int flag)
+        public static bool HasFlag(int? value, MessageFlag flag)
+        {
+            if (value == null)
             {
-                if (value == null)
-                {
-                    return false;
-                }
-
-                return (value.Value & flag) != 0;
+                return false;
             }
+
+            return (value.Value & (int)flag) != 0;
         }
 
         public ProtocolMessage()
@@ -73,10 +81,13 @@ namespace IO.Ably.Types
         public int? Flags { get; set; }
 
         [JsonIgnore]
-        public bool HasPresenceFlag => MessageFlags.HasFlag(Flags, MessageFlags.Presence);
+        public bool HasPresenceFlag => HasFlag(Flags, MessageFlag.HasPresence);
 
         [JsonIgnore]
-        public bool HasBacklogFlag => MessageFlags.HasFlag(Flags, MessageFlags.Backlog);
+        public bool HasBacklogFlag => HasFlag(Flags, MessageFlag.HasBacklog);
+
+        [JsonIgnore]
+        public bool HasResumedFlag => HasFlag(Flags, MessageFlag.Resumed);
 
         [JsonProperty("count")]
         public int? Count { get; set; }

--- a/src/IO.Ably.Tests.Shared/IO.Ably.Tests.Shared.projitems
+++ b/src/IO.Ably.Tests.Shared/IO.Ably.Tests.Shared.projitems
@@ -89,6 +89,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Realtime\CountDownTimerSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Realtime\MockHttpRealtimeSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Realtime\PresenceSandboxSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Realtime\ProtocolMessageSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Realtime\RealtimeSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RestProtocolTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\AblyHttpClientSpecs.cs" />

--- a/src/IO.Ably.Tests.Shared/Realtime/ProtocolMessageSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ProtocolMessageSpecs.cs
@@ -9,19 +9,32 @@ namespace IO.Ably.Tests.Shared.Realtime
 {
     public class ProtocolMessageTests
     {
+
+
         [Fact]
         [Trait("spec", "TR3")]
+        public void ProtocolMessageFlagHaveCorrectValues()
+        {
+            // TR3a to TR3e
+            ((int)ProtocolMessage.Flag.HasPresence).Should().Be(1 << 0);
+            ((int)ProtocolMessage.Flag.HasBacklog).Should().Be(1 << 1);
+            ((int)ProtocolMessage.Flag.Resumed).Should().Be(1 << 2);
+            ((int)ProtocolMessage.Flag.HasLocalPresence).Should().Be(1 << 3);
+            ((int)ProtocolMessage.Flag.Transient).Should().Be(1 << 4);
+
+            // TR3q to TR3t
+            ((int)ProtocolMessage.Flag.Presence).Should().Be(1 << 16);
+            ((int)ProtocolMessage.Flag.Publish).Should().Be(1 << 17);
+            ((int)ProtocolMessage.Flag.Subscribe).Should().Be(1 << 18);
+            ((int)ProtocolMessage.Flag.PresenceSubscribe).Should().Be(1 << 19);
+        }
+
+        [Fact]
         [Trait("spec", "TR4i")]
         public void FlagsContainsBitFlags()
         {
-            // Arrange
-            int hasPresence = 1 << 0;
-            int hasResumed = 1 << 2;
-            int presenceSubscribe = 1 << 19;
-            
-            string messageStr = $"{{\"flags\":{hasPresence + hasResumed + presenceSubscribe}}}";
+            string messageStr = $"{{\"flags\":{(int)ProtocolMessage.Flag.HasPresence + (int)ProtocolMessage.Flag.Resumed + (int)ProtocolMessage.Flag.PresenceSubscribe}}}";
 
-            // Act
             var pm = JsonHelper.Deserialize<ProtocolMessage>(messageStr);
 
             pm.HasFlag(ProtocolMessage.Flag.HasPresence).Should().BeTrue();

--- a/src/IO.Ably.Tests.Shared/Realtime/ProtocolMessageSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ProtocolMessageSpecs.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using FluentAssertions;
+using IO.Ably.Types;
+using Xunit;
+
+namespace IO.Ably.Tests.Shared.Realtime
+{
+    public class ProtocolMessageTests
+    {
+        [Fact]
+        [Trait("spec", "TR3")]
+        [Trait("spec", "TR4i")]
+        public void FlagsContainsBitFlags()
+        {
+            // Arrange
+            int hasPresence = 1 << 0;
+            int hasResumed = 1 << 2;
+            int presenceSubscribe = 1 << 19;
+            
+            string messageStr = $"{{\"flags\":{hasPresence + hasResumed + presenceSubscribe}}}";
+
+            // Act
+            var pm = JsonHelper.Deserialize<ProtocolMessage>(messageStr);
+
+            pm.HasFlag(ProtocolMessage.Flag.HasPresence).Should().BeTrue();
+            pm.HasFlag(ProtocolMessage.Flag.HasBacklog).Should().BeFalse();
+            pm.HasFlag(ProtocolMessage.Flag.Resumed).Should().BeTrue();
+            pm.HasFlag(ProtocolMessage.Flag.HasLocalPresence).Should().BeFalse();
+            pm.HasFlag(ProtocolMessage.Flag.Transient).Should().BeFalse();
+            pm.HasFlag(ProtocolMessage.Flag.Presence).Should().BeFalse();
+            pm.HasFlag(ProtocolMessage.Flag.Publish).Should().BeFalse();
+            pm.HasFlag(ProtocolMessage.Flag.Subscribe).Should().BeFalse();
+            pm.HasFlag(ProtocolMessage.Flag.PresenceSubscribe).Should().BeTrue();
+        }
+    }
+}


### PR DESCRIPTION
(TR3) ProtocolMessage Flag enum has the following values, where a flag with value n is defined to be set if the bitwise AND of the flags field with 2ⁿ is nonzero
- (TR3a) 0: HAS_PRESENCE
- (TR3b) 1: HAS_BACKLOG
- (TR3c) 2: RESUMED
- (TR3d) 3: HAS_LOCAL_PRESENCE
- (TR3e) 4: TRANSIENT
- (TR3q) 16: PRESENCE
- (TR3r) 17: PUBLISH
- (TR3s) 18: SUBSCRIBE
- (TR3t) 19: PRESENCE_SUBSCRIBE

I have added the above (replacing the `const` with `enums`), renamed `MessageFlags` to `Flags` to better align with the spec.

I have removed the HasPresenceFlag property in favour of a `HasFlag(Flag flag)` method because the current naming was going to become unclear, i.e. does `HasPresence` mean 'has a PRESENCE flag' or 'has a HAS_PRESENCE flag'

I had added a simple test that shows all the emums are added and demonstrates HasFlag.