### PR TITLE
RSA4 small tweak

### DIFF
--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
@@ -16,7 +16,7 @@ namespace IO.Ably.Tests
     [Trait("requires", "sandbox")]
     public class AuthSandboxSpecs : SandboxSpecs
     {
-        private string _invalidAuthUrl = "http://domain-that-goes-nowhere.local:12345/";
+        private string _errorUrl = "https://echo.ably.io/respondwith?status=500";
 
         public AuthSandboxSpecs(AblySandboxFixture fixture, ITestOutputHelper output)
             : base(fixture, output)
@@ -246,7 +246,7 @@ namespace IO.Ably.Tests
             {
                 options.TokenDetails = token;
                 options.LogLevel = LogLevel.Debug;
-                options.AuthUrl = new Uri(_invalidAuthUrl);
+                options.AuthUrl = new Uri(_errorUrl);
                 options.AutoConnect = false;
             });
 
@@ -291,7 +291,7 @@ namespace IO.Ably.Tests
             void AuthUrlOptions(ClientOptions options, TestEnvironmentSettings settings)
             {
                 options.AutoConnect = false;
-                options.AuthUrl = new Uri(_invalidAuthUrl);
+                options.AuthUrl = new Uri(_errorUrl);
                 options.RealtimeRequestTimeout = TimeSpan.FromSeconds(2);
                 options.HttpRequestTimeout = TimeSpan.FromSeconds(2);
             }

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
@@ -30,7 +30,7 @@ namespace IO.Ably.Tests.AuthTests
 
             // create new reset client using the dummyTokenDetails
             var client = GetRestClient(null, opts => { opts.TokenDetails = dummyTokenDetails; });
-            
+
             // get the current token
             var newTokenDetails = client.AblyAuth.CurrentToken;
 
@@ -96,7 +96,7 @@ namespace IO.Ably.Tests.AuthTests
             client.AblyAuth.CurrentTokenParams.ShouldBeEquivalentTo(tokenParams);
             data.Ttl.Should().Be(TimeSpan.FromMinutes(260));
         }
-        
+
         [Theory]
         [InlineData(Defaults.TokenExpireBufferInSeconds + 1, false)]
         [InlineData(Defaults.TokenExpireBufferInSeconds, true)]


### PR DESCRIPTION
Fixed a white space formatting issue that had crept back in after a rebase and a tiny change to use https://echo.ably.io/respondwith?status=500 in some tests as this fails fast.