### PR TITLE
RTN22 and RTN22a

### DIFF
--- a/src/IO.Ably.Shared/Transport/ConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionManager.cs
@@ -282,7 +282,7 @@ namespace IO.Ably.Transport
             {
                 if (ShouldWeRenewToken(error))
                 {
-                    await RetryAuthentication();
+                    await RetryAuthentication(updateState: true);
                 }
                 else
                 {
@@ -295,11 +295,19 @@ namespace IO.Ably.Transport
             return false;
         }
 
-        public async Task RetryAuthentication()
+        public async Task RetryAuthentication(bool updateState = true)
         {
             ClearTokenAndRecordRetry();
-            await SetState(new ConnectionDisconnectedState(this, Logger), skipAttach: ConnectionState == Realtime.ConnectionState.Connecting);
-            await SetState(new ConnectionConnectingState(this, Logger));
+            if (updateState)
+            {
+                await SetState(new ConnectionDisconnectedState(this, Logger),
+                    skipAttach: ConnectionState == Realtime.ConnectionState.Connecting);
+                await SetState(new ConnectionConnectingState(this, Logger));
+            }
+            else
+            {
+                await RestClient.AblyAuth.AuthorizeAsync();
+            }
         }
 
         public void CloseConnection()

--- a/src/IO.Ably.Shared/Transport/IConnectionContext.cs
+++ b/src/IO.Ably.Shared/Transport/IConnectionContext.cs
@@ -37,7 +37,7 @@ namespace IO.Ably.Transport
 
         Task<bool> RetryBecauseOfTokenError(ErrorInfo error);
 
-        Task RetryAuthentication();
+        Task RetryAuthentication(bool updateState = true);
 
         void HandleConnectingFailure(ErrorInfo error, Exception ex);
 

--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionConnectedState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionConnectedState.cs
@@ -33,7 +33,7 @@ namespace IO.Ably.Transport.States.Connection
             switch (message.Action)
             {
                 case ProtocolMessage.MessageAction.Auth:
-                    await Context.RetryAuthentication();
+                    Context.RetryAuthentication(updateState: false);
                     return true;
                 case ProtocolMessage.MessageAction.Connected:
                     await Context.SetState(new ConnectionConnectedState(Context, new ConnectionInfo(message), message.Error, Logger) { IsUpdate = true });

--- a/src/IO.Ably.Tests.Shared/Infrastructure/FakeConnectionContext.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/FakeConnectionContext.cs
@@ -147,7 +147,7 @@ namespace IO.Ably.Tests
             return RetryFunc(error);
         }
 
-        public Task RetryAuthentication()
+        public Task RetryAuthentication(bool updateState = true)
         {
             throw new NotImplementedException();
         }

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -985,12 +985,8 @@ namespace IO.Ably.Tests.Realtime
         [Theory]
         [ProtocolData]
         [Trait("spec", "RTN22")]
-        public async Task WhenFakeAuthMessageReceived_ShouldAttemptTokenRenewal(Protocol protocol)
+        public async Task WhenAuthMessageReceived_ShouldAttemptTokenRenewal(Protocol protocol)
         {
-            var authClient = await GetRestClient(protocol);
-            var almostExpiredToken = await authClient.AblyAuth.RequestTokenAsync(new TokenParams { ClientId = "123", Ttl = TimeSpan.FromMilliseconds(35) });
-
-            var reconnectAwaiter = new TaskCompletionAwaiter();
             var client = await GetRealtimeClient(protocol, (options, settings) =>
             {
                 options.UseTokenAuth = true;
@@ -1001,55 +997,10 @@ namespace IO.Ably.Tests.Realtime
             var initialToken = client.RestClient.AblyAuth.CurrentToken;
             var initialClientId = client.ClientId;
 
-            client.Connection.Once(ConnectionEvent.Disconnected, state2 =>
-            {
-                client.Connection.Once(ConnectionEvent.Connected, state3 =>
-                {
-                    reconnectAwaiter.SetCompleted();
-                });
-            });
-
             await client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Auth));
-            var didReconect = await reconnectAwaiter.Task;
-            didReconect.Should().BeTrue();
-            client.RestClient.AblyAuth.CurrentToken.Should().NotBe(initialToken);
-            client.ClientId.Should().Be(initialClientId);
-            client.Close();
-        }
 
-        [Theory]
-        [ProtocolData]
-        [Trait("spec", "RTN22")]
-        public async Task WhenAuthMessageReceived_ShouldAttemptTokenRenewal(Protocol protocol)
-        {
-            var authClient = await GetRestClient(protocol);
+            await Task.Delay(1000);
 
-            var reconnectAwaiter = new TaskCompletionAwaiter(60000);
-            var client = await GetRealtimeClient(protocol, (options, settings) =>
-            {
-                options.AuthCallback = tokenParams =>
-                {
-                    var results = authClient.AblyAuth.RequestToken(new TokenParams { ClientId = "RTN22", Ttl = TimeSpan.FromSeconds(35) });
-                    return Task.FromResult<object>(results);
-                };
-                options.ClientId = "RTN22";
-            });
-
-            await client.WaitForState(ConnectionState.Connected);
-
-            var initialToken = client.RestClient.AblyAuth.CurrentToken;
-            var initialClientId = client.ClientId;
-
-            client.Connection.Once(ConnectionEvent.Disconnected, state2 =>
-            {
-                client.Connection.Once(ConnectionEvent.Connected, state3 =>
-                {
-                    reconnectAwaiter.SetCompleted();
-                });
-            });
-
-            var didReconect = await reconnectAwaiter.Task;
-            didReconect.Should().BeTrue();
             client.RestClient.AblyAuth.CurrentToken.Should().NotBe(initialToken);
             client.ClientId.Should().Be(initialClientId);
             client.Close();


### PR DESCRIPTION
This PR covers RTN22 and RTN22a

`(RTN22) Ably can request that a connected client re-authenticates by sending the client an AUTH ProtocolMessage. The client must then immediately start a new authentication process as described in RTC8`

`(RTN22a) Ably reserves the right to forcibly disconnect a client that does not re-authenticate within an acceptable period of time, or at any time the token is deemed no longer valid. A client is forcibly disconnected following a DISCONNECTED message containing an error code in the range 40140 <= code < 40150. This will in effect force the client to re-authenticate and resume the connection immediately, see RTN15h`

As part of this work I have extracted `ConnectionInfo` and `IConnectionContext` from the `IConnectionManager.cs` file into discrete files. This is as per the style guide.
