### PR TITLE
Issue 205

### DIFF
--- a/src/IO.Ably.Shared/Realtime/ChannelAwaiter.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelAwaiter.cs
@@ -37,10 +37,15 @@ namespace IO.Ably.Realtime
 
         public void Fail(ErrorInfo error)
         {
-            Cancel(error);
+            Complete(false, error);
         }
 
         public void Cancel(ErrorInfo error = null)
+        {
+            Complete(true, error);
+        }
+
+        public void Complete(bool success, ErrorInfo error = null)
         {
             lock (_lock)
             {
@@ -63,7 +68,7 @@ namespace IO.Ably.Realtime
 
             if (error != null)
             {
-                InvokeCallbacks(false, error);
+                InvokeCallbacks(success, error);
             }
         }
 
@@ -158,11 +163,7 @@ namespace IO.Ably.Realtime
 
             if (args.Current == _awaitedState)
             {
-                lock (_lock)
-                {
-                    _waiting = false;
-                }
-
+                Complete(true);
                 InvokeCallbacks(true, null);
             }
         }

--- a/src/IO.Ably.Shared/Realtime/ChannelAwaiter.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelAwaiter.cs
@@ -40,27 +40,10 @@ namespace IO.Ably.Realtime
             Complete(false, error);
         }
 
-        public void Cancel(ErrorInfo error = null)
-        {
-            Complete(true, error);
-        }
-
-        public void Complete(bool success, ErrorInfo error = null)
+        private void Complete(bool success, ErrorInfo error = null)
         {
             lock (_lock)
             {
-                if (Logger.IsDebug)
-                {
-                    if (error == null)
-                    {
-                        Logger.Debug($"ChannelAwaiter completed for - {_name}.");
-                    }
-                    else
-                    {
-                        Logger.Debug($"{_name}: ChannelAwaiter completed for - {_name}; With error: {error.Message}");
-                    }
-                }
-
                 _timer?.Abort();
                 if (_waiting == false) return;
                 _waiting = false;

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -427,7 +427,6 @@ namespace IO.Ably.Realtime
 
                     break;
                 case ChannelState.Attached:
-                    AttachedAwaiter.Cancel();
                     if (protocolMessage != null)
                     {
                         if (protocolMessage.HasPresenceFlag)
@@ -468,7 +467,6 @@ namespace IO.Ably.Realtime
 
                     break;
                 case ChannelState.Detached:
-                    DetachedAwaiter.Cancel();
                     ConnectionManager.FailMessageWaitingForAckAndClearOutgoingQueue(this, error);
                     ClearAndFailChannelQueuedMessages(error);
                     break;

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -386,23 +386,28 @@ namespace IO.Ably.Realtime
 
             //Notify external client using the thread they subscribe on
             RealtimeClient.NotifyExternalClients(() =>
+            {
+                var args = new ChannelStateChange(state, previousState, error);
+                try
                 {
-                    var args = new ChannelStateChange(state, previousState, error);
-                    try
-                    {
-                        StateChanged.Invoke(this, args);
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.Error($"Error notifying event handlers for state change: {state}", ex);
-                    }
+                    StateChanged.Invoke(this, args);
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error($"Error notifying event handlers for state change: {state}", ex);
+                }
 
-                    Emit(state, args);
-                });
+                Emit(state, args);
+            });
         }
 
         private void HandleStateChange(ChannelState state, ErrorInfo error, ProtocolMessage protocolMessage)
         {
+            if (Logger.IsDebug)
+            {
+                Logger.Debug($"HandleStateChange state change: {state}");
+            }
+
             State = state;
 
             switch (state)
@@ -422,7 +427,7 @@ namespace IO.Ably.Realtime
 
                     break;
                 case ChannelState.Attached:
-
+                    AttachedAwaiter.Cancel();
                     if (protocolMessage != null)
                     {
                         if (protocolMessage.HasPresenceFlag)
@@ -463,6 +468,7 @@ namespace IO.Ably.Realtime
 
                     break;
                 case ChannelState.Detached:
+                    DetachedAwaiter.Cancel();
                     ConnectionManager.FailMessageWaitingForAckAndClearOutgoingQueue(this, error);
                     ClearAndFailChannelQueuedMessages(error);
                     break;

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -122,6 +122,24 @@ namespace IO.Ably.Tests.Realtime
             result.Error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         }
 
+        [Theory]
+        [ProtocolData]
+        [Trait("bug", "Issue #205")]
+        public async Task ShouldReturnToPreviousStateIfAttachMessageNotReceivedWithinDefaultTimeout2(Protocol protocol)
+        {
+            var client = await GetRealtimeClient(protocol);
+            bool? didAttach = null;
+            var channel = client.Channels.Get("ChannelSpecs-issue205".AddRandomSuffix());
+            channel.Attach((b, info) =>
+            {
+                didAttach = b;
+            });
+            await Task.Delay(5000);
+            didAttach.Should().BeTrue();
+            channel.State.Should().Be(ChannelState.Attached);
+            await Task.Delay(6000);
+            channel.State.Should().Be(ChannelState.Attached);
+        }
 
         [Theory]
         [ProtocolData]
@@ -222,10 +240,10 @@ namespace IO.Ably.Tests.Realtime
             List<bool> successes3 = new List<bool>();
 
             bool retry = true;
-            int tries = 3; 
+            int tries = 3;
             while (retry)
             {
-               
+
                 var client1 = await GetRealtimeClient(protocol);
                 var client2 = await GetRealtimeClient(protocol);
                 var client3 = await GetRealtimeClient(protocol);


### PR DESCRIPTION
A fix for issue #205.

A brief outline of the problem this fixes:

When `channel.Attach()` is called the channel moves into the `Attaching` state and and starts up a `ChannelAwaiter` that is waiting for the `Attach` state to be attained. Previously when that happened the callback fired but the timer was not cancelled. After the waiter times out (10 seconds as per DF1b), if the channel is attached this moves it to `Attaching` and the cycle starts again. Calling `Detach()` would clear the `AttachedAwaiter` but would start a `DetachedAwaiter` and a similar cycle would begin for Detached/Detaching.

The fix is quite simple as the `ChannelAwaiter` already listens to the Channels state changes, when the desired state is reached the timer is now aborted. I have also refactored this code a little to DRY it up and added a test. 