### PR TITLE
RTL3d

### DIFF
--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -93,10 +93,10 @@ namespace IO.Ably.Realtime
 
         private void SubscribeToConnectionEvents()
         {
-            ConnectionManager.Connection.InternalStateChanged += OnInternalConnectionStateChanged;
+            ConnectionManager.Connection.InternalStateChanged += OnConnectionInternalStateChanged;
         }
 
-        internal void OnInternalConnectionStateChanged(object sender, ConnectionStateChange connectionStateChange)
+        internal void OnConnectionInternalStateChanged(object sender, ConnectionStateChange connectionStateChange)
         {
             switch (connectionStateChange.Current)
             {

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -93,13 +93,19 @@ namespace IO.Ably.Realtime
 
         private void SubscribeToConnectionEvents()
         {
-            ConnectionManager.Connection.InternalStateChanged += InternalOnInternalStateChanged;
+            ConnectionManager.Connection.InternalStateChanged += OnInternalConnectionStateChanged;
         }
 
-        internal void InternalOnInternalStateChanged(object sender, ConnectionStateChange connectionStateChange)
+        internal void OnInternalConnectionStateChanged(object sender, ConnectionStateChange connectionStateChange)
         {
             switch (connectionStateChange.Current)
             {
+                case ConnectionState.Connected:
+                    if (State == ChannelState.Suspended)
+                    {
+                        Attach();
+                    }
+                    break;
                 case ConnectionState.Closed:
                     AttachedAwaiter.Fail(new ErrorInfo("Connection is closed"));
                     DetachedAwaiter.Fail(new ErrorInfo("Connection is closed"));

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -558,7 +558,7 @@ namespace IO.Ably.Tests.Realtime
             var channel = new RealtimeChannel("RTN19b", "RTN19b", client);
             channel.Logger = testLogger;
             channel.State = ChannelState.Attaching;
-            channel.OnInternalConnectionStateChanged(this, new ConnectionStateChange(ConnectionEvent.Connected, ConnectionState.Connected, ConnectionState.Disconnected));
+            channel.OnConnectionInternalStateChanged(this, new ConnectionStateChange(ConnectionEvent.Connected, ConnectionState.Connected, ConnectionState.Disconnected));
             testLogger.MessageSeen.Should().Be(true);
         }
 
@@ -619,7 +619,7 @@ namespace IO.Ably.Tests.Realtime
             channel.Logger = testLogger;
 
             channel.State = ChannelState.Detaching;
-            channel.OnInternalConnectionStateChanged(this, new ConnectionStateChange(ConnectionEvent.Connected, ConnectionState.Connected, ConnectionState.Disconnected));
+            channel.OnConnectionInternalStateChanged(this, new ConnectionStateChange(ConnectionEvent.Connected, ConnectionState.Connected, ConnectionState.Disconnected));
 
             testLogger.MessageSeen.Should().Be(true);
         }

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -558,7 +558,7 @@ namespace IO.Ably.Tests.Realtime
             var channel = new RealtimeChannel("RTN19b", "RTN19b", client);
             channel.Logger = testLogger;
             channel.State = ChannelState.Attaching;
-            channel.InternalOnInternalStateChanged(this, new ConnectionStateChange(ConnectionEvent.Connected, ConnectionState.Connected, ConnectionState.Disconnected));
+            channel.OnInternalConnectionStateChanged(this, new ConnectionStateChange(ConnectionEvent.Connected, ConnectionState.Connected, ConnectionState.Disconnected));
             testLogger.MessageSeen.Should().Be(true);
         }
 
@@ -619,7 +619,7 @@ namespace IO.Ably.Tests.Realtime
             channel.Logger = testLogger;
 
             channel.State = ChannelState.Detaching;
-            channel.InternalOnInternalStateChanged(this, new ConnectionStateChange(ConnectionEvent.Connected, ConnectionState.Connected, ConnectionState.Disconnected));
+            channel.OnInternalConnectionStateChanged(this, new ConnectionStateChange(ConnectionEvent.Connected, ConnectionState.Connected, ConnectionState.Disconnected));
 
             testLogger.MessageSeen.Should().Be(true);
         }


### PR DESCRIPTION
Change to support RTL3d

- (RTL3d) If the connection state enters the CONNECTED state, then a SUSPENDED channel will initiate an attach operation and transition to ATTACHING. If the attach operation times out, the channel should return to the SUSPENDED state

Additionally refactored the clumsy method name `InternalOnInternalStateChanged` to `OnConnectionInternalStateChanged`