### PR TITLE
RTN12d

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -242,6 +242,48 @@ namespace IO.Ably.Tests.Realtime
 
         [Theory]
         [ProtocolData]
+        [Trait("spec", "RTN12d")]
+        public async Task WithDisconnectedOrSuspendedConnection_WhenCloseCalled_AbortRetryAndCloseImmediately(Protocol protocol)
+        {
+            async Task AssertsClosesAndDoesNotReconnect(AblyRealtime realtime, ConnectionState state)
+            {
+                await realtime.WaitForState(state);
+
+                var reconnectAwaiter = new TaskCompletionAwaiter(3000);
+                realtime.Connection.On(ConnectionEvent.Connected, args =>
+                {
+                    reconnectAwaiter.SetCompleted();
+                });
+                realtime.Close();
+
+                await realtime.WaitForState(ConnectionState.Closed);
+                realtime.Connection.State.Should().Be(ConnectionState.Closed);
+
+                var didReconnect = await reconnectAwaiter.Task;
+                didReconnect.Should().BeFalse();
+            }
+
+            // setup a new client and put into a DISCONNECTED state
+            var client = await GetRealtimeClient(protocol, (opts, _) =>
+            {
+                opts.DisconnectedRetryTimeout = TimeSpan.FromSeconds(1);
+            });
+
+            await client.ConnectionManager.SetState(new ConnectionDisconnectedState(client.ConnectionManager, new ErrorInfo("force disconnect"), client.Logger));
+            await AssertsClosesAndDoesNotReconnect(client, ConnectionState.Disconnected);
+
+            // reinitialize the client and put into a SUSPENDED state
+            client = await GetRealtimeClient(protocol, (opts, _) =>
+            {
+                opts.DisconnectedRetryTimeout = TimeSpan.FromSeconds(1);
+            });
+
+            await client.ConnectionManager.SetState(new ConnectionSuspendedState(client.ConnectionManager, new ErrorInfo("force suspend"), client.Logger));
+            await AssertsClosesAndDoesNotReconnect(client, ConnectionState.Suspended);
+        }
+
+        [Theory]
+        [ProtocolData]
         [Trait("spec", "RTN13a")]
         public async Task WithConnectedClient_PingShouldReturnServiceTime(Protocol protocol)
         {

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -250,9 +250,13 @@ namespace IO.Ably.Tests.Realtime
                 await realtime.WaitForState(state);
 
                 var reconnectAwaiter = new TaskCompletionAwaiter(5000);
-                realtime.Connection.On(ConnectionEvent.Connected, args =>
+                realtime.Connection.On(args =>
                 {
-                    reconnectAwaiter.SetCompleted();
+                    if (realtime.Connection.State == ConnectionState.Connecting
+                        || realtime.Connection.State == ConnectionState.Connected)
+                    {
+                        reconnectAwaiter.SetCompleted();
+                    }
                 });
 
                 realtime.Close();


### PR DESCRIPTION
A test to cover RTN12d

`(RTN12d) If the connection state is DISCONNECTED or SUSPENDED, aborts the retry process described in RTN14d and RTN14e and transitions the connection immediately to the CLOSED state		`