### PR TITLE
RTP19, RTP19a RTP6b

### DIFF
--- a/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
+++ b/src/IO.Ably.Shared/Extensions/PresenceExtensions.cs
@@ -4,7 +4,7 @@
     {
         public static bool IsSynthesized(this PresenceMessage msg)
         {
-            return !msg.Id.StartsWith(msg.ConnectionId);
+            return msg.Id == null || !msg.Id.StartsWith(msg.ConnectionId);
         }
 
         public static bool IsNewerThan(this PresenceMessage thisMessage, PresenceMessage thatMessage)

--- a/src/IO.Ably.Shared/Realtime/ChannelStateChangedEventArgs.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelStateChangedEventArgs.cs
@@ -1,14 +1,16 @@
 ﻿using System;
+using IO.Ably.Types;
 
 namespace IO.Ably.Realtime
 {
     public class ChannelStateChange : EventArgs
     {
-        public ChannelStateChange(ChannelState state, ChannelState previous, ErrorInfo error = null)
+        public ChannelStateChange(ChannelState state, ChannelState previous, ErrorInfo error = null, bool resumed = false)
         {
             Previous = previous;
             Current = state;
             Error = error;
+            Resumed = resumed;
         }
 
         public ChannelState Previous { get; }
@@ -16,5 +18,9 @@ namespace IO.Ably.Realtime
         public ChannelState Current { get; }
 
         public ErrorInfo Error { get; }
+
+        public bool Resumed { get;  }
+
+        internal ProtocolMessage ProtocolMessage { get; set; } = null;
     }
 }

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -201,7 +201,7 @@ namespace IO.Ably.Realtime
 
         public void Subscribe(Action<PresenceMessage> handler)
         {
-            if ((_channel.State != ChannelState.Attached) && (_channel.State != ChannelState.Attaching))
+            if (_channel.State != ChannelState.Attached && _channel.State != ChannelState.Attaching)
             {
                 _channel.Attach();
             }

--- a/src/IO.Ably.Shared/Realtime/PresenceMap.cs
+++ b/src/IO.Ably.Shared/Realtime/PresenceMap.cs
@@ -23,6 +23,11 @@ namespace IO.Ably.Realtime
             Failed
         }
 
+        /// <summary>
+        /// Exposed internally to allow for testing
+        /// </summary>
+        internal ConcurrentDictionary<string, PresenceMessage> Members => _members;
+
         private readonly ConcurrentDictionary<string, PresenceMessage> _members;
         private ICollection<string> _residualMembers;
         private bool _isSyncInProgress;

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -622,5 +622,18 @@ namespace IO.Ably.Realtime
 
             ConnectionManager.Send(protocolMessage, callback, Options);
         }
+
+        /// <summary>
+        /// Emits an UPDATE if the channel is ATTACHED
+        /// </summary>
+        /// <param name="errorInfo"></param>
+        /// <param name="resumed"></param>
+        internal void EmitUpdate(ErrorInfo errorInfo, bool resumed)
+        {
+            if (State == ChannelState.Attached)
+            {
+                Emit(ChannelEvent.Update, new ChannelStateChange(State, State, errorInfo, resumed));
+            }
+        }
     }
 }

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -434,7 +434,7 @@ namespace IO.Ably.Realtime
 
             HandleStateChange(state, error, protocolMessage);
 
-            InternalStateChanged.Invoke(this, new ChannelStateChange(state, previousState, error));
+            InternalStateChanged.Invoke(this, new ChannelStateChange(state, previousState, error) { ProtocolMessage = protocolMessage });
 
             // Notify external client using the thread they subscribe on
             RealtimeClient.NotifyExternalClients(() =>

--- a/src/IO.Ably.Tests.Shared/Infrastructure/TestHelpers.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/TestHelpers.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Threading.Tasks;
+using IO.Ably.Tests.Infrastructure;
 using Xunit;
 
 namespace IO.Ably.Tests
@@ -21,6 +23,29 @@ namespace IO.Ably.Tests
         public static Func<DateTimeOffset> NowFunc()
         {
             return Defaults.NowFunc();
+        }
+
+        public static async Task WaitFor(int timeoutMs, int taskCount, Action<Action> action)
+        {
+            var tsc = new TaskCompletionAwaiter(timeoutMs, taskCount);
+
+            void Done()
+            {
+                tsc.Tick();
+            }
+
+            action(Done);
+            var success = await tsc.Task;
+            if (!success)
+            {
+                var msg = $"Timeout of {timeoutMs}ms exceeed.";
+                if (taskCount > 1)
+                {
+                    msg += $" Completed {taskCount - tsc.TaskCount} of {taskCount} tasks.";
+                }
+
+                throw new Exception(msg);
+            }
         }
     }
 }

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using IO.Ably.Realtime;
 using IO.Ably.Tests.Infrastructure;
+using IO.Ably.Transport;
 using IO.Ably.Transport.States.Connection;
 using IO.Ably.Types;
 using Xunit;
@@ -587,6 +588,138 @@ namespace IO.Ably.Tests.Realtime
                 {
                     e.ErrorInfo.Code.Should().Be(91005);
                 }
+            }
+
+            [Theory]
+            [ProtocolData]
+            [Trait("spec", "RTP19")]
+            public async Task PresenceMap_WithExistingMembers_WhenSync_ShouldRemoveLocalMembers_RTP19(Protocol protocol)
+            {
+                var channelName = "RTP19".AddRandomSuffix();
+                var client = await GetRealtimeClient(protocol);
+
+                var channel = client.Channels.Get(channelName);
+                await channel.Presence.EnterClientAsync("1", "one");
+                await channel.Presence.EnterClientAsync("2", "two");
+
+                channel.Presence.Map.Members.Should().HaveCount(2);
+
+                var localMessage = new PresenceMessage()
+                {
+                    Action = PresenceAction.Enter,
+                    Id = $"local:0:0",
+                    Timestamp = DateTimeOffset.UtcNow,
+                    ClientId = "local".AddRandomSuffix(),
+                    ConnectionId = "local",
+                    Data = "local data"
+                };
+
+                channel.Presence.Map.Members[localMessage.MemberKey] = localMessage;
+                channel.Presence.Map.Members.Should().HaveCount(3);
+                channel.Presence.Map.Members.ContainsKey(localMessage.MemberKey).Should().BeTrue();
+
+                var members = (await channel.Presence.GetAsync()).ToArray();
+                members.Should().HaveCount(3);
+                members.Where(m => m.ClientId == "1").Should().HaveCount(1);
+
+                var leaveMessages = new List<PresenceMessage>();
+                await WaitFor(async done =>
+                 {
+                     channel.Presence.Subscribe(PresenceAction.Leave, message =>
+                     {
+                         leaveMessages.Add(message);
+                         done();
+                     });
+
+                     var msg = new ProtocolMessage
+                     {
+                         Action = ProtocolMessage.MessageAction.Sync,
+                         Channel = channelName
+                     };
+
+                     await client.FakeProtocolMessageReceived(msg);
+                 });
+
+                leaveMessages.Should().HaveCount(1);
+                leaveMessages[0].ClientId.Should().Be(localMessage.ClientId);
+
+                members = (await channel.Presence.GetAsync()).ToArray();
+                members.Should().HaveCount(2);
+                members.Any(m => m.ClientId == localMessage.ClientId).Should().BeFalse();
+            }
+
+            [Theory]
+            [ProtocolData]
+            [Trait("spec", "RTP19a")]
+            [Trait("spec", "RTP6b")]
+            public async Task PresenceMap_WithExistingMembers_WhenBecomesAttachedWithoutHasPresence_ShouldEmitLeavesForExistingMembers(Protocol protocol)
+            {
+                var channelName = "RTP19a".AddRandomSuffix();
+                var client = await GetRealtimeClient(protocol);
+                await client.WaitForState();
+                var channel = client.Channels.Get(channelName);
+
+                var localMessage1 = new PresenceMessage()
+                {
+                    Action = PresenceAction.Enter,
+                    Id = $"local:0:1",
+                    Timestamp = DateTimeOffset.UtcNow,
+                    ClientId = "local".AddRandomSuffix(),
+                    ConnectionId = "local",
+                    Data = "local data 1"
+                };
+
+                var localMessage2 = new PresenceMessage()
+                {
+                    Action = PresenceAction.Enter,
+                    Id = $"local:0:2",
+                    Timestamp = DateTimeOffset.UtcNow,
+                    ClientId = "local".AddRandomSuffix(),
+                    ConnectionId = "local",
+                    Data = "local data 2"
+                };
+
+                channel.Presence.Map.Members[localMessage1.MemberKey] = localMessage1;
+                channel.Presence.Map.Members[localMessage2.MemberKey] = localMessage2;
+                channel.Presence.Map.Members.Should().HaveCount(2);
+
+                bool hasPresence = true;
+                int leaveCount = 0;
+                await WaitForMultiple(4, partialDone =>
+                {
+                    client.GetTestTransport().AfterDataReceived += message =>
+                    {
+                        if (message.Action == ProtocolMessage.MessageAction.Attached)
+                        {
+                            hasPresence = message.HasFlag(ProtocolMessage.Flag.HasPresence);
+                            partialDone();
+                        }
+                    };
+
+                    // (RTP6b) Subscribe with a single action argument
+                    channel.Presence.Subscribe(PresenceAction.Leave, leaveMsg =>
+                    {
+                        leaveMsg.ClientId.Should().StartWith("local");
+                        leaveMsg.Action.Should().Be(PresenceAction.Leave);
+                        leaveMsg.Timestamp.Should().BeCloseTo(DateTime.UtcNow, 200);
+                        leaveMsg.Id.Should().BeNull();
+                        leaveCount++;
+                        partialDone(); // should be called twice
+                    });
+
+                    channel.Attach((b, info) =>
+                    {
+                        b.Should().BeTrue();
+                        info.Should().BeNull();
+                        partialDone();
+                    });
+                });
+
+                hasPresence.Should().BeFalse();
+                leaveCount.Should().Be(2);
+
+                var members = await channel.Presence.GetAsync();
+                members.Should().HaveCount(0);
             }
 
             [Theory]

--- a/src/IO.Ably.Tests.Shared/Rest/SandboxSpec.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/SandboxSpec.cs
@@ -69,6 +69,26 @@ namespace IO.Ably.Tests
             return new AblyRealtime(defaultOptions, createRestFunc);
         }
 
+        protected async Task WaitFor(Action<Action> done)
+        {
+            await TestHelpers.WaitFor(10000, 1, done);
+        }
+
+        protected async Task WaitFor(int timeoutMs, Action<Action> done)
+        {
+            await TestHelpers.WaitFor(timeoutMs, 1, done);
+        }
+
+        protected async Task WaitFor(int timeoutMs, int taskCount, Action<Action> done)
+        {
+            await TestHelpers.WaitFor(timeoutMs, taskCount, done);
+        }
+
+        protected async Task WaitForMultiple(int taskCount, Action<Action> done)
+        {
+            await TestHelpers.WaitFor(10000, taskCount, done);
+        }
+
         public class OutputLoggerSink : ILoggerSink
         {
             private readonly ITestOutputHelper _output;


### PR DESCRIPTION
Changes and tests for 

- (RTP19) If the PresenceMap has existing members when a SYNC is started, the client library must ensure that members no longer present on the channel are removed from the local PresenceMap once the sync is complete. In order to do this, the client library must keep track of any members that have not been added or updated in the PresenceMap during the sync process. Note that a member can be added or updated when received in a SYNC message or when received in a PRESENCE message during the sync process. Once the sync is complete, the members in the PresenceMap that have not been added or updated should be removed from the PresenceMap and a LEAVE event should be published for each. The PresenceMessage published should contain the original attributes of the presence member with the action set to LEAVE, PresenceMessage#id set to null, and the timestamp set to the current time. This behaviour should be tested as follows: ENTER presence on a channel, wait for SYNC to complete, inject a member directly into the local PresenceMap so that it only exists locally and not on the server, send a SYNC message with the channel attribute populated with the current channel which will trigger a server initiated SYNC. A LEAVE event should then be published for the injected member, and checking the PresenceMap should reveal that the member was removed and the valid member entered for this connection is still present
- - (RTP19a) If the PresenceMap has existing members when an ATTACHED message is received without a HAS_PRESENCE flag, the client library should emit a LEAVE event for each existing member, and the PresenceMessage published should contain the original attributes of the presence member with the action set to LEAVE, PresenceMessage#id set to null, and the timestamp set to the current time. Once complete, all members in the PresenceMap should be removed as there are no members present on the channel

Also

- (RTP6b) Subscribe with a single action argument – such as ENTER, LEAVE, UPDATE or PRESENT – subscribes a listener to receive only presence messages with that action		
