### PR TITLE
RTN4h, TA1, TA2, TA3, TA5

### DIFF
--- a/src/IO.Ably.Shared/IO.Ably.Shared.projitems
+++ b/src/IO.Ably.Shared/IO.Ably.Shared.projitems
@@ -29,6 +29,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)IPlatform.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IRealtimeClient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)JsonHelper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Realtime\ConnectionEvent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Realtime\RealtimeChannels.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\RestChannels.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyncExtensions.cs" />

--- a/src/IO.Ably.Shared/Realtime/ConnectionEvent.cs
+++ b/src/IO.Ably.Shared/Realtime/ConnectionEvent.cs
@@ -1,0 +1,19 @@
+﻿namespace IO.Ably.Realtime
+{
+    /// <summary>A series of connection states.</summary>
+    public enum ConnectionEvent
+    {
+        /*
+         The values assigned to each enum should correspond with those assigned in ConnectionState.
+         */
+        Initialized = 0,
+        Connecting = 1,
+        Connected = 2,
+        Disconnected = 3,
+        Suspended = 4,
+        Closing = 5,
+        Closed = 6,
+        Failed = 7,
+        Update = 8
+    }
+}

--- a/src/IO.Ably.Shared/Realtime/ConnectionState.cs
+++ b/src/IO.Ably.Shared/Realtime/ConnectionState.cs
@@ -1,4 +1,6 @@
-﻿namespace IO.Ably.Realtime
+﻿using System;
+
+namespace IO.Ably.Realtime
 {
     /// <summary>A series of connection states.</summary>
     public enum ConnectionState
@@ -7,17 +9,17 @@
         /// A connection object having this state has been initialized but no connection has yet been
         /// attempted.
         /// </summary>
-        Initialized,
+        Initialized = 0,
 
         /// <summary>
         /// A connection attempt has been initiated. The connecting state is entered as soon as the library
         /// has completed initialization, and is reentered each time connection is re-attempted following
         /// disconnection.
         /// </summary>
-        Connecting,
+        Connecting = 1,
 
         /// <summary>A connection exists and is active.</summary>
-        Connected,
+        Connected = 2,
 
         /// <summary>A temporary failure condition.
         /// No current connection exists because there is no network connectivity or no host is unavailable.
@@ -27,7 +29,7 @@
         /// attempt after a short period, anticipating that the connection will be re-established soon, and
         /// connection continuity will be possible. Clients can continue to publish messages, and these will
         /// be queued, to be sent as soon as a connection is established.</remarks>
-        Disconnected,
+        Disconnected = 3,
 
         /// <summary>A long term failure condition.
         /// No current connection exists because there is no network
@@ -38,12 +40,12 @@
         /// further two minutes. In the suspended state clients are unable to publish messages. A new
         /// connection attempt can also be triggered by an explicit call to connect() on the connection
         /// object.</remarks>
-        Suspended,
+        Suspended = 4,
 
         /// <summary>
         ///
         /// </summary>
-        Closing,
+        Closing = 5,
 
         /// <summary>The connection has been explicitly closed by the client.</summary>
         /// <remarks>In the closed state, no reconnection attempts are made automatically by the library, and clients
@@ -51,7 +53,7 @@
         /// new connection attempt can be triggered by an explicit call to connect() on the connection
         /// object, which will result in a new connection.
         /// </remarks>
-        Closed,
+        Closed = 6,
 
         /// <summary>
         /// An indefinite failure condition. This state is entered if a connection error has been received from
@@ -63,6 +65,19 @@
         /// may not publish messages. A new connection attempt can be triggered by an explicit call to
         /// onnect() on the connection object.
         /// </remarks>
-        Failed
+        Failed = 7
+    }
+
+    public static class ConnectionStateExtensions
+    {
+        public static ConnectionEvent ToConnectionEvent(this ConnectionState state)
+        {
+            if (Enum.IsDefined(typeof(ConnectionEvent), (int) state))
+            {
+                return (ConnectionEvent) state;
+            }
+
+            throw new ArgumentOutOfRangeException($"ConnectionState '{state}' cannot be cast to a ConnectionEvent.");
+        }
     }
 }

--- a/src/IO.Ably.Shared/Realtime/ConnectionStateChangedEventArgs.cs
+++ b/src/IO.Ably.Shared/Realtime/ConnectionStateChangedEventArgs.cs
@@ -10,8 +10,9 @@ namespace IO.Ably.Realtime
     /// </summary>
     public class ConnectionStateChange : EventArgs
     {
-        public ConnectionStateChange(ConnectionState previous, ConnectionState current, TimeSpan? retryIn = null, ErrorInfo reason = null)
+        public ConnectionStateChange(ConnectionEvent connectionEvent, ConnectionState previous, ConnectionState current, TimeSpan? retryIn = null, ErrorInfo reason = null)
         {
+            Event = connectionEvent;
             Previous = previous;
             Current = current;
             RetryIn = retryIn;
@@ -19,6 +20,8 @@ namespace IO.Ably.Realtime
         }
 
         public ConnectionState Previous { get; }
+
+        public ConnectionEvent Event { get; }
 
         public ConnectionState Current { get; }
 

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
@@ -113,7 +113,7 @@ namespace IO.Ably.Tests
             var realtimeClient = await helper.GetRealTimeClientWithRequests(protocol, almostExpiredToken, invalidateKey: true);
 
             bool connected = false;
-            realtimeClient.Connection.Once(ConnectionState.Connected, (_) => { connected = true; });
+            realtimeClient.Connection.Once(ConnectionEvent.Connected, (_) => { connected = true; });
 
             // assert that there is no pre-existing error
             realtimeClient.Connection.ErrorReason.Should().BeNull();
@@ -176,7 +176,7 @@ namespace IO.Ably.Tests
 
             var awaiter = new TaskCompletionAwaiter(5000);
 
-            realtimeClient.Connection.Once(ConnectionState.Disconnected, state =>
+            realtimeClient.Connection.Once(ConnectionEvent.Disconnected, state =>
             {
                 state.Reason.Code.Should().Be(80019);
                 awaiter.SetCompleted();
@@ -216,7 +216,7 @@ namespace IO.Ably.Tests
             });
 
             var awaiter = new TaskCompletionAwaiter(5000);
-            realtimeClient.Connection.Once(ConnectionState.Disconnected, state =>
+            realtimeClient.Connection.Once(ConnectionEvent.Disconnected, state =>
             {
                 state.Reason.Code.Should().Be(80019);
                 awaiter.SetCompleted();
@@ -251,7 +251,7 @@ namespace IO.Ably.Tests
             });
 
             var awaiter = new TaskCompletionAwaiter(5000);
-            realtimeClient.Connection.Once(ConnectionState.Disconnected, state =>
+            realtimeClient.Connection.Once(ConnectionEvent.Disconnected, state =>
             {
                 state.Reason.Code.Should().Be(80019);
                 awaiter.SetCompleted();
@@ -276,7 +276,7 @@ namespace IO.Ably.Tests
             {
                 TaskCompletionAwaiter tca = new TaskCompletionAwaiter(5000);
                 var realtimeClient = await GetRealtimeClient(protocol, optionsAction);
-                realtimeClient.Connection.On(ConnectionState.Disconnected, change =>
+                realtimeClient.Connection.On(ConnectionEvent.Disconnected, change =>
                 {
                     change.Previous.Should().Be(ConnectionState.Connecting);
                     change.Reason.Code.Should().Be(80019);
@@ -368,7 +368,7 @@ namespace IO.Ably.Tests
                 TaskCompletionAwaiter tca = new TaskCompletionAwaiter(5000);
                 var realtimeClient = await GetRealtimeClient(protocol, optionsAction);
 
-                realtimeClient.Connection.Once(ConnectionState.Failed, change =>
+                realtimeClient.Connection.Once(ConnectionEvent.Failed, change =>
                 {
                     change.Previous.Should().Be(ConnectionState.Connecting);
                     change.Reason.Code.Should().Be(expectedCode);

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -678,7 +678,7 @@ namespace IO.Ably.Tests.Realtime
             var channel = client1.Channels.Get(channelName);
 
             TaskCompletionSource<bool> tsc = new TaskCompletionSource<bool>();
-            client1.Connection.On(ConnectionState.Connected, async state =>
+            client1.Connection.On(ConnectionEvent.Connected, async state =>
             {
                 tsc.SetResult(true);
                 client1.GetTestTransport().Close(false);
@@ -729,7 +729,7 @@ namespace IO.Ably.Tests.Realtime
         {
             Logger.LogLevel = LogLevel.Debug;
             var client = await GetRealtimeClient(protocol, (opts, _) => opts.AutoConnect = false);
-            client.Connection.On(ConnectionState.Connected, async args =>
+            client.Connection.On(ConnectionEvent.Connected, async args =>
             {
                 await client.Channels.Get("test")
                     .HistoryAsync(new HistoryRequestParams() { Start = DateHelper.CreateDate(1969, 1, 1) });

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -186,7 +186,7 @@ namespace IO.Ably.Tests.Realtime
             });
 
             ErrorInfo error = null;
-            realtimeClient.Connection.On(ConnectionState.Connected, (args) =>
+            realtimeClient.Connection.On(ConnectionEvent.Connected, (args) =>
             {
                 error = args.Reason;
                 ResetEvent.Set();
@@ -439,7 +439,7 @@ namespace IO.Ably.Tests.Realtime
             var channel = new RealtimeChannel("RTN19b", "RTN19b", client);
             channel.Logger = testLogger;
             channel.State = ChannelState.Attaching;
-            channel.InternalOnInternalStateChanged(this, new ConnectionStateChange(ConnectionState.Connected, ConnectionState.Disconnected));
+            channel.InternalOnInternalStateChanged(this, new ConnectionStateChange(ConnectionEvent.Connected, ConnectionState.Connected, ConnectionState.Disconnected));
             testLogger.MessageSeen.Should().Be(true);
         }
 
@@ -500,7 +500,7 @@ namespace IO.Ably.Tests.Realtime
             channel.Logger = testLogger;
 
             channel.State = ChannelState.Detaching;
-            channel.InternalOnInternalStateChanged(this, new ConnectionStateChange(ConnectionState.Connected, ConnectionState.Disconnected));
+            channel.InternalOnInternalStateChanged(this, new ConnectionStateChange(ConnectionEvent.Connected, ConnectionState.Connected, ConnectionState.Disconnected));
 
             testLogger.MessageSeen.Should().Be(true);
         }

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
@@ -149,6 +149,7 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
 
         [Fact]
         [Trait("spec", "RTN14d")]
+        [Trait("spec", "TR2")]
         public async Task WhenTransportFails_ShouldTransitionToDisconnectedAndEmitErrorWithRetry()
         {
             FakeTransportFactory.InitialiseFakeTransport =
@@ -174,6 +175,8 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
 
             WaitOne();
             connectionArgs.Current.Should().Be(ConnectionState.Disconnected);
+            connectionArgs.Previous.Should().Be(ConnectionState.Connecting);
+            connectionArgs.Event.Should().Be(ConnectionEvent.Disconnected);
             connectionArgs.RetryIn.Should().Be(options.DisconnectedRetryTimeout);
             connectionArgs.Reason.Should().NotBeNull();
         }

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionParameterSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionParameterSpecs.cs
@@ -117,7 +117,6 @@ namespace IO.Ably.Tests.Realtime
 
         [Fact]
         [Trait("spec", "RTN2g")]
-        [Trait()]
         public void ShouldSetTransportLibVersionParamater()
         {
             string pattern = @"^dotnet(.?\w*)-1.0.(\d+)$";

--- a/src/IO.Ably.Tests.Shared/Samples/DocumentationSamples.cs
+++ b/src/IO.Ably.Tests.Shared/Samples/DocumentationSamples.cs
@@ -292,7 +292,7 @@ namespace IO.Ably.Tests.Samples
         public void ConnectionExamples()
         {
             AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
-            realtime.Connection.On(ConnectionState.Connected, args => Console.WriteLine("Connected, that was easy"));
+            realtime.Connection.On(ConnectionEvent.Connected, args => Console.WriteLine("Connected, that was easy"));
             Action<ConnectionStateChange> action = args => Console.WriteLine("New state is " + args.Current);
             realtime.Connection.On(action);
             realtime.Connection.Off(action);

--- a/src/IO.Ably.Tests.Shared/Samples/RealtimeSamples.cs
+++ b/src/IO.Ably.Tests.Shared/Samples/RealtimeSamples.cs
@@ -23,7 +23,7 @@ namespace IO.Ably.Tests.GithubSamples
         {
             var realtime = new AblyRealtime(_placeholderKey);
 
-            realtime.Connection.On(ConnectionState.Connected, args =>
+            realtime.Connection.On(ConnectionEvent.Connected, args =>
             {
                 // Do stuff
             });


### PR DESCRIPTION
Changes and tests to cover 

- RTN4h
- TA1, TA2, TA3, TA5

Additionally I have fixed some RTN4x test that were not testing through the emitter and were therefore not valid.