### PR TITLE
RTP17 and RTP17a tests

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -52,6 +52,12 @@ namespace IO.Ably.Realtime
             SyncComplete = true;
         }
 
+        internal bool InternalSyncComplete => !Map.IsSyncInProgress && SyncComplete;
+
+        internal PresenceMap Map { get; }
+
+        internal PresenceMap InternalMap { get; }
+
         internal Presence(IConnectionManager connection, RealtimeChannel channel, string cliendId, ILogger logger)
         {
             Logger = logger;
@@ -64,12 +70,6 @@ namespace IO.Ably.Realtime
             _channel.InternalStateChanged += OnChannelStateChanged;
             _clientId = cliendId;
         }
-
-        internal bool InternalSyncComplete => !Map.IsSyncInProgress && SyncComplete;
-
-        internal PresenceMap Map { get; }
-
-        internal PresenceMap InternalMap { get; }
 
         public void Dispose()
         {


### PR DESCRIPTION

- (RTP17) The Presence object is also responsible for keeping a separate copy of an object logically equivalent to the PresenceMap containing only members that match the current connectionId. Any ENTER, PRESENT, UPDATE or LEAVE event that matches the current connectionId should be applied to this object in the same way it is done for the PresenceMap. This object should be private and is used to maintain a list of members that need to be automatically re-entered by the Presence object when a Channel becomes ATTACHED with some or all continuity lost.
- -  (RTP17a) All members belonging to the current connection are published as a PresenceMessage on the Channel by the server irrespective of whether the client has permission to subscribe or the Channel is configured to publish presence events. A test should exist that attaches to a Channel with a presence capability and without a subscribe capability. It should then enter the Channel and ensure that the member entered from the current connection is present in the internal and public presence set available via Presence#get

