### PR TITLE
stylecop.json

### DIFF
--- a/src/stylecop.json
+++ b/src/stylecop.json
@@ -1,0 +1,7 @@
+{
+  "settings": {
+    "layoutRules": {
+      "newlineAtEndOfFile":  "require" 
+    }
+  }
+}


### PR DESCRIPTION
Having checked out the project to run tests on macOS I realised that this config file was never committed as it was filtered by a gitignore rule intended for other style cop related files.