### PR TITLE
RSA10a

### DIFF
--- a/src/IO.Ably.Shared/AblyAuth.cs
+++ b/src/IO.Ably.Shared/AblyAuth.cs
@@ -375,11 +375,6 @@ namespace IO.Ably
         /// <exception cref="AblyException">Throws an ably exception representing the server response</exception>
         public async Task<TokenDetails> AuthorizeAsync(TokenParams tokenParams = null, AuthOptions options = null)
         {
-            return await AuthorizeAsync(tokenParams, options, false);
-        }
-
-        internal async Task<TokenDetails> AuthorizeAsync(TokenParams tokenParams, AuthOptions options, bool force)
-        {
             var authOptions = options ?? new AuthOptions();
 
             authOptions.Merge(CurrentAuthOptions);
@@ -388,22 +383,7 @@ namespace IO.Ably
             var authTokenParams = MergeTokenParamsWithDefaults(tokenParams);
             SetCurrentTokenParams(authTokenParams);
 
-            if (force)
-            {
-                CurrentToken = await RequestTokenAsync(authTokenParams, options);
-            }
-            else if (CurrentToken != null)
-            {
-                if (Now().AddSeconds(Defaults.TokenExpireBufferInSeconds) >= CurrentToken.Expires)
-                {
-                    CurrentToken = await RequestTokenAsync(authTokenParams, options);
-                }
-            }
-            else
-            {
-                CurrentToken = await RequestTokenAsync(authTokenParams, options);
-            }
-
+            CurrentToken = await RequestTokenAsync(authTokenParams, options);
             AuthMethod = AuthMethod.Token;
             return CurrentToken;
         }

--- a/src/IO.Ably.Shared/AblyAuth.cs
+++ b/src/IO.Ably.Shared/AblyAuth.cs
@@ -378,7 +378,7 @@ namespace IO.Ably
             var authOptions = options ?? new AuthOptions();
 
             authOptions.Merge(CurrentAuthOptions);
-            SetCurrentAuthOptions(options);
+            SetCurrentAuthOptions(authOptions);
 
             var authTokenParams = MergeTokenParamsWithDefaults(tokenParams);
             SetCurrentTokenParams(authTokenParams);

--- a/src/IO.Ably.Shared/AblyRest.cs
+++ b/src/IO.Ably.Shared/AblyRest.cs
@@ -136,7 +136,7 @@ namespace IO.Ably
 
                     try
                     {
-                        await AblyAuth.AuthorizeAsync(null, new AuthOptions(), force: true);
+                        await AblyAuth.AuthorizeAsync(null, new AuthOptions());
                         await AblyAuth.AddAuthHeader(request);
                         return await ExecuteHttpRequest(request);
                     }

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
@@ -348,7 +348,19 @@ namespace IO.Ably.Tests
                     change.Reason.Code.Should().Be(80019);
                     tca.SetCompleted();
                 });
-                await realtimeClient.Auth.AuthorizeAsync();
+
+                bool didThrowAblyException = false;
+                try
+                {
+                    await realtimeClient.Auth.AuthorizeAsync();
+                    Assert.True(false, "An exception should be raised before this line is reached.");
+                }
+                catch (AblyException e)
+                {
+                    didThrowAblyException = true;
+                }
+
+                didThrowAblyException.Should().BeTrue();
                 realtimeClient.Connection.State.Should().Be(ConnectionState.Connected);
                 (await tca.Task).Should().BeFalse(context);
             }

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
@@ -521,9 +521,16 @@ namespace IO.Ably.Tests
         public async Task WithoutClientId_WhenAuthorizedWithTokenParamsWithClientId_SetsClientId(Protocol protocol)
         {
             var ably = await GetRestClient(protocol);
-            await ably.Auth.AuthorizeAsync(new TokenParams() { ClientId = "123" }, new AuthOptions());
+            var tokenDetails1 = await ably.Auth.AuthorizeAsync(new TokenParams() { ClientId = "123" }, new AuthOptions());
             ably.AblyAuth.ClientId.Should().Be("123");
+
+            // uses Token Auth for all future requests (RSA10a)
             ably.AblyAuth.AuthMethod.Should().Be(AuthMethod.Token);
+
+            // create a token immediately (RSA10a)
+            // regardless of whether the existing token is valid or not
+            var tokenDetails2 = await ably.Auth.AuthorizeAsync(new TokenParams() { ClientId = "123" }, new AuthOptions());
+            tokenDetails1.Token.Should().NotBe(tokenDetails2.Token);
         }
 
         [Theory]

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
@@ -41,30 +41,6 @@ namespace IO.Ably.Tests.AuthTests
             data.Ttl.Should().Be(TimeSpan.FromMinutes(260));
         }
 
-        [Theory]
-        [InlineData(Defaults.TokenExpireBufferInSeconds + 1, false)]
-        [InlineData(Defaults.TokenExpireBufferInSeconds, true)]
-        [InlineData(Defaults.TokenExpireBufferInSeconds - 1, true)]
-        [Trait("spec", "RSA10c")]
-        public async Task Authorize_WithTokenExpiringIn15Seconds_RenewsToken(int secondsLeftToExpire, bool shouldRenew)
-        {
-            var client = GetRestClient();
-            var initialToken = new TokenDetails() { Expires = Now.AddSeconds(secondsLeftToExpire) };
-            client.AblyAuth.CurrentToken = initialToken;
-
-            var token = await client.Auth.AuthorizeAsync();
-
-            if (shouldRenew)
-            {
-                Assert.Contains("requestToken", LastRequest.Url);
-                token.Should().NotBeSameAs(initialToken);
-            }
-            else
-            {
-                token.Should().BeSameAs(initialToken);
-            }
-        }
-
         [Fact]
         [Trait("spec", "RSA10g")]
         public async Task ShouldKeepTokenParamsAndAuthOptionsExcetpForceAndCurrentTimestamp()

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
@@ -16,62 +16,6 @@ namespace IO.Ably.Tests.AuthTests
             client.AblyAuth.CurrentToken.Should().BeNull();
         }
 
-        /*
-         * (RSA10a) Instructs the library to create a token immediately and ensures Token Auth is used for all future requests.
-         * See RTC8 for re-authentication behaviour when called for a realtime client
-         */
-
-        [Fact]
-        [Trait("spec", "RSA10a")]
-        public async Task Authorize_WithNotExpiredCurrentTokenAndForceFalse_ReturnsCurrentToken()
-        {
-            // create a fake token that has not expired
-            var dummyTokenDetails = new TokenDetails() { Expires = TestHelpers.Now().AddHours(1) };
-
-            // create new reset client using the dummyTokenDetails
-            var client = GetRestClient(null, opts => { opts.TokenDetails = dummyTokenDetails; });
-
-            // get the current token
-            var newTokenDetails = client.AblyAuth.CurrentToken;
-
-            // new token should match the dummy token
-            newTokenDetails.Should().BeSameAs(dummyTokenDetails);
-
-            // authorise again
-            var sameTokenDetails = await client.Auth.AuthorizeAsync();
-
-            // the same token should be returned
-            client.AblyAuth.CurrentToken.Should().BeSameAs(sameTokenDetails);
-            client.AblyAuth.CurrentToken.Should().Be(newTokenDetails);
-        }
-
-        [Fact]
-        [Trait("spec", "RSA10a")]
-        public async Task Authorize_WithNotExpiredCurrentTokenAndForceTrue_ReturnsNewToken()
-        {
-            // create a fake token that has not expired
-            var dummyTokenDetails = new TokenDetails() { Expires = TestHelpers.Now().AddHours(1) };
-
-            // create new reset client using the dummyTokenDetails
-            var client = GetRestClient(null, opts =>
-            {
-                opts.TokenDetails = dummyTokenDetails;
-            });
-
-            // get the current token
-            var currentToken = client.AblyAuth.CurrentToken;
-
-            // new token should match the dummy token
-            currentToken.Should().BeSameAs(dummyTokenDetails);
-
-            // authorise again, this should force a new token
-            var newToken = await client.Auth.AuthorizeAsync();
-
-            // A different token should be returned
-            client.AblyAuth.CurrentToken.Should().Be(currentToken);
-            client.AblyAuth.CurrentToken.Should().BeSameAs(newToken);
-        }
-
         [Fact]
         [Trait("spec", "RSA10a")]
         [Trait("spec", "RSA10f")]


### PR DESCRIPTION
`(RSA10a) Instructs the library to create a token immediately and ensures Token Auth is used for all future requests. See RTC8 for re-authentication behaviour when called for a realtime client`