### PR TITLE
RTP5a & RTP5b

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -308,8 +308,8 @@ namespace IO.Ably.Realtime
             switch (_channel.State)
             {
                 case ChannelState.Initialized:
-                    _channel.Attach();
                     PendingPresenceQueue.Enqueue(new QueuedPresenceMessage(msg, callback));
+                    _channel.Attach();
                     break;
                 case ChannelState.Attaching:
                     PendingPresenceQueue.Enqueue(new QueuedPresenceMessage(msg, callback));

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -20,7 +21,7 @@ namespace IO.Ably.Realtime
         private readonly Handlers<PresenceMessage> _handlers = new Handlers<PresenceMessage>();
 
         private readonly IConnectionManager _connection;
-        private readonly List<QueuedPresenceMessage> _pendingPresence;
+        private readonly ConcurrentQueue<QueuedPresenceMessage> _pendingPresenceQueue;
 
         private string _currentSyncChannelSerial;
         private bool _syncAsResultOfAttach;
@@ -63,7 +64,7 @@ namespace IO.Ably.Realtime
             Logger = logger;
             Map = new PresenceMap(channel.Name, logger);
             InternalMap = new PresenceMap(channel.Name, logger);
-            _pendingPresence = new List<QueuedPresenceMessage>();
+            _pendingPresenceQueue = new ConcurrentQueue<QueuedPresenceMessage>();
             _connection = connection;
             _connection.Connection.ConnectionStateChanged += OnConnectionStateChanged;
             _channel = channel;
@@ -307,10 +308,10 @@ namespace IO.Ably.Realtime
             {
                 case ChannelState.Initialized:
                     _channel.Attach();
-                    _pendingPresence.Add(new QueuedPresenceMessage(msg, callback));
+                    _pendingPresenceQueue.Enqueue(new QueuedPresenceMessage(msg, callback));
                     break;
                 case ChannelState.Attaching:
-                    _pendingPresence.Add(new QueuedPresenceMessage(msg, callback));
+                    _pendingPresenceQueue.Enqueue(new QueuedPresenceMessage(msg, callback));
                     break;
                 case ChannelState.Attached:
                     var message = new ProtocolMessage(ProtocolMessage.MessageAction.Presence, _channel.Name);
@@ -585,25 +586,27 @@ namespace IO.Ably.Realtime
 
         private void SendQueuedMessages()
         {
-            if (_pendingPresence.Count == 0)
+            if (_pendingPresenceQueue.Count == 0)
             {
                 return;
             }
 
             var message = new ProtocolMessage(ProtocolMessage.MessageAction.Presence, _channel.Name);
-            message.Presence = new PresenceMessage[_pendingPresence.Count];
+            message.Presence = new PresenceMessage[_pendingPresenceQueue.Count];
             var callbacks = new List<Action<bool, ErrorInfo>>();
             var i = 0;
-            foreach (var presenceMessage in _pendingPresence)
+
+            while (!_pendingPresenceQueue.IsEmpty)
             {
-                message.Presence[i++] = presenceMessage.Message;
-                if (presenceMessage.Callback != null)
+                if (_pendingPresenceQueue.TryDequeue(out var queuedPresenceMessage))
                 {
-                    callbacks.Add(presenceMessage.Callback);
+                    message.Presence[i++] = queuedPresenceMessage.Message;
+                    if (queuedPresenceMessage.Callback != null)
+                    {
+                        callbacks.Add(queuedPresenceMessage.Callback);
+                    }
                 }
             }
-
-            _pendingPresence.Clear();
 
             _connection.Send(message, (s, e) =>
             {
@@ -616,12 +619,13 @@ namespace IO.Ably.Realtime
 
         private void FailQueuedMessages(ErrorInfo reason)
         {
-            foreach (var presenceMessage in _pendingPresence.Where(c => c.Callback != null))
+            while (!_pendingPresenceQueue.IsEmpty)
             {
-                presenceMessage.Callback(false, reason);
+                if (_pendingPresenceQueue.TryDequeue(out var queuedPresenceMessage))
+                {
+                    queuedPresenceMessage.Callback?.Invoke(false, reason);
+                }
             }
-
-            _pendingPresence.Clear();
         }
 
         public Task<PaginatedResult<PresenceMessage>> HistoryAsync(bool untilAttach = false)

--- a/src/IO.Ably.Tests.Shared/Infrastructure/ProtocolData.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/ProtocolData.cs
@@ -1,17 +1,36 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
+using Xunit;
 using Xunit.Sdk;
 
 namespace IO.Ably.Tests
 {
     public class ProtocolDataAttribute : DataAttribute
     {
+        private readonly object[] _data;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProtocolDataAttribute"/> class.
+        /// </summary>
+        /// <param name="data">The data values to pass to the theory.</param>
+        public ProtocolDataAttribute(params object[] data)
+        {
+            _data = data;
+        }
+
+        /// <inheritdoc/>
         public override IEnumerable<object[]> GetData(MethodInfo testMethod)
         {
-            yield return new object[] { Protocol.Json };
+            var d = new List<object> { Protocol.Json };
+            d.AddRange(_data);
+            yield return d.ToArray();
+
             if (Config.MsgPackEnabled)
             {
-                yield return new object[] { Defaults.Protocol };
+                d = new List<object> { Defaults.Protocol };
+                d.AddRange(_data);
+                yield return d.ToArray();
             }
         }
     }

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -1121,24 +1121,24 @@ namespace IO.Ably.Tests.Realtime
                     bool? success = null;
                     ErrorInfo errInfo = null;
                     await WaitForMultiple(2, partialDone =>
-                     {
-                         // insert an error when attaching
-                         channel.Once(ChannelEvent.Attached, args =>
-                         {
+                    {
+                        // insert an error when attaching
+                        channel.Once(ChannelEvent.Attaching, args =>
+                        {
+                             // before we change the state capture proof that we have a queued message
+                             initialCount = channel.Presence.PendingPresenceQueue.Count;
                              channel.SetChannelState(channelState, new ErrorInfo("RTP5a test"));
                              partialDone();
-                         });
+                        });
 
-                         // enter client, this should trigger attach
-                         channel.Presence.EnterClient("123", null, (b, info) =>
-                         {
-                             success = b;
-                             errInfo = info;
-                             partialDone();
-                         });
-
-                         initialCount = channel.Presence.PendingPresenceQueue.Count;
-                     });
+                        // enter client, this should trigger attach
+                        channel.Presence.EnterClient("123", null, (b, info) =>
+                        {
+                            success = b;
+                            errInfo = info;
+                            partialDone();
+                        });
+                    });
 
                     initialCount.Should().Be(1, "a presence message should have been queued");
                     success.Should().HaveValue("EnterClient callback should have executed");

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -1110,7 +1110,7 @@ namespace IO.Ably.Tests.Realtime
                 [ProtocolData(ChannelState.Failed)]
                 [ProtocolData(ChannelState.Detached)]
                 [Trait("spec", "RTP5a")]
-                public async Task WhenChannelBecomesFailed_QueuedPresenceMessagesShouldFail(Protocol protocol, ChannelState channelState)
+                public async Task WhenChannelBecomesFailedOrDetached_QueuedPresenceMessagesShouldFail(Protocol protocol, ChannelState channelState)
                 {
                     var client = await GetRealtimeClient(protocol);
                     await client.WaitForState();
@@ -1153,7 +1153,7 @@ namespace IO.Ably.Tests.Realtime
                 [ProtocolData(ChannelState.Failed)]
                 [ProtocolData(ChannelState.Detached)]
                 [Trait("spec", "RTP5a")]
-                public async Task WhenChannelBecomesFailed_ShouldClearPresenceMapAndShouldNotEmitEvents(Protocol protocol, ChannelState channelState)
+                public async Task WhenChannelBecomesFailedOrDetached_ShouldClearPresenceMapAndShouldNotEmitEvents(Protocol protocol, ChannelState channelState)
                 {
                     var client = await GetRealtimeClient(protocol);
                     await client.WaitForState();


### PR DESCRIPTION
- (RTP5a) If the channel enters the DETACHED or FAILED state then all queued presence messages will fail immediately, and the PresenceMap and internal PresenceMap (see RTP17) is cleared. The latter ensures members are not automatically re-entered if the Channel later becomes attached. Since channels in the DETACHED and FAILED states will not receive any presence updates from Ably, presence events (specifically LEAVE) should not be emitted when the PresenceMap is cleared as each presence member's state is unknown		

- (RTP5b) If a channel enters the ATTACHED state then all queued presence messages will be sent immediately and a presence SYNC may be initiated by the Ably service or the Ably service may indicate there is no SYNC necessary		