### PR TITLE
RTL11 & RTL11a

### DIFF
--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -534,17 +534,14 @@ namespace IO.Ably.Realtime
 
                     break;
                 case ChannelState.Detached:
-                    ConnectionManager.FailMessageWaitingForAckAndClearOutgoingQueue(this, error);
                     ClearAndFailChannelQueuedMessages(error);
                     break;
                 case ChannelState.Failed:
                     AttachedAwaiter.Fail(error);
                     DetachedAwaiter.Fail(error);
-                    ConnectionManager.FailMessageWaitingForAckAndClearOutgoingQueue(this, error);
                     ClearAndFailChannelQueuedMessages(error);
                     break;
                 case ChannelState.Suspended:
-                    ConnectionManager.FailMessageWaitingForAckAndClearOutgoingQueue(this, error);
                     ClearAndFailChannelQueuedMessages(error);
                     break;
             }

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -543,6 +543,10 @@ namespace IO.Ably.Realtime
                     ConnectionManager.FailMessageWaitingForAckAndClearOutgoingQueue(this, error);
                     ClearAndFailChannelQueuedMessages(error);
                     break;
+                case ChannelState.Suspended:
+                    ConnectionManager.FailMessageWaitingForAckAndClearOutgoingQueue(this, error);
+                    ClearAndFailChannelQueuedMessages(error);
+                    break;
             }
         }
 

--- a/src/IO.Ably.Tests.Shared/Infrastructure/TaskCompletionAwaiter.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/TaskCompletionAwaiter.cs
@@ -43,6 +43,11 @@ namespace IO.Ably.Tests.Infrastructure
             }
         }
 
+        public void Set(bool value)
+        {
+            _taskCompletionSource.TrySetResult(value);
+        }
+
         public void SetCompleted()
         {
             _taskCompletionSource.TrySetResult(true);

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -630,7 +630,7 @@ namespace IO.Ably.Tests.Realtime
                     options.HttpMaxRetryDuration = TimeSpan.FromMilliseconds(100);
                 });
 
-            var channel = client.Channels.Get("test");
+            var channel = client.Channels.Get("test".AddRandomSuffix());
 
             var tsc = new TaskCompletionAwaiter(5000);
             client.Connection.Once(ConnectionEvent.Disconnected, change =>
@@ -659,8 +659,8 @@ namespace IO.Ably.Tests.Realtime
         public async Task WhenChannelEntersDetachedFailedSuspendedState_MessagesAwaitingAckOrNackShouldNotBeAffected(ChannelState state)
         {
             var client = await GetRealtimeClient(Defaults.Protocol);
-            var channel = client.Channels.Get("test");
-            var tsc = new TaskCompletionAwaiter(35000);
+            var channel = client.Channels.Get("test".AddRandomSuffix());
+            var tsc = new TaskCompletionAwaiter(5000);
 
             channel.Once(ChannelEvent.Attached, async x =>
             {
@@ -694,7 +694,7 @@ namespace IO.Ably.Tests.Realtime
             Logger.LogLevel = LogLevel.Debug;
 
             var client1 = await GetRealtimeClient(Protocol.Json);
-            var channel = client1.Channels.Get("test");
+            var channel = client1.Channels.Get("test".AddRandomSuffix());
             var task = Task.Run(() => channel.Attach());
             await task.ConfigureAwait(false);
             var task2 = Task.Run(() => channel.Attach());


### PR DESCRIPTION
This PR covers RTL11 and RTL11a:

- (RTL11) If a channel enters the DETACHED, SUSPENDED or FAILED state, then all messages that are still queued for send on that channel should be deleted from the queue triggering a failure for the publish or presence methods invoked for those messages
- (RTL11a) For clarity, any messages awaiting an ACK or NACK are unaffected by channel state changes i.e. a channel that becomes detached following an explicit request to detach may still receive an ACK or NACK for messages published on that channel later

