### PR TITLE
RTN7c Suspended

### DIFF
--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionSuspendedState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionSuspendedState.cs
@@ -45,6 +45,9 @@ namespace IO.Ably.Transport.States.Connection
 
         public override Task OnAttachToContext()
         {
+            // This is a terminal state. Clear the transport.
+            Context.ClearAckQueueAndFailMessages(ErrorInfo.ReasonSuspended);
+
             if (RetryIn.HasValue)
             {
                 _timer.Start(RetryIn.Value, OnTimeOut);

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/SuspendedStateSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/SuspendedStateSpecs.cs
@@ -97,5 +97,17 @@ namespace IO.Ably.Tests
             // Assert
             _context.StateShouldBe<ConnectionConnectingState>();
         }
+
+        [Fact]
+        [Trait("spec", "RTN7c")]
+        [Trait("sandboxTest", "needed")]
+        public async Task OnAttached_ClearsAckQueue()
+        {
+            // Arrange
+            await _state.OnAttachToContext();
+
+            _context.ClearAckQueueMessagesCalled.Should().BeTrue();
+            _context.ClearAckMessagesError.Should().Be(ErrorInfo.ReasonSuspended);
+        }
     }
 }


### PR DESCRIPTION
```(RTN7c) If a connection enters the SUSPENDED, CLOSED or FAILED state, or if the connection state is lost, and an ACK or NACK has not yet been received for a message, the client should consider the delivery of those messages as failed		```

This was a small change as RTN7c was already implemented for [CLOSED](
https://github.com/ably/ably-dotnet/blob/29c014a7d89e4627f1c288ec1f11b0001cbbeb7b/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/ClosedStateSpecs.cs#L90) and [FAILED](
https://github.com/ably/ably-dotnet/blob/29c014a7d89e4627f1c288ec1f11b0001cbbeb7b/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/FailedStateSpecs.cs#L109) but not SUSPENDED
