### PR TITLE
RTN24, RTN21 and partial RTN4h

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Connection.cs
+++ b/src/IO.Ably.Shared/Realtime/Connection.cs
@@ -195,7 +195,7 @@ namespace IO.Ably.Realtime
 
         internal void UpdateState(ConnectionStateBase state)
         {
-            if (state.State == State)
+            if (!state.IsUpdate && state.State == State)
             {
                 return;
             }

--- a/src/IO.Ably.Shared/Transport/ConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionManager.cs
@@ -116,30 +116,35 @@ namespace IO.Ably.Transport
                 {
                     lock (_stateSyncLock)
                     {
-                        if (State.State == newState.State)
+                        if (!newState.IsUpdate)
                         {
-                            if (Logger.IsDebug)
+                            if (State.State == newState.State)
                             {
-                                Logger.Debug($"xx State is already {State.State}. Skipping SetState action.");
+                                if (Logger.IsDebug)
+                                {
+                                    Logger.Debug($"xx State is already {State.State}. Skipping SetState action.");
+                                }
+
+                                return;
                             }
 
-                            return;
+                            AttemptsInfo.UpdateAttemptState(newState);
+                            // Abort any timers on the old state
+                            State.AbortTimer();
                         }
 
-                        // Abort any timers on the old state
-                        State.AbortTimer();
                         if (Logger.IsDebug)
                         {
                             Logger.Debug($"xx {newState.State}: BeforeTransition");
                         }
 
                         newState.BeforeTransition();
+
                         if (Logger.IsDebug)
                         {
                             Logger.Debug($"xx {newState.State}: BeforeTransition end");
                         }
 
-                        AttemptsInfo.UpdateAttemptState(newState);
                         Connection.UpdateState(newState);
                     }
 

--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionConnectedState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionConnectedState.cs
@@ -35,6 +35,9 @@ namespace IO.Ably.Transport.States.Connection
                 case ProtocolMessage.MessageAction.Auth:
                     await Context.RetryAuthentication();
                     return true;
+                case ProtocolMessage.MessageAction.Connected:
+                    await Context.SetState(new ConnectionConnectedState(Context, new ConnectionInfo(message), message.Error, Logger) { IsUpdate = true });
+                    return true;
                 case ProtocolMessage.MessageAction.Close:
                     await Context.SetState(new ConnectionClosedState(Context, message.Error, Logger));
                     return true;

--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionState.cs
@@ -31,6 +31,8 @@ namespace IO.Ably.Transport.States.Connection
 
         public virtual bool CanSend => false;
 
+        public virtual bool IsUpdate { get; protected set; }
+
         public virtual void Connect()
         {
         }

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -841,6 +841,7 @@ namespace IO.Ably.Tests.Realtime
                     // should have both previous and current attributes set to CONNECTED
                     state.Current.Should().Be(ConnectionState.Connected);
                     state.Previous.Should().Be(ConnectionState.Connected);
+                    state.Reason.Message = "fake-error";
                     updateAwaiter.SetCompleted();
                 }
                 else
@@ -856,7 +857,8 @@ namespace IO.Ably.Tests.Realtime
                     ConnectionKey = "key",
                     ClientId = "RTN21",
                     ConnectionStateTtl = TimeSpan.MaxValue
-                }
+                },
+                Error = new ErrorInfo("fake-error")
             });
 
             var didUpdate = await updateAwaiter.Task;

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -839,11 +839,14 @@ namespace IO.Ably.Tests.Realtime
                 // RTN4h - can emit UPDATE event
                 if (state.Event == ConnectionEvent.Update)
                 {
+                    // should have both previous and current attributes set to CONNECTED
+                    state.Current.Should().Be(ConnectionState.Connected);
+                    state.Previous.Should().Be(ConnectionState.Connected);
                     updateAwaiter.SetCompleted();
                 }
                 else
                 {
-                    throw new Exception("Only an UPDATE event should fire, see RTN4h");
+                    throw new Exception($"'{state.Event}' was handled. Only an 'Update' event should have occured");
                 }
             });
 

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -825,7 +825,6 @@ namespace IO.Ably.Tests.Realtime
             var client = await GetRealtimeClient(protocol, (options, settings) =>
             {
                 options.UseTokenAuth = true;
-                options.AutoConnect = true;
             });
 
             await client.WaitForState(ConnectionState.Connected);

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/ConnectedStateSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/ConnectedStateSpecs.cs
@@ -39,7 +39,6 @@ namespace IO.Ably.Tests
         [InlineData(ProtocolMessage.MessageAction.Attached)]
         [InlineData(ProtocolMessage.MessageAction.Closed)]
         [InlineData(ProtocolMessage.MessageAction.Connect)]
-        [InlineData(ProtocolMessage.MessageAction.Connected)]
         [InlineData(ProtocolMessage.MessageAction.Detach)]
         [InlineData(ProtocolMessage.MessageAction.Detached)]
         [InlineData(ProtocolMessage.MessageAction.Disconnect)]


### PR DESCRIPTION

`(RTN24) A connected client may receive a CONNECTED ProtocolMessage from Ably at any point (though is typically triggered by a reauth, see RTC8a). The connectionDetails in the ProtocolMessage must override any stored details, see RTN21. The Connection should emit an UPDATE event with a ChannelStateChange object, which should have both previous and current attributes set to CONNECTED, and the reason attribute set to to the error member of the CONNECTED ProtocolMessage (if any). (Note that UPDATE should be the only event emitted: in particular, the library must not emit an CONNECTED event if the client was already connected, see RTN4h).	`		

`(RTN21) If the CONNECTED ProtocolMessage contains a connectionDetails property, the attributes within ConnectionDetails will be used as the defaults for this client library, overriding any configured options at the time the CONNECTED ProtocolMessage is received`

`(RTN4h) It can emit an UPDATE event (this is the only ConnectionEvent which is not a ConnectionState). This is used for changes to connection conditions for which the ConnectionState (e.g. CONNECTED) does not change. (The library must never emit a ConnectionState event for a state equal to the previous state).`

The final part of RTN4h `The library must never emit a ConnectionState event for a state equal to the previous state` is not covered by these tests. 

There is a [pre-existing test for RTN8b](https://github.com/ably/ably-dotnet/blob/e76f6c94df952171a38bc84a2f5cfd1ac1a42e6f/src/IO.Ably.Tests/Realtime/ConnectionStateTests/ConnectedStateSpecs.cs#L119) that additionally covers part of RTN21 at a lower level.