### PR TITLE
RTL2b, RTL2f, RTL2g, RTL12 & RTL3d

### DIFF
--- a/src/IO.Ably.Shared/Realtime/ChannelMessageProcessor.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelMessageProcessor.cs
@@ -49,16 +49,17 @@ namespace IO.Ably.Realtime
                     break;
                 case ProtocolMessage.MessageAction.Attach:
                 case ProtocolMessage.MessageAction.Attached:
-                    if (channel.State != ChannelState.Attached)
+                    if (channel.State == ChannelState.Attached)
                     {
-                        channel.SetChannelState(ChannelState.Attached, protocolMessage);
+                        // RTL12
+                        if (!protocolMessage.HasFlag(ProtocolMessage.Flag.Resumed))
+                        {
+                            channel.EmitUpdate(ChannelState.Attached, protocolMessage);
+                        }
                     }
                     else
                     {
-                        if (protocolMessage.Error != null)
-                        {
-                            channel.OnError(protocolMessage.Error);
-                        }
+                        channel.SetChannelState(ChannelState.Attached, protocolMessage);
                     }
 
                     break;

--- a/src/IO.Ably.Shared/Realtime/ChannelStateChangedEventArgs.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelStateChangedEventArgs.cs
@@ -4,11 +4,12 @@ namespace IO.Ably.Realtime
 {
     public class ChannelStateChange : EventArgs
     {
-        public ChannelStateChange(ChannelState state, ChannelState previous, ErrorInfo error = null)
+        public ChannelStateChange(ChannelState state, ChannelState previous, ErrorInfo error = null, bool resumed = false)
         {
             Previous = previous;
             Current = state;
             Error = error;
+            Resumed = resumed;
         }
 
         public ChannelState Previous { get; }
@@ -16,5 +17,7 @@ namespace IO.Ably.Realtime
         public ChannelState Current { get; }
 
         public ErrorInfo Error { get; }
+
+        public bool Resumed { get;  }
     }
 }

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -434,9 +434,10 @@ namespace IO.Ably.Realtime
             {
                 channelEvent = (ChannelEvent) state;
                 channelStateChange = new ChannelStateChange(state, State, error, protocolMessage != null && protocolMessage.HasFlag(ProtocolMessage.Flag.Resumed));
-                HandleStateChange(state, error, protocolMessage);
-                InternalStateChanged.Invoke(this, channelStateChange);
             }
+
+            HandleStateChange(state, error, protocolMessage);
+            InternalStateChanged.Invoke(this, channelStateChange);
 
             // Notify external client using the thread they subscribe on
             RealtimeClient.NotifyExternalClients(() =>

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -534,13 +534,14 @@ namespace IO.Ably.Realtime
 
                     break;
                 case ChannelState.Detached:
-                    ConnectionManager.FailMessageWaitingForAckAndClearOutgoingQueue(this, error);
                     ClearAndFailChannelQueuedMessages(error);
                     break;
                 case ChannelState.Failed:
                     AttachedAwaiter.Fail(error);
                     DetachedAwaiter.Fail(error);
-                    ConnectionManager.FailMessageWaitingForAckAndClearOutgoingQueue(this, error);
+                    ClearAndFailChannelQueuedMessages(error);
+                    break;
+                case ChannelState.Suspended:
                     ClearAndFailChannelQueuedMessages(error);
                     break;
             }

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -423,8 +423,6 @@ namespace IO.Ably.Realtime
             }
 
             ChannelEvent channelEvent;
-            ChannelStateChange channelStateChange;
-
             if (emitUpdate)
             {
                 channelEvent = ChannelEvent.Update;
@@ -434,7 +432,7 @@ namespace IO.Ably.Realtime
                 channelEvent = (ChannelEvent) state;
             }
 
-            channelStateChange = new ChannelStateChange(state, State, error, protocolMessage != null && protocolMessage.HasFlag(ProtocolMessage.Flag.Resumed));
+            var channelStateChange = new ChannelStateChange(state, State, error, protocolMessage != null && protocolMessage.HasFlag(ProtocolMessage.Flag.Resumed));
             HandleStateChange(state, error, protocolMessage);
             InternalStateChanged.Invoke(this, channelStateChange);
 

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -428,14 +428,13 @@ namespace IO.Ably.Realtime
             if (emitUpdate)
             {
                 channelEvent = ChannelEvent.Update;
-                channelStateChange = new ChannelStateChange(state, PreviousState, error, protocolMessage != null && protocolMessage.HasFlag(ProtocolMessage.Flag.Resumed));
             }
             else
             {
                 channelEvent = (ChannelEvent) state;
-                channelStateChange = new ChannelStateChange(state, State, error, protocolMessage != null && protocolMessage.HasFlag(ProtocolMessage.Flag.Resumed));
             }
 
+            channelStateChange = new ChannelStateChange(state, State, error, protocolMessage != null && protocolMessage.HasFlag(ProtocolMessage.Flag.Resumed));
             HandleStateChange(state, error, protocolMessage);
             InternalStateChanged.Invoke(this, channelStateChange);
 

--- a/src/IO.Ably.Tests.Shared/Infrastructure/TaskCompletionAwaiter.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/TaskCompletionAwaiter.cs
@@ -43,6 +43,11 @@ namespace IO.Ably.Tests.Infrastructure
             }
         }
 
+        public void Set(bool value)
+        {
+            _taskCompletionSource.TrySetResult(value);
+        }
+
         public void SetCompleted()
         {
             _taskCompletionSource.TrySetResult(true);

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -9,6 +9,7 @@ using FluentAssertions;
 using IO.Ably.Encryption;
 using IO.Ably.Realtime;
 using IO.Ably.Tests.Infrastructure;
+using IO.Ably.Types;
 using Newtonsoft.Json.Linq;
 using Xunit;
 using Xunit.Abstractions;
@@ -612,6 +613,80 @@ namespace IO.Ably.Tests.Realtime
             client.Close();
         }
 
+        [Theory]
+        [InlineData(ChannelState.Detached)]
+        [InlineData(ChannelState.Failed)]
+        [InlineData(ChannelState.Suspended)]
+        [Trait("spec", "RTL11")]
+        public async Task WhenChannelEntersDetachedFailedSuspendedState_ShouldDeleteQueuedMessageAndCallbackShouldIndicateError(ChannelState state)
+        {
+            var client = await GetRealtimeClient(Defaults.Protocol, (options, settings) =>
+                {
+                    // A bogus AuthUrl will cause connection to become disconnected
+                    options.AuthUrl = new Uri("http://235424c24.fake:49999");
+
+                    // speed up the AuthUrl failure
+                    options.HttpMaxRetryCount = 1;
+                    options.HttpMaxRetryDuration = TimeSpan.FromMilliseconds(100);
+                });
+
+            var channel = client.Channels.Get("test".AddRandomSuffix());
+
+            var tsc = new TaskCompletionAwaiter(5000);
+            client.Connection.Once(ConnectionEvent.Disconnected, change =>
+            {
+                // place a message on the queue
+                channel.Publish("wibble", "wobble", (success, info) =>
+                {
+                    // expect an error
+                    tsc.Set(!success);
+                });
+
+                // setting the state should cause the queued message to be removed
+                // and the callback to indicate an error
+                (channel as RealtimeChannel).SetChannelState(state);
+            });
+
+            var result = await tsc.Task;
+            result.Should().BeTrue("publish should have failed");
+        }
+
+        [Theory]
+        [InlineData(ChannelState.Detached)]
+        [InlineData(ChannelState.Failed)]
+        [InlineData(ChannelState.Suspended)]
+        [Trait("spec", "RTL11a")]
+        public async Task WhenChannelEntersDetachedFailedSuspendedState_MessagesAwaitingAckOrNackShouldNotBeAffected(ChannelState state)
+        {
+            var client = await GetRealtimeClient(Defaults.Protocol);
+            var channel = client.Channels.Get("test".AddRandomSuffix());
+            var tsc = new TaskCompletionAwaiter(5000);
+
+            channel.Once(ChannelEvent.Attached, async x =>
+            {
+                channel.Publish("wibble", "wobble", (success, info) =>
+                {
+                    // message publish should succeed
+                    tsc.Set(success);
+                });
+
+                client.Connection.Once(ConnectionEvent.Disconnected, change =>
+                {
+                    (channel as RealtimeChannel).SetChannelState(state);
+                });
+
+                await client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Disconnected)
+                {
+                    Error = new ErrorInfo("test", 40140)
+                });
+            });
+
+            channel.Attach();
+
+            var result = await tsc.Task;
+            result.Should().BeTrue();
+        }
+
         [Fact]
         [Trait("bug", "102")]
         public async Task WhenAttachingToAChannelFromMultipleThreads_ItShouldNotThrowAnError()
@@ -619,7 +694,7 @@ namespace IO.Ably.Tests.Realtime
             Logger.LogLevel = LogLevel.Debug;
 
             var client1 = await GetRealtimeClient(Protocol.Json);
-            var channel = client1.Channels.Get("test");
+            var channel = client1.Channels.Get("test".AddRandomSuffix());
             var task = Task.Run(() => channel.Attach());
             await task.ConfigureAwait(false);
             var task2 = Task.Run(() => channel.Attach());

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -52,45 +52,6 @@ namespace IO.Ably.Tests.Realtime
                 channel.Presence.Should().BeOfType<Presence>();
             }
 
-            [Fact]
-            [Trait("spec", "RTL12")]
-            [Trait("intermittent", "true")]
-            public async Task OnceAttachedWhenConsequentAttachMessageArriveWithError_ShouldEmitErrorOnChannelButNoStateChange()
-            {
-                var client = GetConnectedClient();
-                var channel = client.Channels.Get("test");
-                SetState(channel, ChannelState.Attached);
-
-                ErrorInfo expectedError = new ErrorInfo();
-                ErrorInfo error = null;
-                channel.Error += (sender, args) =>
-                {
-                    error = args.Reason;
-                };
-                bool stateChanged = false;
-
-                await Task.Delay(10); // Allow the notification thread to fire
-
-                ChannelState newState = ChannelState.Initialized;
-                channel.On((args) =>
-                {
-                    stateChanged = true;
-                    newState = args.Current;
-                });
-
-                await
-                    client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Attached)
-                    {
-                        Error = expectedError,
-                        Channel = "test"
-                    });
-
-                await Task.Delay(10); // Allow the notification thread to fire
-
-                error.Should().BeSameAs(expectedError);
-                stateChanged.Should().BeFalse("State should not have changed but is now: " + newState);
-            }
-
             public GeneralSpecs(ITestOutputHelper output)
                 : base(output)
             {

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -90,7 +90,6 @@ namespace IO.Ably.Tests.Realtime
             }
 
             [Theory]
-            [InlineData(ChannelEvent.Initialized)]
             [InlineData(ChannelEvent.Attaching)]
             [InlineData(ChannelEvent.Attached)]
             [InlineData(ChannelEvent.Detaching)]

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -239,7 +239,7 @@ namespace IO.Ably.Tests.Realtime
                 channel.Once(stateChange =>
                 {
                     stateDidChange = true;
-                    throw new Exception("state chage event should not be emitted");
+                    throw new Exception("state change event should not be emitted");
                 });
 
                 // attempt to set the same state again

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -210,7 +210,7 @@ namespace IO.Ably.Tests.Realtime
 
                 await client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Attached, "test")
                 {
-                    Flags = 4, // resumed
+                    Flags = ProtocolMessage.Flag.Resumed, // resumed
                     Error = new ErrorInfo("test error")
                 });
 


### PR DESCRIPTION
This PR covers the following spec items (apologies, this is quite a large one, but it need to be done)

- (RTL2f) When a channel ATTACHED ProtocolMessage is received, the ProtocolMessage may contain a RESUMED bit flag indicating that the channel has been resumed. The corresponding ChannelStateChange (either ATTACHED per RTL2a, or UPDATE per RTL12) will contain a resumed boolean attribute with value true if the bit flag RESUMED was included. When resumed is true, this indicates that the channel attach resumed the channel state from an existing connection and there has been no loss of message continuity. In all other cases, resumed is false. A test should exist to ensure that resumed is always false when a channel first becomes ATTACHED, it is true when the channel is ATTACHED following a successful connection recovery, and is false when the channel is ATTACHED following a failed connection recovery		

- (RTL2g) It can emit an UPDATE event (this is the only ChannelEvent which is not a ChannelState). This is used for changes to channel conditions for which the ChannelState (e.g. ATTACHED) does not change. (The library must never emit a ChannelState for a state equal to the previous state).		

- (RTL12) An attached channel may receive an additional ATTACHED ProtocolMessage from Ably at any point. (This is typically triggered following a transport being upgraded or resumed to indicate a partial loss of message continuity on that channel, in which case the ProtocolMessage will have a resumed flag set to false). If and only if the resumed flag is false, this should result in the channel emitting an UPDATE event with a ChannelStateChange object. The ChannelStateChange object should have both previous and current attributes set to attached, the reason attribute set to to the error member of the ATTACHED ProtocolMessage (if any), and the resumed attribute set per the RESUMED bitflag of the ATTACHED ProtocolMessage. (Note that UPDATE should be the only event emitted: in particular, the library must not emit an ATTACHED event if the channel was already attached, see RTL2g).

In addition to the above I had to update the the existing RTN19b tests, they were incorrect for the current spec, but passing. After changes required for the above spec items the existing tests failed. Thanks to @funkyboy for giving me a nudge run the right direction with those. 
