### PR TITLE
regex would only match single digit

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionParameterSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionParameterSpecs.cs
@@ -124,7 +124,7 @@ namespace IO.Ably.Tests.Realtime
             var client = GetClientWithFakeTransport();
             LastCreatedTransport.Parameters.GetParams().Should().ContainKey("lib");
             var v = LastCreatedTransport.Parameters.GetParams()["lib"];
-            Regex.Match(v, @"^dotnet-0.8.(\d)$").Success.ShouldBeEquivalentTo(true);
+            Regex.Match(v, @"^dotnet-0.8.(\d+)$").Success.ShouldBeEquivalentTo(true);
         }
 
         public ConnectionParameterSpecs(ITestOutputHelper output) : base(output)


### PR DESCRIPTION
This has been fixed on the v1.0 branch, but was not back ported and is causing the CI to fail for v0.8.10. 