### PR TITLE
RTP11 and subsections

### DIFF
--- a/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
+++ b/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
@@ -4,7 +4,7 @@
     {
         public static bool IsSynthesized(this PresenceMessage msg)
         {
-            return !msg.Id.StartsWith(msg.ConnectionId);
+            return msg.Id == null || !msg.Id.StartsWith(msg.ConnectionId);
         }
 
         public static bool IsNewerThan(this PresenceMessage thisMessage, PresenceMessage thatMessage)

--- a/src/IO.Ably.Shared/Realtime/ChannelStateChangedEventArgs.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelStateChangedEventArgs.cs
@@ -1,14 +1,16 @@
 ﻿using System;
+using IO.Ably.Types;
 
 namespace IO.Ably.Realtime
 {
     public class ChannelStateChange : EventArgs
     {
-        public ChannelStateChange(ChannelState state, ChannelState previous, ErrorInfo error = null)
+        public ChannelStateChange(ChannelState state, ChannelState previous, ErrorInfo error = null, bool resumed = false)
         {
             Previous = previous;
             Current = state;
             Error = error;
+            Resumed = resumed;
         }
 
         public ChannelState Previous { get; }
@@ -16,5 +18,9 @@ namespace IO.Ably.Realtime
         public ChannelState Current { get; }
 
         public ErrorInfo Error { get; }
+
+        public bool Resumed { get;  }
+
+        internal ProtocolMessage ProtocolMessage { get; set; } = null;
     }
 }

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -109,7 +109,7 @@ namespace IO.Ably.Realtime
             return await GetAsync(new GetParams() { WaitForSync = waitForSync });
         }
 
-        public async Task<IEnumerable<PresenceMessage>> GetAsync(string clientId, bool waitForSync = false)
+        public async Task<IEnumerable<PresenceMessage>> GetAsync(string clientId, bool waitForSync = true)
         {
             return await GetAsync(new GetParams() { ClientId = clientId, WaitForSync = waitForSync });
         }

--- a/src/IO.Ably.Shared/Realtime/PresenceMap.cs
+++ b/src/IO.Ably.Shared/Realtime/PresenceMap.cs
@@ -23,6 +23,11 @@ namespace IO.Ably.Realtime
             Failed
         }
 
+        /// <summary>
+        /// Exposed internally to allow for testing
+        /// </summary>
+        internal ConcurrentDictionary<string, PresenceMessage> Members => _members;
+
         private readonly ConcurrentDictionary<string, PresenceMessage> _members;
         private ICollection<string> _residualMembers;
         private bool _isSyncInProgress;

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -434,7 +434,7 @@ namespace IO.Ably.Realtime
 
             HandleStateChange(state, error, protocolMessage);
 
-            InternalStateChanged.Invoke(this, new ChannelStateChange(state, previousState, error));
+            InternalStateChanged.Invoke(this, new ChannelStateChange(state, previousState, error) { ProtocolMessage = protocolMessage });
 
             // Notify external client using the thread they subscribe on
             RealtimeClient.NotifyExternalClients(() =>
@@ -621,6 +621,19 @@ namespace IO.Ably.Realtime
             }
 
             ConnectionManager.Send(protocolMessage, callback, Options);
+        }
+
+        /// <summary>
+        /// Emits an UPDATE if the channel is ATTACHED
+        /// </summary>
+        /// <param name="errorInfo"></param>
+        /// <param name="resumed"></param>
+        internal void EmitUpdate(ErrorInfo errorInfo, bool resumed)
+        {
+            if (State == ChannelState.Attached)
+            {
+                Emit(ChannelEvent.Update, new ChannelStateChange(State, State, errorInfo, resumed));
+            }
         }
     }
 }

--- a/src/IO.Ably.Tests.Shared/Infrastructure/ProtocolData.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/ProtocolData.cs
@@ -1,17 +1,36 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
+using Xunit;
 using Xunit.Sdk;
 
 namespace IO.Ably.Tests
 {
     public class ProtocolDataAttribute : DataAttribute
     {
+        private readonly object[] _data;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProtocolDataAttribute"/> class.
+        /// </summary>
+        /// <param name="data">The data values to pass to the theory.</param>
+        public ProtocolDataAttribute(params object[] data)
+        {
+            _data = data;
+        }
+
+        /// <inheritdoc/>
         public override IEnumerable<object[]> GetData(MethodInfo testMethod)
         {
-            yield return new object[] { Protocol.Json };
+            var d = new List<object> { Protocol.Json };
+            d.AddRange(_data);
+            yield return d.ToArray();
+
             if (Config.MsgPackEnabled)
             {
-                yield return new object[] { Defaults.Protocol };
+                d = new List<object> { Defaults.Protocol };
+                d.AddRange(_data);
+                yield return d.ToArray();
             }
         }
     }

--- a/src/IO.Ably.Tests.Shared/Infrastructure/TestHelpers.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/TestHelpers.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading.Tasks;
+using IO.Ably.Tests.Infrastructure;
 using Xunit;
 
 namespace IO.Ably.Tests
@@ -21,6 +23,29 @@ namespace IO.Ably.Tests
         public static Func<DateTimeOffset> NowFunc()
         {
             return Defaults.NowFunc();
+        }
+
+        public static async Task WaitFor(int timeoutMs, int taskCount, Action<Action> action)
+        {
+            var tsc = new TaskCompletionAwaiter(timeoutMs, taskCount);
+
+            void Done()
+            {
+                tsc.Tick();
+            }
+
+            action(Done);
+            var success = await tsc.Task;
+            if (!success)
+            {
+                var msg = $"Timeout of {timeoutMs}ms exceeed.";
+                if (taskCount > 1)
+                {
+                    msg += $" Completed {taskCount - tsc.TaskCount} of {taskCount} tasks.";
+                }
+
+                throw new Exception(msg);
+            }
         }
     }
 }

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -374,7 +374,7 @@ namespace IO.Ably.Tests.Realtime
                         * Client library won't return a presence message if it is stored as ABSENT
                         * so the result of the presence.get() call should be empty.
                         */
-                        var result = await channel.Presence.GetAsync("4");
+                        var result = await channel.Presence.GetAsync("4", false);
                         seenLeaveMessageAsAbsentForClient4 = result.ToArray().Length == 0;
                     }
                 });
@@ -403,9 +403,9 @@ namespace IO.Ably.Tests.Realtime
                     Presence = TestPresence3()
                 });
 
-                var presence1 = await channel.Presence.GetAsync("1");
-                var presence2 = await channel.Presence.GetAsync("2");
-                var presence3 = await channel.Presence.GetAsync("3");
+                var presence1 = await channel.Presence.GetAsync("1", false);
+                var presence2 = await channel.Presence.GetAsync("2", false);
+                var presence3 = await channel.Presence.GetAsync("3", false);
                 var presenceOthers = await channel.Presence.GetAsync();
 
                 presence1.ToArray().Length.ShouldBeEquivalentTo(0, "incomplete sync should be discarded");

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using IO.Ably.Realtime;
 using IO.Ably.Tests.Infrastructure;
+using IO.Ably.Transport;
 using IO.Ably.Transport.States.Connection;
 using IO.Ably.Types;
 using Xunit;
@@ -259,6 +260,190 @@ namespace IO.Ably.Tests.Realtime
                     syncPresenceMessages[i].Id.ShouldBeEquivalentTo(presenceMessages[i].Id, "result should be the same in case of SYNC");
                     syncPresenceMessages[i].Action.ShouldBeEquivalentTo(presenceMessages[i].Action, "result should be the same in case of SYNC");
                 }
+            }
+
+            [Theory]
+            [ProtocolData]
+            [Trait("spec", "RTP17")]
+            public async Task Presence_ShouldHaveInternalMapForCurrentConnectionId(Protocol protocol)
+            {
+                /*
+                 * any ENTER, PRESENT, UPDATE or LEAVE event that matches
+                 * the current connectionId should be applied to the internal map
+                 */
+
+                var channelName = "RTP17".AddRandomSuffix();
+                var clientA = await GetRealtimeClient(protocol, (options, settings) => { options.ClientId = "A"; });
+                var channelA = clientA.Channels.Get(channelName);
+
+                var clientB = await GetRealtimeClient(protocol, (options, settings) => { options.ClientId = "B"; });
+                var channelB = clientB.Channels.Get(channelName);
+
+                // ENTER
+                PresenceMessage msgA = null, msgB = null;
+                await WaitForMultiple(2, partialDone =>
+                {
+                    channelA.Presence.Subscribe(msg =>
+                    {
+                        msgA = msg;
+                        partialDone();
+                    });
+
+                    channelB.Presence.Subscribe(msg =>
+                    {
+                        msgB = msg;
+                        partialDone();
+                    });
+
+                    channelA.Presence.Enter("chA");
+                });
+
+                msgA.Should().NotBeNull();
+                msgA.Action.Should().Be(PresenceAction.Enter);
+                msgA.ConnectionId.Should().Be(clientA.Connection.Id);
+                channelA.Presence.Map.Members.Should().HaveCount(1);
+                channelA.Presence.InternalMap.Members.Should().HaveCount(1);
+                channelA.Presence.Unsubscribe();
+
+                msgB.Should().NotBeNull();
+                msgB.Action.Should().Be(PresenceAction.Enter);
+                msgB.ConnectionId.Should().NotBe(clientB.Connection.Id);
+                channelB.Presence.Map.Members.Should().HaveCount(1);
+                channelB.Presence.InternalMap.Members.Should().HaveCount(0);
+                channelB.Presence.Unsubscribe();
+
+                msgA = null;
+                msgB = null;
+                await WaitForMultiple(2, partialDone =>
+                {
+                    channelA.Presence.Subscribe(msg =>
+                    {
+                        msgA = msg;
+                        channelA.Presence.Unsubscribe();
+                        partialDone();
+                    });
+
+                    channelB.Presence.Subscribe(msg =>
+                    {
+                        msgB = msg;
+                        channelB.Presence.Unsubscribe();
+                        partialDone();
+                    });
+
+                    channelB.Presence.Enter("chB");
+                });
+
+                msgA.Should().NotBeNull();
+                msgA.Action.Should().Be(PresenceAction.Enter);
+                msgA.ConnectionId.Should().NotBe(clientA.Connection.Id);
+                channelA.Presence.Map.Members.Should().HaveCount(2);
+                channelA.Presence.InternalMap.Members.Should().HaveCount(1);
+
+                msgB.Should().NotBeNull();
+                msgB.Action.Should().Be(PresenceAction.Enter);
+                msgB.ConnectionId.Should().Be(clientB.Connection.Id);
+                channelB.Presence.Map.Members.Should().HaveCount(2);
+                channelB.Presence.InternalMap.Members.Should().HaveCount(1);
+
+                // UPDATE
+                msgA = null;
+                msgB = null;
+                await WaitForMultiple(2, partialDone =>
+                {
+                    channelA.Presence.Subscribe(msg =>
+                    {
+                        msgA = msg;
+                        channelA.Presence.Unsubscribe();
+                        partialDone();
+                    });
+
+                    channelB.Presence.Subscribe(msg =>
+                    {
+                        msgB = msg;
+                        channelB.Presence.Unsubscribe();
+                        partialDone();
+                    });
+
+                    channelB.Presence.Update("chB-update");
+                });
+
+                msgA.Should().NotBeNull();
+                msgA.Action.Should().Be(PresenceAction.Update);
+                msgA.ConnectionId.Should().NotBe(clientA.Connection.Id);
+                msgA.Data.ToString().Should().Be("chB-update");
+                channelA.Presence.Map.Members.Should().HaveCount(2);
+                channelA.Presence.InternalMap.Members.Should().HaveCount(1);
+
+                msgB.Should().NotBeNull();
+                msgB.Action.Should().Be(PresenceAction.Update);
+                msgB.ConnectionId.Should().Be(clientB.Connection.Id);
+                msgB.Data.ToString().Should().Be("chB-update");
+                channelB.Presence.Map.Members.Should().HaveCount(2);
+                channelB.Presence.InternalMap.Members.Should().HaveCount(1);
+
+                // LEAVE
+                msgA = null;
+                msgB = null;
+                await WaitForMultiple(2, partialDone =>
+                {
+                    channelA.Presence.Subscribe(msg =>
+                    {
+                        msgA = msg;
+                        channelA.Presence.Unsubscribe();
+                        partialDone();
+                    });
+
+                    channelB.Presence.Subscribe(msg =>
+                    {
+                        msgB = msg;
+                        channelB.Presence.Unsubscribe();
+                        partialDone();
+                    });
+
+                    channelB.Presence.Leave("chB-leave");
+                });
+
+                msgA.Should().NotBeNull();
+                msgA.Action.Should().Be(PresenceAction.Leave);
+                msgA.ConnectionId.Should().NotBe(clientA.Connection.Id);
+                msgA.Data.ToString().Should().Be("chB-leave");
+                channelA.Presence.Map.Members.Should().HaveCount(1);
+                channelA.Presence.InternalMap.Members.Should().HaveCount(1);
+
+                msgB.Should().NotBeNull();
+                msgB.Action.Should().Be(PresenceAction.Leave);
+                msgB.ConnectionId.Should().Be(clientB.Connection.Id);
+                msgB.Data.ToString().Should().Be("chB-leave");
+                channelB.Presence.Map.Members.Should().HaveCount(1);
+                channelB.Presence.InternalMap.Members.Should().HaveCount(0);
+
+                // clean up
+                clientA.Close();
+                clientB.Close();
+            }
+
+            [Theory]
+            [ProtocolData]
+            [Trait("spec", "RTP17a")]
+            public async Task Presence_ShouldPublishAllMembersForTheCurrentConnection(Protocol protocol)
+            {
+                var channelName = "RTP17a".AddRandomSuffix();
+                var clientId = "RTP17a-client".AddRandomSuffix();
+                var capability = new Capability();
+                capability.AddResource(channelName).AllowPresence().AllowPublish();
+                var client = await GetRealtimeClient(protocol, (options, settings) =>
+                {
+                    options.DefaultTokenParams = new TokenParams { Capability = capability, ClientId = clientId };
+                });
+
+                var channel = client.Channels.Get(channelName);
+                var result = await channel.Presence.EnterClientAsync(clientId, null);
+                result.IsSuccess.Should().BeTrue();
+
+                var members = await channel.Presence.GetAsync();
+                members.Should().HaveCount(1);
+                channel.Presence.Map.Members.Should().HaveCount(1);
+                channel.Presence.InternalMap.Members.Should().HaveCount(1);
             }
 
             /*
@@ -587,6 +772,151 @@ namespace IO.Ably.Tests.Realtime
                 {
                     e.ErrorInfo.Code.Should().Be(91005);
                 }
+            }
+
+            [Theory]
+            [ProtocolData]
+            [Trait("spec", "RTP19")]
+            public async Task PresenceMap_WithExistingMembers_WhenSync_ShouldRemoveLocalMembers_RTP19(Protocol protocol)
+            {
+                var channelName = "RTP19".AddRandomSuffix();
+                var client = await GetRealtimeClient(protocol);
+                var channel = client.Channels.Get(channelName);
+
+                // ENTER presence on a channel
+                await channel.Presence.EnterClientAsync("1", "one");
+                await channel.Presence.EnterClientAsync("2", "two");
+                channel.Presence.Map.Members.Should().HaveCount(2);
+
+                var localMessage = new PresenceMessage()
+                {
+                    Action = PresenceAction.Enter,
+                    Id = $"local:0:0",
+                    Timestamp = DateTimeOffset.UtcNow,
+                    ClientId = "local".AddRandomSuffix(),
+                    ConnectionId = "local",
+                    Data = "local data"
+                };
+
+                // inject a member directly into the local PresenceMap
+                channel.Presence.Map.Members[localMessage.MemberKey] = localMessage;
+                channel.Presence.Map.Members.Should().HaveCount(3);
+                channel.Presence.Map.Members.ContainsKey(localMessage.MemberKey).Should().BeTrue();
+
+                var members = (await channel.Presence.GetAsync()).ToArray();
+                members.Should().HaveCount(3);
+                members.Where(m => m.ClientId == "1").Should().HaveCount(1);
+
+                var leaveMessages = new List<PresenceMessage>();
+                await WaitFor(async done =>
+                 {
+                     channel.Presence.Subscribe(PresenceAction.Leave, message =>
+                     {
+                         leaveMessages.Add(message);
+                         done();
+                     });
+
+                     // trigger a server initiated SYNC
+                     var msg = new ProtocolMessage
+                     {
+                         Action = ProtocolMessage.MessageAction.Sync,
+                         Channel = channelName
+                     };
+
+                     await client.FakeProtocolMessageReceived(msg);
+                 });
+
+                // A LEAVE event should have be published for the injected member
+                leaveMessages.Should().HaveCount(1);
+                leaveMessages[0].ClientId.Should().Be(localMessage.ClientId);
+
+                // valid members entered for this connection are still present
+                members = (await channel.Presence.GetAsync()).ToArray();
+                members.Should().HaveCount(2);
+                members.Any(m => m.ClientId == localMessage.ClientId).Should().BeFalse();
+            }
+
+            [Theory]
+            [ProtocolData]
+            [Trait("spec", "RTP19a")]
+            [Trait("spec", "RTP6b")]
+            public async Task PresenceMap_WithExistingMembers_WhenBecomesAttachedWithoutHasPresence_ShouldEmitLeavesForExistingMembers(Protocol protocol)
+            {
+                /* (RTP19a) If the PresenceMap has existing members when an ATTACHED message
+                 is received without a HAS_PRESENCE flag, the client library should emit a
+                 LEAVE event for each existing member, and the PresenceMessage published should
+                 contain the original attributes of the presence member with the action set to LEAVE,
+                 PresenceMessage#id set to null, and the timestamp set to the current time. Once complete,
+                 all members in the PresenceMap should be removed as there are no members present on the channel
+                 */
+
+                var channelName = "RTP19a".AddRandomSuffix();
+                var client = await GetRealtimeClient(protocol);
+                await client.WaitForState();
+                var channel = client.Channels.Get(channelName);
+
+                var localMessage1 = new PresenceMessage()
+                {
+                    Action = PresenceAction.Enter,
+                    Id = $"local:0:1",
+                    Timestamp = DateTimeOffset.UtcNow,
+                    ClientId = "local".AddRandomSuffix(),
+                    ConnectionId = "local",
+                    Data = "local data 1"
+                };
+
+                var localMessage2 = new PresenceMessage()
+                {
+                    Action = PresenceAction.Enter,
+                    Id = $"local:0:2",
+                    Timestamp = DateTimeOffset.UtcNow,
+                    ClientId = "local".AddRandomSuffix(),
+                    ConnectionId = "local",
+                    Data = "local data 2"
+                };
+
+                // inject a members directly into the local PresenceMap
+                channel.Presence.Map.Members[localMessage1.MemberKey] = localMessage1;
+                channel.Presence.Map.Members[localMessage2.MemberKey] = localMessage2;
+                channel.Presence.Map.Members.Should().HaveCount(2);
+
+                bool hasPresence = true;
+                int leaveCount = 0;
+                await WaitForMultiple(4, partialDone =>
+                {
+                    client.GetTestTransport().AfterDataReceived += message =>
+                    {
+                        if (message.Action == ProtocolMessage.MessageAction.Attached)
+                        {
+                            hasPresence = message.HasFlag(ProtocolMessage.Flag.HasPresence);
+                            partialDone();
+                        }
+                    };
+
+                    // (RTP6b) Subscribe with a single action argument
+                    channel.Presence.Subscribe(PresenceAction.Leave, leaveMsg =>
+                    {
+                        leaveMsg.ClientId.Should().StartWith("local");
+                        leaveMsg.Action.Should().Be(PresenceAction.Leave, "Action shold be leave");
+                        leaveMsg.Timestamp.Should().BeCloseTo(DateTime.UtcNow, 200, "timestamp should be current time" );
+                        leaveMsg.Id.Should().BeNull("Id should be null");
+                        leaveCount++;
+                        partialDone(); // should be called twice
+                    });
+
+                    channel.Attach((b, info) =>
+                    {
+                        b.Should().BeTrue();
+                        info.Should().BeNull();
+                        partialDone();
+                    });
+                });
+
+                hasPresence.Should().BeFalse("ATTACHED message was received without a HAS_PRESENCE flag");
+                leaveCount.Should().Be(2, "should emit a LEAVE event for each existing member");
+
+                var members = await channel.Presence.GetAsync();
+                members.Should().HaveCount(0, "should be no members");
             }
 
             [Theory]

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -1097,6 +1097,134 @@ namespace IO.Ably.Tests.Realtime
 
                 exHandled.Should().BeFalse();
             }
+
+            [Trait("spec", "RTP5")]
+            public class ChannelStatechangeSideEffects : PresenceSandboxSpecs
+            {
+                public ChannelStatechangeSideEffects(AblySandboxFixture fixture, ITestOutputHelper output)
+                    : base(fixture, output)
+                {
+                }
+
+                [Theory]
+                [ProtocolData(ChannelState.Failed)]
+                [ProtocolData(ChannelState.Detached)]
+                [Trait("spec", "RTP5a")]
+                public async Task WhenChannelBecomesFailedOrDetached_QueuedPresenceMessagesShouldFail(Protocol protocol, ChannelState channelState)
+                {
+                    var client = await GetRealtimeClient(protocol);
+                    await client.WaitForState();
+
+                    var channel = client.Channels.Get("RTP5a".AddRandomSuffix()) as RealtimeChannel;
+
+                    int initialCount = 0;
+                    bool? success = null;
+                    ErrorInfo errInfo = null;
+                    await WaitForMultiple(2, partialDone =>
+                    {
+                        // insert an error when attaching
+                        channel.Once(ChannelEvent.Attaching, args =>
+                        {
+                             // before we change the state capture proof that we have a queued message
+                             initialCount = channel.Presence.PendingPresenceQueue.Count;
+                             channel.SetChannelState(channelState, new ErrorInfo("RTP5a test"));
+                             partialDone();
+                        });
+
+                        // enter client, this should trigger attach
+                        channel.Presence.EnterClient("123", null, (b, info) =>
+                        {
+                            success = b;
+                            errInfo = info;
+                            partialDone();
+                        });
+                    });
+
+                    initialCount.Should().Be(1, "a presence message should have been queued");
+                    success.Should().HaveValue("EnterClient callback should have executed");
+                    success.Value.Should().BeFalse("queued presence message should have failed immediately");
+                    errInfo.Message.Should().Be("RTP5a test");
+                    channel.Presence.PendingPresenceQueue.Should().HaveCount(0, "presence message queue should have been cleared");
+
+                    client.Close();
+                }
+
+                [Theory]
+                [ProtocolData(ChannelState.Failed)]
+                [ProtocolData(ChannelState.Detached)]
+                [Trait("spec", "RTP5a")]
+                public async Task WhenChannelBecomesFailedOrDetached_ShouldClearPresenceMapAndShouldNotEmitEvents(Protocol protocol, ChannelState channelState)
+                {
+                    var client = await GetRealtimeClient(protocol);
+                    await client.WaitForState();
+
+                    var channel = client.Channels.Get("RTP5a".AddRandomSuffix()) as RealtimeChannel;
+                    var result = await channel.Presence.EnterClientAsync("123", null);
+                    result.IsSuccess.Should().BeTrue();
+
+                    channel.Presence.Map.Members.Should().HaveCount(1);
+                    channel.Presence.InternalMap.Members.Should().HaveCount(1);
+
+                    bool didReceiveMessage = false;
+                    channel.Subscribe(msg => { didReceiveMessage = true; });
+                    didReceiveMessage.Should().BeFalse("No events should be emitted");
+
+                    channel.SetChannelState(channelState, new ErrorInfo("RTP5a test"));
+
+                    await channel.WaitForState(channelState);
+
+                    channel.Presence.Map.Members.Should().HaveCount(0);
+                    channel.Presence.InternalMap.Members.Should().HaveCount(0);
+
+                    client.Close();
+                }
+
+                [Theory]
+                [ProtocolData]
+                [Trait("spec", "RTP5b")]
+                public async Task WhenChannelBecomesAttached_ShouldSendQueuedMessagesAndInitiateSYNC(Protocol protocol)
+                {
+                    var client1 = await GetRealtimeClient(protocol);
+                    var client2 = await GetRealtimeClient(protocol);
+
+                    await client1.WaitForState();
+                    await client2.WaitForState();
+
+                    var channel1 = client1.Channels.Get("RTP5b_ch1".AddRandomSuffix());
+                    var result = await channel1.Presence.EnterClientAsync("client1", null);
+                    result.IsFailure.Should().BeFalse();
+
+                    var channel2 = client2.Channels.Get(channel1.Name);
+                    var presence2 = channel2.Presence;
+
+                    await WaitForMultiple(2, partialDone =>
+                    {
+                        presence2.EnterClient("client2", null, (b, info) =>
+                        {
+                            presence2.PendingPresenceQueue.Should().HaveCount(0);
+                            partialDone();
+                        });
+
+                        presence2.Subscribe(PresenceAction.Enter, msg =>
+                        {
+                            presence2.Map.Members.Should().HaveCount(presence2.SyncComplete ? 2 : 1);
+                            presence2.Unsubscribe();
+                            partialDone();
+                        });
+
+                        presence2.PendingPresenceQueue.Should().HaveCount(1);
+                        presence2.SyncComplete.Should().BeFalse();
+                        presence2.Map.Members.Should().HaveCount(0);
+                    });
+
+                    var transport = client2.GetTestTransport();
+                    transport.ProtocolMessagesReceived.Any(m => m.Action == ProtocolMessage.MessageAction.Sync).Should().BeTrue();
+                    presence2.SyncComplete.Should().BeTrue();
+                    presence2.Map.Members.Should().HaveCount(2);
+
+                    client1.Close();
+                }
+            }
         }
 
         public class With250PresentMembersOnAChannel : PresenceSandboxSpecs

--- a/src/IO.Ably.Tests.Shared/Rest/SandboxSpec.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/SandboxSpec.cs
@@ -69,6 +69,26 @@ namespace IO.Ably.Tests
             return new AblyRealtime(defaultOptions, createRestFunc);
         }
 
+        protected async Task WaitFor(Action<Action> done)
+        {
+            await TestHelpers.WaitFor(10000, 1, done);
+        }
+
+        protected async Task WaitFor(int timeoutMs, Action<Action> done)
+        {
+            await TestHelpers.WaitFor(timeoutMs, 1, done);
+        }
+
+        protected async Task WaitFor(int timeoutMs, int taskCount, Action<Action> done)
+        {
+            await TestHelpers.WaitFor(timeoutMs, taskCount, done);
+        }
+
+        protected async Task WaitForMultiple(int taskCount, Action<Action> done)
+        {
+            await TestHelpers.WaitFor(10000, taskCount, done);
+        }
+
         public class OutputLoggerSink : ILoggerSink
         {
             private readonly ITestOutputHelper _output;


### PR DESCRIPTION
Implements RTP11 with tests

(RTP11) Presence#get function:
- (RTP11a) Returns the list of current members on the channel in a callback. By default, will wait for the SYNC to be completed, see RTP11c1
- (RTP11b) Implicitly attaches the Channel if the channel is in the INITIALIZED state. However, if the channel is in or enters the DETACHED or FAILED state before the operation succeeds, it will result in an error
- (RTP11d) If the Channel is in the SUSPENDED state then the get function will by default, or if waitForSync is set to true, result in an error with code 91005 and a message stating that the presence state is out of sync due to the channel being in a SUSPENDED state. If however the get function is called with waitForSync set to false, then it immediately returns the members currently stored in the PresenceMap giving developers access to the members that were present at the time the channel became SUSPENDED
- (RTP11c) An optional set of params can be provided:
    - (RTP11c1) waitForSync (default true). When true, method will wait until SYNC is complete before returning a list of members. When false, known set of presence members is returned immediately, which may be incomplete if the SYNC is not finished
    - (RTP11c2) clientId filters members by the provided clientId
    - (RTP11c3) connectionId filters members by the provided connectionId

RTP11a "Returns the list of current members on the channel in a callback" - async/await is used so there is no callback as such. Async/await is more idiomatic and acheives the same result, but wrapper methods could be added if it is felt having a callback is important.
