### PR TITLE
RTN11b, RTN11c, RTN11d

### DIFF
--- a/src/IO.Ably.Shared/AblyAuthUpdatedEventArgs.cs
+++ b/src/IO.Ably.Shared/AblyAuthUpdatedEventArgs.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace IO.Ably
+{
+    internal class AblyAuthUpdatedEventArgs : EventArgs
+    {
+        public TokenDetails Token { get; set; }
+
+        /// <summary>
+        /// Gets the TaskCompletionSource for this event
+        /// A handler should Complete this task to allow the
+        /// AuthorizeAsync call to complete
+        /// </summary>
+        internal TaskCompletionSource<bool> CompletedTask { get; }
+
+        public AblyAuthUpdatedEventArgs()
+        {
+            CompletedTask = new TaskCompletionSource<bool>();
+        }
+
+        public AblyAuthUpdatedEventArgs(TokenDetails token) : this()
+        {
+            Token = token;
+        }
+
+        public void CompleteAuthorization(bool success)
+        {
+            CompletedTask.TrySetResult(success);
+        }
+    }
+}

--- a/src/IO.Ably.Shared/AblyRealtime.cs
+++ b/src/IO.Ably.Shared/AblyRealtime.cs
@@ -34,6 +34,8 @@ namespace IO.Ably
             Connection = new Connection(this, options.NowFunc, options.Logger);
             Connection.Initialise();
 
+            RestClient.AblyAuth.AuthUpdated += Connection.ConnectionManager.OnAuthUpdated;
+
             if (options.AutoConnect)
             {
                 Connect();

--- a/src/IO.Ably.Shared/AblyRest.cs
+++ b/src/IO.Ably.Shared/AblyRest.cs
@@ -136,7 +136,7 @@ namespace IO.Ably
 
                     try
                     {
-                        await AblyAuth.AuthorizeAsync(null, new AuthOptions(), force: true);
+                        await AblyAuth.AuthorizeAsync(null, new AuthOptions());
                         await AblyAuth.AddAuthHeader(request);
                         return await ExecuteHttpRequest(request);
                     }

--- a/src/IO.Ably.Shared/IO.Ably.Shared.projitems
+++ b/src/IO.Ably.Shared/IO.Ably.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)AblyAuth.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AblyAuthUpdatedEventArgs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AblyException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AblyRealtime.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AblyRest.cs" />

--- a/src/IO.Ably.Shared/Realtime/ChannelMessageProcessor.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelMessageProcessor.cs
@@ -41,11 +41,7 @@ namespace IO.Ably.Realtime
             switch (protocolMessage.Action)
             {
                 case ProtocolMessage.MessageAction.Error:
-                    if (protocolMessage.Channel.IsNotEmpty())
-                    {
-                        channel.SetChannelState(ChannelState.Failed, protocolMessage);
-                    }
-
+                    channel.SetChannelState(ChannelState.Failed, protocolMessage);
                     break;
                 case ProtocolMessage.MessageAction.Attach:
                 case ProtocolMessage.MessageAction.Attached:

--- a/src/IO.Ably.Shared/Realtime/Connection.cs
+++ b/src/IO.Ably.Shared/Realtime/Connection.cs
@@ -19,6 +19,8 @@ namespace IO.Ably.Realtime
 
     public sealed class Connection : EventEmitter<ConnectionEvent, ConnectionStateChange>, IDisposable
     {
+        internal event EventHandler BeginConnect;
+
         private static readonly ConcurrentBag<WeakReference<Action<NetworkState>>> OsEventSubscribers =
             new ConcurrentBag<WeakReference<Action<NetworkState>>>();
 
@@ -240,6 +242,11 @@ namespace IO.Ably.Realtime
             {
                 Serial = message.ConnectionSerial.Value;
             }
+        }
+
+        internal void OnBeginConnect()
+        {
+            BeginConnect?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -121,6 +121,10 @@ namespace IO.Ably.Realtime
             switch (connectionStateChange.Current)
             {
                 case ConnectionState.Connecting:
+                    if (connectionStateChange.Previous == ConnectionState.Failed)
+                    {
+                        SetChannelState(ChannelState.Initialized);
+                    }
                     break;
                 case ConnectionState.Disconnected:
                     if (State == ChannelState.Attaching)

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -93,7 +93,27 @@ namespace IO.Ably.Realtime
 
         private void SubscribeToConnectionEvents()
         {
+            ConnectionManager.Connection.BeginConnect += ConnectionOnBeginConnect;
             ConnectionManager.Connection.InternalStateChanged += InternalOnInternalStateChanged;
+        }
+
+        private void UnSubscribeFromConnectionEvents()
+        {
+            ConnectionManager.Connection.BeginConnect -= ConnectionOnBeginConnect;
+            ConnectionManager.Connection.InternalStateChanged -= InternalOnInternalStateChanged;
+        }
+
+        private void ConnectionOnBeginConnect(object sender, EventArgs e)
+        {
+            switch (ConnectionState)
+            {
+                case ConnectionState.Failed:
+                    /* (RTN11d)
+                     * If the [Connection] state is FAILED,
+                     * transitions all the channels to INITIALIZED */
+                    SetChannelState(ChannelState.Initialized);
+                    break;
+            }
         }
 
         internal void InternalOnInternalStateChanged(object sender, ConnectionStateChange connectionStateChange)
@@ -101,11 +121,6 @@ namespace IO.Ably.Realtime
             switch (connectionStateChange.Current)
             {
                 case ConnectionState.Connecting:
-                    if (connectionStateChange.Previous == ConnectionState.Failed)
-                    {
-                        SetChannelState(ChannelState.Initialized);
-                    }
-
                     break;
                 case ConnectionState.Disconnected:
                     if (State == ChannelState.Attaching)
@@ -375,6 +390,7 @@ namespace IO.Ably.Realtime
             DetachedAwaiter?.Dispose();
             _handlers.RemoveAll();
             Presence?.Dispose();
+            UnSubscribeFromConnectionEvents();
         }
 
         internal void AddUntilAttachParameter(HistoryRequestParams query)
@@ -502,7 +518,7 @@ namespace IO.Ably.Realtime
                             /* RTP1 If [HAS_PRESENCE] flag is 0 or there is no flags field,
                              * the presence map should be considered in sync immediately
                              * with no members present on the channel */
-                            Presence.SkipSync();
+                    Presence.SkipSync();
                         }
 
                         AttachedSerial = protocolMessage.ChannelSerial;

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -100,7 +100,13 @@ namespace IO.Ably.Realtime
         {
             switch (connectionStateChange.Current)
             {
-                // case ConnectionState.Connected:
+                case ConnectionState.Connecting:
+                    if (connectionStateChange.Previous == ConnectionState.Failed)
+                    {
+                        SetChannelState(ChannelState.Initialized);
+                    }
+
+                    break;
                 case ConnectionState.Disconnected:
                     if (State == ChannelState.Attaching)
                     {

--- a/src/IO.Ably.Shared/Transport/ConnectionInfo.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionInfo.cs
@@ -27,7 +27,8 @@ namespace IO.Ably.Transport
 
             if (message.Action != ProtocolMessage.MessageAction.Connected)
             {
-                throw new InvalidOperationException("Can only create Connection info from Connected message. Current passed: " + message.Action);
+                throw new InvalidOperationException(
+                    $"A ConnectionInfo only be created from a Connected action protocol message. A value with action '{message.Action}' was passed" );
             }
 
             ConnectionId = message.ConnectionId;

--- a/src/IO.Ably.Shared/Transport/ConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionManager.cs
@@ -129,7 +129,6 @@ namespace IO.Ably.Transport
                             }
 
                             AttemptsInfo.UpdateAttemptState(newState);
-                            // Abort any timers on the old state
                             State.AbortTimer();
                         }
 

--- a/src/IO.Ably.Shared/Transport/ConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionManager.cs
@@ -98,6 +98,7 @@ namespace IO.Ably.Transport
 
         public void Connect()
         {
+            Connection.OnBeginConnect();
             State.Connect();
         }
 

--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionClosingState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionClosingState.cs
@@ -16,6 +16,7 @@ namespace IO.Ably.Transport.States.Connection
         /// </summary>
         private bool _inConnectTransition = false;
 
+
         public ConnectionClosingState(IConnectionContext context, ILogger logger)
             : this(context, null, new CountdownTimer("Closing state timer", logger), logger)
         {

--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionClosingState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionClosingState.cs
@@ -10,9 +10,11 @@ namespace IO.Ably.Transport.States.Connection
         private const int CloseTimeout = 1000;
         private readonly ICountdownTimer _timer;
 
-        // used to mitigate a potential race condition where by OnAttachToContext()
-        // can be called after Connect() is called but before the new state is attached
-        private bool _inTransition = false;
+        /// <summary>
+        /// used to mitigate a potential race condition where by OnAttachToContext()
+        /// can be called after Connect() is called but before the new state is attached
+        /// </summary>
+        private bool _inConnectTransition = false;
 
         public ConnectionClosingState(IConnectionContext context, ILogger logger)
             : this(context, null, new CountdownTimer("Closing state timer", logger), logger)
@@ -53,7 +55,7 @@ namespace IO.Ably.Transport.States.Connection
 
         public override Task OnAttachToContext()
         {
-            if (_inTransition)
+            if (_inConnectTransition)
             {
                 return TaskConstants.BooleanTrue;
             }
@@ -85,7 +87,7 @@ namespace IO.Ably.Transport.States.Connection
 
         public override void Connect()
         {
-            _inTransition = true;
+            _inConnectTransition = true;
             _timer.Abort();
             Context.Connection.Key = string.Empty;
             Context.SetState(new ConnectionConnectingState(Context, Logger));

--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionClosingState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionClosingState.cs
@@ -10,6 +10,10 @@ namespace IO.Ably.Transport.States.Connection
         private const int CloseTimeout = 1000;
         private readonly ICountdownTimer _timer;
 
+        // used to mitigate a potential race condition where by OnAttachToContext()
+        // can be called after Connect() is called but before the new state is attached
+        private bool _inTransition = false;
+
         public ConnectionClosingState(IConnectionContext context, ILogger logger)
             : this(context, null, new CountdownTimer("Closing state timer", logger), logger)
         {
@@ -29,22 +33,14 @@ namespace IO.Ably.Transport.States.Connection
             switch (message.Action)
             {
                 case ProtocolMessage.MessageAction.Closed:
-                    {
-                        TransitionState(new ConnectionClosedState(Context, Logger));
-                        return TaskConstants.BooleanTrue;
-                    }
-
+                    TransitionState(new ConnectionClosedState(Context, Logger));
+                    return TaskConstants.BooleanTrue;
                 case ProtocolMessage.MessageAction.Disconnected:
-                    {
-                        TransitionState(new ConnectionDisconnectedState(Context, message.Error, Logger));
-                        return TaskConstants.BooleanTrue;
-                    }
-
+                    TransitionState(new ConnectionDisconnectedState(Context, message.Error, Logger));
+                    return TaskConstants.BooleanTrue;
                 case ProtocolMessage.MessageAction.Error:
-                    {
-                        TransitionState(new ConnectionFailedState(Context, message.Error, Logger));
-                        return TaskConstants.BooleanTrue;
-                    }
+                    TransitionState(new ConnectionFailedState(Context, message.Error, Logger));
+                    return TaskConstants.BooleanTrue;
             }
 
             return TaskConstants.BooleanFalse;
@@ -57,6 +53,11 @@ namespace IO.Ably.Transport.States.Connection
 
         public override Task OnAttachToContext()
         {
+            if (_inTransition)
+            {
+                return TaskConstants.BooleanTrue;
+            }
+
             var transport = Context.Transport;
             if (transport?.State == TransportState.Connected)
             {
@@ -73,14 +74,20 @@ namespace IO.Ably.Transport.States.Connection
 
         private void OnTimeOut()
         {
-            Context.Execute(() =>
-                Context.SetState(new ConnectionClosedState(Context, Logger)));
+            Context.Execute(() => Context.SetState(new ConnectionClosedState(Context, Logger)));
         }
 
         private void TransitionState(ConnectionStateBase newState)
         {
             _timer.Abort();
             Context.SetState(newState);
+        }
+
+        public override void Connect()
+        {
+            _inTransition = true;
+            _timer.Abort();
+            Context.SetState(new ConnectionConnectingState(Context, Logger));
         }
     }
 }

--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionClosingState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionClosingState.cs
@@ -87,6 +87,7 @@ namespace IO.Ably.Transport.States.Connection
         {
             _inTransition = true;
             _timer.Abort();
+            Context.Connection.Key = string.Empty;
             Context.SetState(new ConnectionConnectingState(Context, Logger));
         }
     }

--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionConnectedState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionConnectedState.cs
@@ -56,7 +56,13 @@ namespace IO.Ably.Transport.States.Connection
                     await Context.SetState(new ConnectionDisconnectedState(Context, message.Error, Logger));
                     return true;
                 case ProtocolMessage.MessageAction.Error:
-                    await Context.SetState(new ConnectionFailedState(Context, message.Error, Logger));
+                    // an error message may signify an error state in the connection or in a channel
+                    // Only handle connection errors here.
+                    if (message.Channel.IsEmpty())
+                    {
+                        await Context.SetState(new ConnectionFailedState(Context, message.Error, Logger));
+                    }
+
                     return true;
             }
 

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
@@ -16,62 +16,6 @@ namespace IO.Ably.Tests.AuthTests
             client.AblyAuth.CurrentToken.Should().BeNull();
         }
 
-        /*
-         * (RSA10a) Instructs the library to create a token immediately and ensures Token Auth is used for all future requests.
-         * See RTC8 for re-authentication behaviour when called for a realtime client
-         */
-
-        [Fact]
-        [Trait("spec", "RSA10a")]
-        public async Task Authorize_WithNotExpiredCurrentTokenAndForceFalse_ReturnsCurrentToken()
-        {
-            // create a fake token that has not expired
-            var dummyTokenDetails = new TokenDetails() { Expires = TestHelpers.Now().AddHours(1) };
-
-            // create new reset client using the dummyTokenDetails
-            var client = GetRestClient(null, opts => { opts.TokenDetails = dummyTokenDetails; });
-
-            // get the current token
-            var newTokenDetails = client.AblyAuth.CurrentToken;
-
-            // new token should match the dummy token
-            newTokenDetails.Should().BeSameAs(dummyTokenDetails);
-
-            // authorise again
-            var sameTokenDetails = await client.Auth.AuthorizeAsync();
-
-            // the same token should be returned
-            client.AblyAuth.CurrentToken.Should().BeSameAs(sameTokenDetails);
-            client.AblyAuth.CurrentToken.Should().Be(newTokenDetails);
-        }
-
-        [Fact]
-        [Trait("spec", "RSA10a")]
-        public async Task Authorize_WithNotExpiredCurrentTokenAndForceTrue_ReturnsNewToken()
-        {
-            // create a fake token that has not expired
-            var dummyTokenDetails = new TokenDetails() { Expires = TestHelpers.Now().AddHours(1) };
-
-            // create new reset client using the dummyTokenDetails
-            var client = GetRestClient(null, opts =>
-            {
-                opts.TokenDetails = dummyTokenDetails;
-            });
-
-            // get the current token
-            var currentToken = client.AblyAuth.CurrentToken;
-
-            // new token should match the dummy token
-            currentToken.Should().BeSameAs(dummyTokenDetails);
-
-            // authorise again, this should force a new token
-            var newToken = await client.Auth.AuthorizeAsync();
-
-            // A different token should be returned
-            client.AblyAuth.CurrentToken.Should().Be(currentToken);
-            client.AblyAuth.CurrentToken.Should().BeSameAs(newToken);
-        }
-
         [Fact]
         [Trait("spec", "RSA10a")]
         [Trait("spec", "RSA10f")]
@@ -95,30 +39,6 @@ namespace IO.Ably.Tests.AuthTests
             var data = LastRequest.PostData as TokenRequest;
             client.AblyAuth.CurrentTokenParams.ShouldBeEquivalentTo(tokenParams);
             data.Ttl.Should().Be(TimeSpan.FromMinutes(260));
-        }
-
-        [Theory]
-        [InlineData(Defaults.TokenExpireBufferInSeconds + 1, false)]
-        [InlineData(Defaults.TokenExpireBufferInSeconds, true)]
-        [InlineData(Defaults.TokenExpireBufferInSeconds - 1, true)]
-        [Trait("spec", "RSA10c")]
-        public async Task Authorize_WithTokenExpiringIn15Seconds_RenewsToken(int secondsLeftToExpire, bool shouldRenew)
-        {
-            var client = GetRestClient();
-            var initialToken = new TokenDetails() { Expires = Now.AddSeconds(secondsLeftToExpire) };
-            client.AblyAuth.CurrentToken = initialToken;
-
-            var token = await client.Auth.AuthorizeAsync();
-
-            if (shouldRenew)
-            {
-                Assert.Contains("requestToken", LastRequest.Url);
-                token.Should().NotBeSameAs(initialToken);
-            }
-            else
-            {
-                token.Should().BeSameAs(initialToken);
-            }
         }
 
         [Fact]

--- a/src/IO.Ably.Tests.Shared/IO.Ably.Tests.Shared.projitems
+++ b/src/IO.Ably.Tests.Shared/IO.Ably.Tests.Shared.projitems
@@ -90,6 +90,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Realtime\MockHttpRealtimeSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Realtime\PresenceSandboxSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Realtime\ProtocolMessageSpecs.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Realtime\RealtimeSandboxSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Realtime\RealtimeSpecs.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RestProtocolTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Rest\AblyHttpClientSpecs.cs" />

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -142,7 +142,7 @@ namespace IO.Ably.Tests.Realtime
             await client.WaitForState();
 
             // capture initial values
-            var initialConnection = client.Connection;
+            var initialConnectionId = client.Connection.Id;
             var initialTransport = client.ConnectionManager.Transport;
 
             // The close timeout is 1000ms, so 3000ms is enough time to wait
@@ -158,6 +158,8 @@ namespace IO.Ably.Tests.Realtime
             client.Connect();
             await client.WaitForState(ConnectionState.Connected);
 
+            client.Connection.Id.Should().NotBeNullOrEmpty();
+            client.Connection.Id.Should().NotBe(initialConnectionId);
             client.ConnectionManager.Transport.Should().NotBe(initialTransport);
 
             var didClose = await awaiter.Task;

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -156,7 +156,7 @@ namespace IO.Ably.Tests.Realtime
             await client.WaitForState(ConnectionState.Closing);
 
             client.Connect();
-            await client.WaitForState();
+            await client.WaitForState(ConnectionState.Connected);
 
             client.ConnectionManager.Transport.Should().NotBe(initialTransport);
 
@@ -190,9 +190,6 @@ namespace IO.Ably.Tests.Realtime
         public async Task WithSuspendedConnection_WhenConnectCalled_ImmediatelyReconnect(Protocol protocol)
         {
             var client = await GetRealtimeClient(protocol);
-            await client.WaitForState();
-            await client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Disconnected));
-            await client.WaitForState(ConnectionState.Disconnected);
             await client.ConnectionManager.SetState(new ConnectionSuspendedState(client.ConnectionManager, new ErrorInfo("force suspended"), client.Logger));
             await client.WaitForState(ConnectionState.Suspended);
             var s = new Stopwatch();

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -138,10 +138,10 @@ namespace IO.Ably.Tests.Realtime
                 opts.DisconnectedRetryTimeout = TimeSpan.MaxValue;
             });
 
-            // Start collecting events after the connection is open
             await client.WaitForState();
 
             // capture initial values
+            var initialConnection = client.Connection;
             var initialConnectionId = client.Connection.Id;
             var initialTransport = client.ConnectionManager.Transport;
 
@@ -162,6 +162,8 @@ namespace IO.Ably.Tests.Realtime
             client.Connection.Id.Should().NotBe(initialConnectionId);
             client.ConnectionManager.Transport.Should().NotBe(initialTransport);
 
+            // because a new transport is created the CLOSED message for the
+            // old connection never arrives.
             var didClose = await awaiter.Task;
             didClose.Should().BeFalse();
         }

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -213,7 +213,7 @@ namespace IO.Ably.Tests.Realtime
             var client = await GetRealtimeClient(protocol);
             await client.WaitForState(ConnectionState.Connected);
 
-            var chan1 = client.Channels.Get("RTN11c".AddRandomSuffix());
+            var chan1 = client.Channels.Get("RTN11d".AddRandomSuffix());
             await chan1.AttachAsync();
 
             // show that the channel is not in the initialized state already

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/ClosingStateSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/ClosingStateSpecs.cs
@@ -18,13 +18,6 @@ namespace IO.Ably.Tests
         }
 
         [Fact]
-        public void OnConnectCalled_SHouldDoNothing()
-        {
-            // Act
-            _state.Connect();
-        }
-
-        [Fact]
         public void CloseCalled_ShouldDoNothing()
         {
             // Act

--- a/src/IO.Ably.Tests.Shared/Realtime/RealtimeSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/RealtimeSandboxSpecs.cs
@@ -1,0 +1,255 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IO.Ably.Realtime;
+using IO.Ably.Tests.Infrastructure;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace IO.Ably.Tests.Realtime
+{
+    [Trait("requires", "sandbox")]
+    public class RealtimeSandboxSpecs : SandboxSpecs
+    {
+        public RealtimeSandboxSpecs(AblySandboxFixture fixture, ITestOutputHelper output)
+            : base(fixture, output)
+        {
+        }
+
+        [Theory]
+        [ProtocolData]
+        [Trait("spec", "RTC8")]
+        public async Task WithNotConnectedClient_AuthorizeObtainsNewTokenAndConnects(Protocol protocol)
+        {
+            // TODO: test against all non CONNECTED states
+            var client = await GetRealtimeClient(protocol, (opts, _) =>
+            {
+                opts.AutoConnect = false;
+                opts.ClientId = "RTC8";
+            });
+
+            // show that the connection is not connected
+            client.Connection.State.Should().Be(ConnectionState.Initialized);
+
+            var tokenDetails = await client.Auth.AuthorizeAsync();
+            tokenDetails.ClientId.Should().Be("RTC8");
+
+            await client.WaitForState(ConnectionState.Connecting);
+            await client.WaitForState(ConnectionState.Connected);
+
+            client.Connection.State.Should().Be(ConnectionState.Connected);
+        }
+
+        [Theory]
+        [ProtocolData]
+        [Trait("spec", "RTC8")]
+        [Trait("spec", "RTC8a")]
+        [Trait("spec", "RTC8a1")]
+        [Trait("spec", "RTC8a2")]
+        [Trait("spec", "RTC8a3")]
+        public async Task WithConnectedClient_AuthorizeObtainsNewTokenAndUpgradesConnection_AndShouldEmitUpdate(
+            Protocol protocol)
+        {
+            var validClientId1 = "RTC8";
+            var invalidClientId = "RTC8-incompatible-clientId";
+
+            // For a realtime client, Auth#authorize instructs the library to obtain
+            // a token using the provided tokenParams and authOptions and upgrade
+            // the current connection to use that token
+            var client = await GetRealtimeClient(protocol, (opts, _) => { opts.ClientId = validClientId1; });
+
+            var awaiter = new TaskCompletionAwaiter();
+            client.Connection.On(ConnectionEvent.Update, args => { awaiter.SetCompleted(); });
+            await client.WaitForState(ConnectionState.Connected);
+
+            var tokenDetails = await client.Auth.AuthorizeAsync(new TokenParams {ClientId = validClientId1});
+            tokenDetails.ClientId.Should().Be(validClientId1);
+            client.Connection.State.Should().Be(ConnectionState.Connected);
+            client.RestClient.AblyAuth.CurrentToken.Should().Be(tokenDetails);
+            var didUpdate = await awaiter.Task;
+            client.Connection.State.Should().Be(ConnectionState.Connected);
+            didUpdate.Should().BeTrue(
+                "the AUTH message should trigger a CONNECTED response from the server that causes an UPDATE to be emitted.");
+
+            client.Connection.On(args =>
+            {
+                if (args.Current != ConnectionState.Failed)
+                {
+                    Assert.True(false, $"unexpected state '{args.Current}'");
+                }
+            });
+
+            // AuthorizeAsync will not return until either a CONNECTED or ERROR response
+            // (or timeout) is seen from Ably, so we do not need to use WaitForState() here
+            await client.Auth.AuthorizeAsync(new TokenParams {ClientId = invalidClientId});
+            client.Connection.State.Should().Be(ConnectionState.Failed);
+            client.Close();
+
+            // if not currently connected, to connects with the token.
+            var client2 = await GetRealtimeClient(protocol, (opts, _) =>
+            {
+                opts.AutoConnect = false;
+                opts.TokenDetails = tokenDetails;
+            });
+            await client2.Auth.AuthorizeAsync();
+            await client2.WaitForState(ConnectionState.Connected);
+            client2.Connection.State.Should().Be(ConnectionState.Connected);
+            client2.Close();
+
+            // internally AblyAuth.AuthorizeCompleted is used to indicate when an Authorize call is finished
+            // AuthorizeCompleted should timeout if no valid response (CONNECTED or ERROR) is received from Ably
+            var auth = new AblyAuth(client.Options, client.RestClient);
+            auth.Options.RealtimeRequestTimeout = TimeSpan.FromSeconds(1);
+            var authEventArgs = new AblyAuthUpdatedEventArgs();
+            try
+            {
+                var result = await auth.AuthorizeCompleted(authEventArgs);
+                result.Should().BeFalse();
+                throw new Exception("AuthorizeCompleted did not raise an exception.");
+            }
+            catch (AblyException e)
+            {
+                e.Should().BeOfType<AblyException>();
+                e.ErrorInfo.Code.Should().Be(40140);
+            }
+        }
+
+        [Theory]
+        [ProtocolData]
+        [Trait("spec", "RTC8a1")]
+        public async Task WithConnectedClient_WhenUpgradingCapabilities_ConnectionShouldNotBeImpaired(Protocol protocol)
+        {
+            var clientId = "RTC8a1".AddRandomSuffix();
+            var capability = new Capability();
+            capability.AddResource("foo").AllowPublish();
+
+            var restClient = await GetRestClient(protocol);
+            var tokenDetails = await restClient.Auth.RequestTokenAsync(new TokenParams
+            {
+                ClientId = clientId,
+                Capability = capability
+            });
+
+            var realtime = await GetRealtimeClient(protocol, (opts, _) =>
+            {
+                opts.Token = tokenDetails.Token;
+            });
+            await realtime.WaitForState();
+
+            // upgrade of capabilities without any loss of continuity or connectivity
+            realtime.Connection.Once(ConnectionEvent.Disconnected, change => throw new Exception("should not disconnect"));
+
+            var fooChannel = realtime.Channels.Get("foo");
+            var barChannel = realtime.Channels.Get("bar");
+
+            var fooSuccessAWaiter = new TaskCompletionAwaiter(5000);
+            fooChannel.Publish("test", "should-not-fail", (b, info) =>
+            {
+                // foo should succeed
+                b.Should().BeTrue();
+                info.Should().BeNull();
+                fooSuccessAWaiter.SetCompleted();
+            });
+            Assert.True(await fooSuccessAWaiter.Task);
+
+            var barFailAwaiter = new TaskCompletionAwaiter(5000);
+            barChannel.Publish("test", "should-fail", (b, info) =>
+            {
+                // bar should fail
+                b.Should().BeFalse();
+                info.Code.Should().Be(40160);
+                barFailAwaiter.SetCompleted();
+            });
+            Assert.True(await barFailAwaiter.Task);
+
+            // upgrade bar
+            capability = new Capability();
+            capability.AddResource("bar").AllowPublish();
+            await realtime.Auth.AuthorizeAsync(new TokenParams
+            {
+                Capability = capability,
+                ClientId = clientId
+            });
+            realtime.Connection.State.Should().Be(ConnectionState.Connected);
+            var barSuccessAwaiter = new TaskCompletionAwaiter(5000);
+            barChannel.Attach((b2, info2) =>
+            {
+                b2.Should().BeTrue();
+                barChannel.Publish("test", "should-succeed", (b, info) =>
+                {
+                    b.Should().BeTrue();
+                    info.Should().BeNull();
+                    barSuccessAwaiter.SetCompleted();
+                });
+            });
+
+            Assert.True(await barSuccessAwaiter.Task);
+        }
+
+        [Theory]
+        [ProtocolData]
+        [Trait("spec", "RTC8a1")]
+        public async Task WithConnectedClient_WhenDowngradingCapabilities_ChannelShouldBecomeFailed(Protocol protocol)
+        {
+            var clientId = "RTC8a1-downgrade".AddRandomSuffix();
+            var channelName = "RTC8a1-downgrade-channel".AddRandomSuffix();
+            var wrongChannelName = "wrong".AddRandomSuffix();
+            var capability = new Capability();
+            capability.AddResource(channelName).AllowAll();
+
+            var restClient = await GetRestClient(protocol);
+            var tokenDetails = await restClient.Auth.RequestTokenAsync(new TokenParams
+            {
+                ClientId = clientId,
+                Capability = capability
+            });
+
+            var realtime = await GetRealtimeClient(protocol, (opts, _) =>
+            {
+                opts.Token = tokenDetails.Token;
+            });
+            await realtime.WaitForState(ConnectionState.Connected);
+
+            realtime.Connection.Once(ConnectionEvent.Disconnected, change => throw new Exception("Should not require a disconnect"));
+            var channel = realtime.Channels.Get(channelName);
+            var awaiter1 = new TaskCompletionAwaiter(10000);
+            channel.Publish("test", "should-not-fail", (b, info) =>
+            {
+                b.Should().BeTrue();
+                info.Should().BeNull();
+                awaiter1.SetCompleted();
+            });
+            Assert.True(await awaiter1.Task);
+            channel.State.Should().Be(ChannelState.Attached);
+
+            // channel should fail fast, allow 2000ms
+            var channelFailedAwaiter = new TaskCompletionAwaiter(2000);
+            channel.Attach(async (success, info2) =>
+            {
+                success.Should().BeTrue();
+
+                // downgrade
+                capability = new Capability();
+                capability.AddResource(wrongChannelName).AllowSubscribe();
+                var newToken = await realtime.Auth.AuthorizeAsync(new TokenParams
+                {
+                    Capability = capability,
+                    ClientId = clientId
+                });
+                newToken.Should().NotBeNull();
+                channel.Once(ChannelState.Failed, state =>
+                {
+                    state.Error.Code.Should().Be(40160);
+                    state.Error.Message.Should().Contain("Channel denied access");
+                    channelFailedAwaiter.SetCompleted();
+                });
+            });
+
+            var channelFailed = await channelFailedAwaiter.Task;
+            channelFailed.Should().BeTrue("channel should have failed");
+        }
+    }
+}


### PR DESCRIPTION
Changes and tests to cover RTNb, c & d

`(RTN11) Connection#connect function:`

`(RTN11b) If the state is CLOSING, the client should make a new connection with a new transport instance and remove all references to the old one. In particular, it should make sure that, when the CLOSED ProtocolMessage arrives for the old connection, it doesn’t affect the new one.`

`(RTN11c) If the state is DISCONNECTED or SUSPENDED, aborts the retry process described in RTN14d and RTN14e and immediately tries to reconnect.`

`(RTN11d) If the state is FAILED, transitions all the channels to INITIALIZED, sets their errorReason to null, and sets the connection’s errorReason to null.`

(RTN11a is omitted as it has a [pre-existing test](https://github.com/ably/ably-dotnet/blob/5816d286d203eb6a248153b42b0e6c15668586e6/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs#L37))