### PR TITLE
RTL3c

### DIFF
--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -137,7 +137,7 @@ namespace IO.Ably.Realtime
                     DetachedAwaiter.Fail(new ErrorInfo("Connection is suspended"));
                     if (State == ChannelState.Attached || State == ChannelState.Attaching)
                     {
-                        SetChannelState(ChannelState.Detaching, ErrorInfo.ReasonSuspended);
+                        SetChannelState(ChannelState.Suspended, ErrorInfo.ReasonSuspended);
                     }
 
                     break;

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -93,35 +93,18 @@ namespace IO.Ably.Realtime
 
         private void SubscribeToConnectionEvents()
         {
-            ConnectionManager.Connection.InternalStateChanged += InternalOnInternalStateChanged;
+            ConnectionManager.Connection.InternalStateChanged += OnConnectionInternalStateChanged;
         }
 
-        internal void InternalOnInternalStateChanged(object sender, ConnectionStateChange connectionStateChange)
+        internal void OnConnectionInternalStateChanged(object sender, ConnectionStateChange connectionStateChange)
         {
             switch (connectionStateChange.Current)
             {
-                // case ConnectionState.Connected:
-                case ConnectionState.Disconnected:
-                    if (State == ChannelState.Attaching)
+                case ConnectionState.Connected:
+                    if (State == ChannelState.Suspended)
                     {
-                        if (Logger.IsDebug)
-                        {
-                            Logger.Debug($"#{Name} Resending Attach because connection became {State} while the channel was {ChannelState.Attaching}.");
-                        }
-
-                        SendMessage(new ProtocolMessage(ProtocolMessage.MessageAction.Attach, Name));
+                        Attach();
                     }
-
-                    if (State == ChannelState.Detaching)
-                    {
-                        if (Logger.IsDebug)
-                        {
-                            Logger.Debug($"#{Name} Resending Detach because connection became {State} while the channel was {ChannelState.Detaching}.");
-                        }
-
-                        SendMessage(new ProtocolMessage(ProtocolMessage.MessageAction.Detach, Name));
-                    }
-
                     break;
                 case ConnectionState.Closed:
                     AttachedAwaiter.Fail(new ErrorInfo("Connection is closed"));

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -6,6 +6,8 @@ using FluentAssertions;
 using FluentAssertions.Execution;
 using IO.Ably.MessageEncoders;
 using IO.Ably.Realtime;
+using IO.Ably.Tests.Infrastructure;
+using IO.Ably.Transport;
 using IO.Ably.Transport.States.Connection;
 using IO.Ably.Types;
 using Xunit;
@@ -216,6 +218,37 @@ namespace IO.Ably.Tests.Realtime
                 _channel.State.Should().Be(ChannelState.Detached);
             }
 
+            [Fact]
+            [Trait("spec", "RTL3d")]
+            public async Task WhenChannelIsSuspended_WhenConnectionBecomeConnectedAttemptAttach()
+            {
+                var client = GetConnectedClient();
+                var channel = client.Channels.Get("test".AddRandomSuffix());
+
+                await client.ConnectionManager.SetState(new ConnectionSuspendedState(client.ConnectionManager, Logger));
+                await client.WaitForState(ConnectionState.Suspended);
+
+                (channel as RealtimeChannel).SetChannelState(ChannelState.Suspended);
+
+                await client.ConnectionManager.SetState(new ConnectionConnectedState(client.ConnectionManager, new ConnectionInfo("1", 100, "connectionKey", string.Empty)));
+
+                await client.WaitForState(ConnectionState.Connected);
+                client.Connection.State.Should().Be(ConnectionState.Connected);
+                channel.State.Should().Be(ChannelState.Attaching);
+
+                var tsc = new TaskCompletionAwaiter();
+                channel.Once(ChannelEvent.Suspended, s =>
+                {
+                    s.Error.Should().NotBeNull();
+                    s.Error.Message.Should().Be("Channel didn't attach within the default timeout");
+                    s.Error.Code.Should().Be(50000);
+                    tsc.SetCompleted();
+                });
+
+                var completed = await tsc.Task;
+                completed.Should().BeTrue("channel should have become Suspended again");
+            }
+
             [Theory]
             [InlineData(ChannelState.Attached)]
             [InlineData(ChannelState.Attaching)]
@@ -230,6 +263,27 @@ namespace IO.Ably.Tests.Realtime
 
                 _client.Connection.State.Should().Be(ConnectionState.Suspended);
                 _channel.State.Should().Be(ChannelState.Suspended);
+            }
+
+            [Theory]
+            [InlineData(ChannelState.Attached)]
+            [InlineData(ChannelState.Attaching)]
+            [InlineData(ChannelState.Failed)]
+            [InlineData(ChannelState.Suspended)]
+            [InlineData(ChannelState.Detached)]
+            [InlineData(ChannelState.Detaching)]
+            [InlineData(ChannelState.Initialized)]
+            [Trait("spec", "RTL3e")]
+            public async Task WhenConnectionIsDisconnected_ChannelStateShouldNotChange(ChannelState state)
+            {
+                (_channel as RealtimeChannel).SetChannelState(state);
+
+                _client.Close();
+
+                await _client.ConnectionManager.SetState(new ConnectionDisconnectedState(_client.ConnectionManager, Logger));
+
+                _client.Connection.State.Should().Be(ConnectionState.Disconnected);
+                _channel.State.Should().Be(state);
             }
 
             public ConnectionStateChangeEffectSpecs(ITestOutputHelper output)

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -219,8 +219,8 @@ namespace IO.Ably.Tests.Realtime
             [Theory]
             [InlineData(ChannelState.Attached)]
             [InlineData(ChannelState.Attaching)]
-            [Trait("spec", "RTL3b")]
-            public async Task WhenConnectionIsSuspended_AttachingOrAttachedChannelsShouldTrasitionToDetached(ChannelState state)
+            [Trait("spec", "RTL3c")]
+            public async Task WhenConnectionIsSuspended_AttachingOrAttachedChannelsShouldTrasitionToSuspended(ChannelState state)
             {
                 (_channel as RealtimeChannel).SetChannelState(state);
 
@@ -229,7 +229,7 @@ namespace IO.Ably.Tests.Realtime
                 await _client.ConnectionManager.SetState(new ConnectionSuspendedState(_client.ConnectionManager, Logger));
 
                 _client.Connection.State.Should().Be(ConnectionState.Suspended);
-                _channel.State.Should().Be(ChannelState.Detached);
+                _channel.State.Should().Be(ChannelState.Suspended);
             }
 
             public ConnectionStateChangeEffectSpecs(ITestOutputHelper output)

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -558,7 +558,7 @@ namespace IO.Ably.Tests.Realtime
             var channel = new RealtimeChannel("RTN19b", "RTN19b", client);
             channel.Logger = testLogger;
             channel.State = ChannelState.Attaching;
-            channel.InternalOnInternalStateChanged(this, new ConnectionStateChange(ConnectionEvent.Connected, ConnectionState.Connected, ConnectionState.Disconnected));
+            channel.OnConnectionInternalStateChanged(this, new ConnectionStateChange(ConnectionEvent.Connected, ConnectionState.Connected, ConnectionState.Disconnected));
             testLogger.MessageSeen.Should().Be(true);
         }
 
@@ -619,7 +619,7 @@ namespace IO.Ably.Tests.Realtime
             channel.Logger = testLogger;
 
             channel.State = ChannelState.Detaching;
-            channel.InternalOnInternalStateChanged(this, new ConnectionStateChange(ConnectionEvent.Connected, ConnectionState.Connected, ConnectionState.Disconnected));
+            channel.OnConnectionInternalStateChanged(this, new ConnectionStateChange(ConnectionEvent.Connected, ConnectionState.Connected, ConnectionState.Disconnected));
 
             testLogger.MessageSeen.Should().Be(true);
         }


### PR DESCRIPTION
Small change to comply with changes to RTL3b and the addition of RTL3c. 

0.8 spec
- (RTL3b) If the connection state changes to CLOSED or SUSPENDED then an ATTACHING or ATTACHED channel state will transition to DETACHED

1.0 spec
- (RTL3b) If the connection state enters the CLOSED state, then an ATTACHING or ATTACHED channel state will transition to DETACHED
- (RTL3c) If the connection state enters the SUSPENDED state, then an ATTACHING or ATTACHED channel state will transition to SUSPENDED

An existing test covers the updated RTL3b [here](https://github.com/ably/ably-dotnet/blob/51e1ad8dec8d5634bd31812ff9b7b9b7d5cd4d02/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs#L207).