### PR TITLE
Test tweaks 

### DIFF
--- a/src/IO.Ably.Tests.DotNetCore20/xunit.runner.json
+++ b/src/IO.Ably.Tests.DotNetCore20/xunit.runner.json
@@ -1,4 +1,4 @@
 ﻿{
-  "maxParallelThreads": 4,
-  "parallelizeTestCollections":  false
+  "maxParallelThreads": 2,
+  "parallelizeTestCollections":  true
 }

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -117,6 +117,7 @@ namespace IO.Ably.Tests.Realtime
 
         [Theory]
         [ProtocolData]
+        [Trait("spec", "RTC1a")]
         public async Task TestAttachChannel_Sending3Messages_EchoesItBack(Protocol protocol)
         {
             Logger.LogLevel = LogLevel.Debug;
@@ -125,7 +126,7 @@ namespace IO.Ably.Tests.Realtime
             var client = await GetRealtimeClient(protocol);
             await client.WaitForState(ConnectionState.Connected);
 
-            ManualResetEvent resetEvent = new ManualResetEvent(false);
+            var tsc = new TaskCompletionAwaiter(10000, 3);
             IRealtimeChannel target = client.Channels.Get("test" + protocol);
             target.Attach();
             await target.WaitForState(ChannelState.Attached);
@@ -135,24 +136,19 @@ namespace IO.Ably.Tests.Realtime
             target.Subscribe(message =>
             {
                 messagesReceived.Enqueue(message);
-                count++;
-                if (count == 3)
-                {
-                    resetEvent.Set();
-                }
+                tsc.Tick();
             });
 
             // Act
-            target.Publish("test1", "test 12");
-            target.Publish("test2", "test 123");
-            target.Publish("test3", "test 321");
+            await target.PublishAsync("test1", "test 12");
+            await target.PublishAsync("test2", "test 123");
+            await target.PublishAsync("test3", "test 321");
 
-            bool result = resetEvent.WaitOne(8000);
-            await Task.Delay(100);
+            bool result = await tsc.Task;
             result.Should().BeTrue();
 
             // Assert
-            messagesReceived.Count.ShouldBeEquivalentTo(3);
+            messagesReceived.Should().HaveCount(3);
             var messages = messagesReceived.ToList();
             messages[0].Name.ShouldBeEquivalentTo("test1");
             messages[0].Data.ShouldBeEquivalentTo("test 12");
@@ -165,6 +161,7 @@ namespace IO.Ably.Tests.Realtime
         [Theory]
         [ProtocolData]
         [Trait("spec", "RTL7f")]
+        [Trait("spec", "RTC1a")]
         public async Task TestAttachChannel_SendingMessage_Doesnt_EchoesItBack(Protocol protocol)
         {
             var channelName = "echo_off_test";

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -220,11 +220,11 @@ namespace IO.Ably.Tests.Realtime
 
             [Fact]
             [Trait("spec", "RTL3d")]
-            public async Task WhenChannelIsSuspended_WhenConnectionBecomeConnectedAttemptAttach()
+            public async Task WhenChannelIsSuspended_WhenConnectionBecomesConnectedAttemptAttach()
             {
                 var client = GetConnectedClient();
                 var channel = client.Channels.Get("test".AddRandomSuffix());
-
+                await client.WaitForState(ConnectionState.Connected);
                 await client.ConnectionManager.SetState(new ConnectionSuspendedState(client.ConnectionManager, Logger));
                 await client.WaitForState(ConnectionState.Suspended);
 
@@ -236,7 +236,7 @@ namespace IO.Ably.Tests.Realtime
                 client.Connection.State.Should().Be(ConnectionState.Connected);
                 channel.State.Should().Be(ChannelState.Attaching);
 
-                var tsc = new TaskCompletionAwaiter();
+                var tsc = new TaskCompletionAwaiter(15000);
                 channel.Once(ChannelEvent.Suspended, s =>
                 {
                     s.Error.Should().NotBeNull();

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -262,7 +262,7 @@ namespace IO.Ably.Tests.Realtime
         [Trait("spec", "RTN15h")]
         public async Task WhenDisconnectedMessageContainsTokenError_IfTokenIsRenewable_ShouldNotEmitError(Protocol protocol)
         {
-            var awaiter = new TaskCompletionAwaiter(10000, 2);
+            var awaiter = new TaskCompletionAwaiter(15000, 2);
             var authClient = await GetRestClient(protocol);
             var tokenDetails = await authClient.AblyAuth.RequestTokenAsync(new TokenParams { ClientId = "123", Ttl = TimeSpan.FromSeconds(2) });
 


### PR DESCRIPTION
CI has been unreliable most due to timeouts so I have made some tweaks to help resolve this.

In this PR I have added some longer timeouts, fixed a typo, and added some traits to existing tests that pertain to RTC1a and then streamlined said test a little.