### PR TITLE
TR4 & AD1

### DIFF
--- a/src/IO.Ably.Shared.MsgPack/CustomSerialisers/GeneratedSerializers/IO_Ably_Types_ProtocolMessageSerializer.cs
+++ b/src/IO.Ably.Shared.MsgPack/CustomSerialisers/GeneratedSerializers/IO_Ably_Types_ProtocolMessageSerializer.cs
@@ -86,7 +86,6 @@ namespace IO.Ably.CustomSerialisers {
                 objectTree.ChannelSerial.IsNotEmpty(),
                 objectTree.ConnectionDetails != null,
                 objectTree.ConnectionId.IsNotEmpty(),
-                objectTree.ConnectionKey.IsNotEmpty(),
                 objectTree.ConnectionSerial != null,
                 objectTree.Count != null,
                 objectTree.Error != null,
@@ -119,11 +118,6 @@ namespace IO.Ably.CustomSerialisers {
             {
                 this._serializer0.PackTo(packer, "connectionId");
                 this._serializer0.PackTo(packer, objectTree.ConnectionId);
-            }
-            if (objectTree.ConnectionKey.IsNotEmpty())
-            {
-                this._serializer0.PackTo(packer, "connectionKey");
-                this._serializer0.PackTo(packer, objectTree.ConnectionKey);
             }
             if (objectTree.ConnectionSerial != null)
             {
@@ -427,170 +421,155 @@ namespace IO.Ably.CustomSerialisers {
                                                 }
                                                 else
                                                 {
-                                                    if ((key == "connectionKey"))
+                                                    if ((key == "connectionId"))
                                                     {
-                                                        string nullable20 = default(string);
-                                                        nullable20 =
+                                                        string nullable19 = default(string);
+                                                        nullable19 =
                                                             MsgPack.Serialization.UnpackHelpers.UnpackStringValue(
                                                                 unpacker, typeof(IO.Ably.Types.ProtocolMessage),
-                                                                "System.String connectionKey");
-                                                        if (((nullable20 == null)
-                                                             == false))
+                                                                "System.String connectionId");
+                                                        if (((nullable19 == null)
+                                                                == false))
                                                         {
-                                                            result.ConnectionKey = nullable20;
+                                                            result.ConnectionId = nullable19;
                                                         }
                                                     }
                                                     else
                                                     {
-                                                        if ((key == "connectionId"))
+                                                        if ((key == "connectionDetails"))
                                                         {
-                                                            string nullable19 = default(string);
-                                                            nullable19 =
-                                                                MsgPack.Serialization.UnpackHelpers.UnpackStringValue(
-                                                                    unpacker, typeof(IO.Ably.Types.ProtocolMessage),
-                                                                    "System.String connectionId");
-                                                            if (((nullable19 == null)
-                                                                 == false))
+                                                            IO.Ably.ConnectionDetails nullable18 =
+                                                                default(IO.Ably.ConnectionDetails);
+                                                            if ((unpacker.Read() == false))
                                                             {
-                                                                result.ConnectionId = nullable19;
+                                                                throw MsgPack.Serialization.SerializationExceptions
+                                                                    .NewMissingItem(i);
+                                                            }
+                                                            if (((unpacker.IsArrayHeader == false)
+                                                                    && (unpacker.IsMapHeader == false)))
+                                                            {
+                                                                nullable18 = this._serializer2.UnpackFrom(unpacker);
+                                                            }
+                                                            else
+                                                            {
+                                                                MsgPack.Unpacker disposable7 =
+                                                                    default(MsgPack.Unpacker);
+                                                                disposable7 = unpacker.ReadSubtree();
+                                                                try
+                                                                {
+                                                                    nullable18 =
+                                                                        this._serializer2.UnpackFrom(disposable7);
+                                                                }
+                                                                finally
+                                                                {
+                                                                    if (((disposable7 == null)
+                                                                            == false))
+                                                                    {
+                                                                        disposable7.Dispose();
+                                                                    }
+                                                                }
+                                                            }
+                                                            if (((nullable18 == null)
+                                                                    == false))
+                                                            {
+                                                                result.ConnectionDetails = nullable18;
                                                             }
                                                         }
                                                         else
                                                         {
-                                                            if ((key == "connectionDetails"))
+                                                            if ((key == "channelSerial"))
                                                             {
-                                                                IO.Ably.ConnectionDetails nullable18 =
-                                                                    default(IO.Ably.ConnectionDetails);
-                                                                if ((unpacker.Read() == false))
+                                                                string nullable17 = default(string);
+                                                                nullable17 =
+                                                                    MsgPack.Serialization.UnpackHelpers
+                                                                        .UnpackStringValue(unpacker,
+                                                                            typeof(IO.Ably.Types.ProtocolMessage),
+                                                                            "System.String channelSerial");
+                                                                if (((nullable17 == null)
+                                                                        == false))
                                                                 {
-                                                                    throw MsgPack.Serialization.SerializationExceptions
-                                                                        .NewMissingItem(i);
-                                                                }
-                                                                if (((unpacker.IsArrayHeader == false)
-                                                                     && (unpacker.IsMapHeader == false)))
-                                                                {
-                                                                    nullable18 = this._serializer2.UnpackFrom(unpacker);
-                                                                }
-                                                                else
-                                                                {
-                                                                    MsgPack.Unpacker disposable7 =
-                                                                        default(MsgPack.Unpacker);
-                                                                    disposable7 = unpacker.ReadSubtree();
-                                                                    try
-                                                                    {
-                                                                        nullable18 =
-                                                                            this._serializer2.UnpackFrom(disposable7);
-                                                                    }
-                                                                    finally
-                                                                    {
-                                                                        if (((disposable7 == null)
-                                                                             == false))
-                                                                        {
-                                                                            disposable7.Dispose();
-                                                                        }
-                                                                    }
-                                                                }
-                                                                if (((nullable18 == null)
-                                                                     == false))
-                                                                {
-                                                                    result.ConnectionDetails = nullable18;
+                                                                    result.ChannelSerial = nullable17;
                                                                 }
                                                             }
                                                             else
                                                             {
-                                                                if ((key == "channelSerial"))
+                                                                if ((key == "channel"))
                                                                 {
-                                                                    string nullable17 = default(string);
-                                                                    nullable17 =
+                                                                    string nullable16 = default(string);
+                                                                    nullable16 =
                                                                         MsgPack.Serialization.UnpackHelpers
                                                                             .UnpackStringValue(unpacker,
-                                                                                typeof(IO.Ably.Types.ProtocolMessage),
-                                                                                "System.String channelSerial");
-                                                                    if (((nullable17 == null)
-                                                                         == false))
+                                                                                typeof(IO.Ably.Types.ProtocolMessage
+                                                                                    ), "System.String channel");
+                                                                    if (((nullable16 == null)
+                                                                            == false))
                                                                     {
-                                                                        result.ChannelSerial = nullable17;
+                                                                        result.Channel = nullable16;
                                                                     }
                                                                 }
                                                                 else
                                                                 {
-                                                                    if ((key == "channel"))
+                                                                    if ((key == "action"))
                                                                     {
-                                                                        string nullable16 = default(string);
-                                                                        nullable16 =
-                                                                            MsgPack.Serialization.UnpackHelpers
-                                                                                .UnpackStringValue(unpacker,
-                                                                                    typeof(IO.Ably.Types.ProtocolMessage
-                                                                                        ), "System.String channel");
-                                                                        if (((nullable16 == null)
-                                                                             == false))
+                                                                        System.Nullable
+                                                                            <
+                                                                                IO.Ably.Types.ProtocolMessage.
+                                                                                    MessageAction> nullable15 =
+                                                                                        default(
+                                                                                            System.Nullable
+                                                                                                <
+                                                                                                    IO.Ably.Types.
+                                                                                                        ProtocolMessage
+                                                                                                        .
+                                                                                                        MessageAction
+                                                                                                    >);
+                                                                        if ((unpacker.Read() == false))
                                                                         {
-                                                                            result.Channel = nullable16;
+                                                                            throw MsgPack.Serialization
+                                                                                .SerializationExceptions
+                                                                                .NewMissingItem(i);
+                                                                        }
+                                                                        if (((unpacker.IsArrayHeader == false)
+                                                                                && (unpacker.IsMapHeader == false)))
+                                                                        {
+                                                                            nullable15 =
+                                                                                this._serializer11.UnpackFrom(
+                                                                                    unpacker);
+                                                                        }
+                                                                        else
+                                                                        {
+                                                                            MsgPack.Unpacker disposable6 =
+                                                                                default(MsgPack.Unpacker);
+                                                                            disposable6 = unpacker.ReadSubtree();
+                                                                            try
+                                                                            {
+                                                                                nullable15 =
+                                                                                    this._serializer11.UnpackFrom(
+                                                                                        disposable6);
+                                                                            }
+                                                                            finally
+                                                                            {
+                                                                                if (((disposable6 == null)
+                                                                                        == false))
+                                                                                {
+                                                                                    disposable6.Dispose();
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                        if (nullable15.HasValue)
+                                                                        {
+                                                                            result.Action = nullable15.Value;
                                                                         }
                                                                     }
                                                                     else
                                                                     {
-                                                                        if ((key == "action"))
-                                                                        {
-                                                                            System.Nullable
-                                                                                <
-                                                                                    IO.Ably.Types.ProtocolMessage.
-                                                                                        MessageAction> nullable15 =
-                                                                                            default(
-                                                                                                System.Nullable
-                                                                                                    <
-                                                                                                        IO.Ably.Types.
-                                                                                                            ProtocolMessage
-                                                                                                            .
-                                                                                                            MessageAction
-                                                                                                        >);
-                                                                            if ((unpacker.Read() == false))
-                                                                            {
-                                                                                throw MsgPack.Serialization
-                                                                                    .SerializationExceptions
-                                                                                    .NewMissingItem(i);
-                                                                            }
-                                                                            if (((unpacker.IsArrayHeader == false)
-                                                                                 && (unpacker.IsMapHeader == false)))
-                                                                            {
-                                                                                nullable15 =
-                                                                                    this._serializer11.UnpackFrom(
-                                                                                        unpacker);
-                                                                            }
-                                                                            else
-                                                                            {
-                                                                                MsgPack.Unpacker disposable6 =
-                                                                                    default(MsgPack.Unpacker);
-                                                                                disposable6 = unpacker.ReadSubtree();
-                                                                                try
-                                                                                {
-                                                                                    nullable15 =
-                                                                                        this._serializer11.UnpackFrom(
-                                                                                            disposable6);
-                                                                                }
-                                                                                finally
-                                                                                {
-                                                                                    if (((disposable6 == null)
-                                                                                         == false))
-                                                                                    {
-                                                                                        disposable6.Dispose();
-                                                                                    }
-                                                                                }
-                                                                            }
-                                                                            if (nullable15.HasValue)
-                                                                            {
-                                                                                result.Action = nullable15.Value;
-                                                                            }
-                                                                        }
-                                                                        else
-                                                                        {
-                                                                            unpacker.Skip();
-                                                                        }
+                                                                        unpacker.Skip();
                                                                     }
                                                                 }
                                                             }
                                                         }
                                                     }
+                                                    
                                                 }
                                             }
                                         }

--- a/src/IO.Ably.Shared/IO.Ably.Shared.projitems
+++ b/src/IO.Ably.Shared/IO.Ably.Shared.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AblyRealtime.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AblyRest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ApiKey.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Types\AuthDetails.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AuthMethod.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AuthOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Capability.cs" />

--- a/src/IO.Ably.Shared/Transport/IConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/IConnectionManager.cs
@@ -34,7 +34,6 @@ namespace IO.Ably.Transport
 
             ConnectionId = message.ConnectionId;
             ConnectionSerial = message.ConnectionSerial ?? -1;
-            ConnectionKey = message.ConnectionKey;
             ClientId = message.ConnectionDetails?.ClientId;
             ConnectionStateTtl = message.ConnectionDetails?.ConnectionStateTtl;
         }

--- a/src/IO.Ably.Shared/Transport/IConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/IConnectionManager.cs
@@ -36,6 +36,7 @@ namespace IO.Ably.Transport
             ConnectionSerial = message.ConnectionSerial ?? -1;
             ClientId = message.ConnectionDetails?.ClientId;
             ConnectionStateTtl = message.ConnectionDetails?.ConnectionStateTtl;
+            ConnectionKey = message.ConnectionDetails?.ConnectionKey;
         }
 
         public TimeSpan? ConnectionStateTtl { get; private set; }

--- a/src/IO.Ably.Shared/Types/AuthDetails.cs
+++ b/src/IO.Ably.Shared/Types/AuthDetails.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace IO.Ably.Types
+{
+    /// <summary>
+    /// AuthDetails is a type used with an AUTH protocol messages to send authentication details
+    /// </summary>
+    public class AuthDetails
+    {
+        /// <summary>
+        /// Gets or sets the accessToken.
+        /// </summary>
+        [JsonProperty("accessToken")]
+        public string AccessToken { get; set; }
+    }
+}

--- a/src/IO.Ably.Shared/Types/ProtocolMessage.cs
+++ b/src/IO.Ably.Shared/Types/ProtocolMessage.cs
@@ -76,6 +76,9 @@ namespace IO.Ably.Types
         [JsonProperty("action")]
         public MessageAction Action { get; set; }
 
+        [JsonProperty("auth")]
+        public AuthDetails Auth { get; set; }
+
         [JsonProperty("flags")]
         public int? Flags { get; set; }
 
@@ -96,22 +99,6 @@ namespace IO.Ably.Types
 
         [JsonProperty("connectionId")]
         public string ConnectionId { get; set; }
-
-        [JsonProperty("connectionKey")]
-        public string ConnectionKey
-        {
-            get
-            {
-                if (ConnectionDetails != null && ConnectionDetails.ConnectionKey.IsNotEmpty())
-                {
-                    return ConnectionDetails.ConnectionKey;
-                }
-
-                return _connectionKey;
-            }
-
-            set { _connectionKey = value; }
-        }
 
         [JsonProperty("connectionSerial")]
         public long? ConnectionSerial { get; set; }
@@ -157,6 +144,7 @@ namespace IO.Ably.Types
                 Presence = null;
             }
         }
+
         public bool HasFlag(Flag flag)
         {
             return ProtocolMessage.HasFlag(Flags, flag);

--- a/src/IO.Ably.Tests.Shared/JsonMessageSerializerTests.cs
+++ b/src/IO.Ably.Tests.Shared/JsonMessageSerializerTests.cs
@@ -257,24 +257,6 @@ namespace IO.Ably.Tests
         [InlineData("123.456")]
         [InlineData("123^&456")]
         [InlineData("absder#^&456")]
-        public void DeserializesMessageCorrectly_ConnectionKey(string connectionKey)
-        {
-            // Arrange
-            string message = string.Format("{{\"connectionKey\":\"{0}\"}}", connectionKey);
-
-            // Act
-            ProtocolMessage target = JsonHelper.Deserialize<ProtocolMessage>(message);
-
-            // Assert
-            Assert.NotNull(target);
-            Assert.Equal(connectionKey, target.ConnectionKey);
-        }
-
-        [Theory]
-        [InlineData("123")]
-        [InlineData("123.456")]
-        [InlineData("123^&456")]
-        [InlineData("absder#^&456")]
         public void DeserializesMessageCorrectly_Id(string id)
         {
             // Arrange

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/GeneralConnectionSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/GeneralConnectionSpecs.cs
@@ -61,17 +61,6 @@ namespace IO.Ably.Tests.Realtime
         }
 
         [Fact]
-        [Trait("spec", "RTN19")]
-        public void WhenConnectedMessageReceived_WithNoConnectionDetailsButConnectionKeyInMessage_ShouldHaveCorrectKey()
-        {
-            var client = GetClientWithFakeTransport();
-
-            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Connected));
-
-            client.Connection.Key.Should().Be("unimportant");
-        }
-
-        [Fact]
         [Trait("spec", "RSA15a")]
         [Trait("sandboxTest", "needed")]
         public void WhenConnectedMessageReceivedWithClientId_AblyAuthShouldUseConnectionClientId()

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/GeneralConnectionSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/GeneralConnectionSpecs.cs
@@ -53,8 +53,7 @@ namespace IO.Ably.Tests.Realtime
             };
             client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Connected)
             {
-                ConnectionDetails = connectionDetailsMessage,
-                ConnectionKey = "unimportant"
+                ConnectionDetails = connectionDetailsMessage
             });
 
             client.Connection.State.Should().Be(ConnectionState.Connected);
@@ -67,10 +66,7 @@ namespace IO.Ably.Tests.Realtime
         {
             var client = GetClientWithFakeTransport();
 
-            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Connected)
-            {
-                ConnectionKey = "unimportant"
-            });
+            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Connected));
 
             client.Connection.Key.Should().Be("unimportant");
         }


### PR DESCRIPTION
This PR adds the AuthDetails object and updates the ProtocolMessage to v1.0 spec, including the removal of the connectionKey.
An updated test verifying the ProtocolMessage attributes (all subsections of TR4) and AD1 and AD2 is provided.