### PR TITLE
namespace was not updated when the project name was updated

### DIFF
--- a/src/IO.Ably.Tests.NETFramework/IO.Ably.Tests.NETFramework.csproj
+++ b/src/IO.Ably.Tests.NETFramework/IO.Ably.Tests.NETFramework.csproj
@@ -7,8 +7,8 @@
     <ProjectGuid>{567FEEF7-41AF-42F2-AD34-546A278355B1}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>IO.Ably.Tests.Net46</RootNamespace>
-    <AssemblyName>IO.Ably.Tests.Net46</AssemblyName>
+    <RootNamespace>IO.Ably.Tests.NETFramework</RootNamespace>
+    <AssemblyName>IO.Ably.Tests.NETFramework</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>


### PR DESCRIPTION
The project named IO.Ably.Tests.NETFramework did not have the namespace updated to match the project name, as is convention. This fixes that.