### PR TITLE
RTP16b

### DIFF
--- a/src/IO.Ably.Shared/AblyAuth.cs
+++ b/src/IO.Ably.Shared/AblyAuth.cs
@@ -225,22 +225,23 @@ namespace IO.Ably
                     else
                     {
                         shouldCatch = false;
-                        throw new AblyException($"AuthCallback returned an unsupported type ({callbackResult.GetType()}. Expected either TokenDetails or TokenRequest", 80019);
+                        throw new AblyException($"AuthCallback returned an unsupported type ({callbackResult.GetType()}. Expected either TokenDetails or TokenRequest", 80019, HttpStatusCode.BadRequest);
                     }
                 }
                 catch (Exception ex) when (shouldCatch)
                 {
-                    HttpStatusCode? statusCode = null;
-                    int code = 80019;
-                    if (ex is AblyException ablyException)
+                    var statusCode = HttpStatusCode.Unauthorized;
+                    if (ex is AblyException aex)
                     {
-                        statusCode = ablyException.ErrorInfo.StatusCode;
-                        code = ablyException.ErrorInfo.Code == 40300 ? ablyException.ErrorInfo.Code : 80019;
+                        statusCode = aex.ErrorInfo.StatusCode == HttpStatusCode.Forbidden
+                            ? HttpStatusCode.Forbidden
+                            : HttpStatusCode.Unauthorized;
                     }
 
                     throw new AblyException(
                         new ErrorInfo(
-                        "Error calling AuthCallback, token request failed. See inner exception for details.", code, statusCode), ex);
+                        "Error calling AuthCallback, token request failed. See inner exception for details.", 80019,
+                        statusCode), ex);
                 }
             }
             else if (mergedOptions.AuthUrl.IsNotEmpty())
@@ -272,8 +273,8 @@ namespace IO.Ably
                     throw new AblyException(
                         new ErrorInfo(
                             "Error calling Auth URL, token request failed. See the InnerException property for details of the underlying exception.",
-                            ex.ErrorInfo.Code == 40300 ? ex.ErrorInfo.Code : 80019,
-                            ex.ErrorInfo.StatusCode),
+                            80019,
+                            ex.ErrorInfo.StatusCode == HttpStatusCode.Forbidden ? ex.ErrorInfo.StatusCode : HttpStatusCode.Unauthorized),
                         ex);
                 }
             }

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -323,11 +323,19 @@ namespace IO.Ably.Realtime
             switch (_channel.State)
             {
                 case ChannelState.Initialized:
-                    PendingPresenceQueue.Enqueue(new QueuedPresenceMessage(msg, callback));
-                    _channel.Attach();
+                    if (_connection.Options.QueueMessages)
+                    {
+                        PendingPresenceQueue.Enqueue(new QueuedPresenceMessage(msg, callback));
+                        _channel.Attach();
+                    }
+
                     break;
                 case ChannelState.Attaching:
-                    PendingPresenceQueue.Enqueue(new QueuedPresenceMessage(msg, callback));
+                    if (_connection.Options.QueueMessages)
+                    {
+                        PendingPresenceQueue.Enqueue(new QueuedPresenceMessage(msg, callback));
+                    }
+
                     break;
                 case ChannelState.Attached:
                     var message = new ProtocolMessage(ProtocolMessage.MessageAction.Presence, _channel.Name);

--- a/src/IO.Ably.Shared/Transport/ConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionManager.cs
@@ -282,7 +282,7 @@ namespace IO.Ably.Transport
             {
                 if (ShouldWeRenewToken(error))
                 {
-                    await RetryAuthentication();
+                    await RetryAuthentication(updateState: true);
                 }
                 else
                 {
@@ -295,11 +295,19 @@ namespace IO.Ably.Transport
             return false;
         }
 
-        public async Task RetryAuthentication()
+        public async Task RetryAuthentication(bool updateState = true)
         {
             ClearTokenAndRecordRetry();
-            await SetState(new ConnectionDisconnectedState(this, Logger), skipAttach: ConnectionState == Realtime.ConnectionState.Connecting);
-            await SetState(new ConnectionConnectingState(this, Logger));
+            if (updateState)
+            {
+                await SetState(new ConnectionDisconnectedState(this, Logger),
+                    skipAttach: ConnectionState == Realtime.ConnectionState.Connecting);
+                await SetState(new ConnectionConnectingState(this, Logger));
+            }
+            else
+            {
+                await RestClient.AblyAuth.AuthorizeAsync();
+            }
         }
 
         public void CloseConnection()

--- a/src/IO.Ably.Shared/Transport/IConnectionContext.cs
+++ b/src/IO.Ably.Shared/Transport/IConnectionContext.cs
@@ -37,7 +37,7 @@ namespace IO.Ably.Transport
 
         Task<bool> RetryBecauseOfTokenError(ErrorInfo error);
 
-        Task RetryAuthentication();
+        Task RetryAuthentication(bool updateState = true);
 
         void HandleConnectingFailure(ErrorInfo error, Exception ex);
 

--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionConnectedState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionConnectedState.cs
@@ -33,7 +33,7 @@ namespace IO.Ably.Transport.States.Connection
             switch (message.Action)
             {
                 case ProtocolMessage.MessageAction.Auth:
-                    await Context.RetryAuthentication();
+                    Context.RetryAuthentication(updateState: false);
                     return true;
                 case ProtocolMessage.MessageAction.Connected:
                     await Context.SetState(new ConnectionConnectedState(Context, new ConnectionInfo(message), message.Error, Logger) { IsUpdate = true });

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
@@ -412,8 +412,8 @@ namespace IO.Ably.Tests
                 };
             }
 
-            await Test403BecomesFailed("With 403 response connection should become Failed", 40300, AuthUrlOptions);
-            await Test403BecomesFailed("With ErrorInfo with StatusCode of 403 connection should become Failed", 40300, AuthCallbackOptions);
+            await Test403BecomesFailed("With 403 response connection should become Failed", expectedCode: 80019, optionsAction: AuthUrlOptions);
+            await Test403BecomesFailed("With ErrorInfo with StatusCode of 403 connection should become Failed", expectedCode: 80019, optionsAction: AuthCallbackOptions);
         }
 
         [Theory]

--- a/src/IO.Ably.Tests.Shared/Infrastructure/FakeConnectionContext.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/FakeConnectionContext.cs
@@ -147,7 +147,7 @@ namespace IO.Ably.Tests
             return RetryFunc(error);
         }
 
-        public Task RetryAuthentication()
+        public Task RetryAuthentication(bool updateState = true)
         {
             throw new NotImplementedException();
         }

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -985,12 +985,8 @@ namespace IO.Ably.Tests.Realtime
         [Theory]
         [ProtocolData]
         [Trait("spec", "RTN22")]
-        public async Task WhenFakeAuthMessageReceived_ShouldAttemptTokenRenewal(Protocol protocol)
+        public async Task WhenAuthMessageReceived_ShouldAttemptTokenRenewal(Protocol protocol)
         {
-            var authClient = await GetRestClient(protocol);
-            var almostExpiredToken = await authClient.AblyAuth.RequestTokenAsync(new TokenParams { ClientId = "123", Ttl = TimeSpan.FromMilliseconds(35) });
-
-            var reconnectAwaiter = new TaskCompletionAwaiter();
             var client = await GetRealtimeClient(protocol, (options, settings) =>
             {
                 options.UseTokenAuth = true;
@@ -1001,55 +997,10 @@ namespace IO.Ably.Tests.Realtime
             var initialToken = client.RestClient.AblyAuth.CurrentToken;
             var initialClientId = client.ClientId;
 
-            client.Connection.Once(ConnectionEvent.Disconnected, state2 =>
-            {
-                client.Connection.Once(ConnectionEvent.Connected, state3 =>
-                {
-                    reconnectAwaiter.SetCompleted();
-                });
-            });
-
             await client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Auth));
-            var didReconect = await reconnectAwaiter.Task;
-            didReconect.Should().BeTrue();
-            client.RestClient.AblyAuth.CurrentToken.Should().NotBe(initialToken);
-            client.ClientId.Should().Be(initialClientId);
-            client.Close();
-        }
 
-        [Theory]
-        [ProtocolData]
-        [Trait("spec", "RTN22")]
-        public async Task WhenAuthMessageReceived_ShouldAttemptTokenRenewal(Protocol protocol)
-        {
-            var authClient = await GetRestClient(protocol);
+            await Task.Delay(1000);
 
-            var reconnectAwaiter = new TaskCompletionAwaiter(60000);
-            var client = await GetRealtimeClient(protocol, (options, settings) =>
-            {
-                options.AuthCallback = tokenParams =>
-                {
-                    var results = authClient.AblyAuth.RequestToken(new TokenParams { ClientId = "RTN22", Ttl = TimeSpan.FromSeconds(35) });
-                    return Task.FromResult<object>(results);
-                };
-                options.ClientId = "RTN22";
-            });
-
-            await client.WaitForState(ConnectionState.Connected);
-
-            var initialToken = client.RestClient.AblyAuth.CurrentToken;
-            var initialClientId = client.ClientId;
-
-            client.Connection.Once(ConnectionEvent.Disconnected, state2 =>
-            {
-                client.Connection.Once(ConnectionEvent.Connected, state3 =>
-                {
-                    reconnectAwaiter.SetCompleted();
-                });
-            });
-
-            var didReconect = await reconnectAwaiter.Task;
-            didReconect.Should().BeTrue();
             client.RestClient.AblyAuth.CurrentToken.Should().NotBe(initialToken);
             client.ClientId.Should().Be(initialClientId);
             client.Close();

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -1381,9 +1381,11 @@ namespace IO.Ably.Tests.Realtime
 
                     errCount.Should().Be(4);
 
-                    client.Close();                    
+                    client.Close();
                 }
-                
+
+                [Theory]
+                [ProtocolData]
                 [Trait("spec", "RTP16a")]
                 public async Task ConnectionStateCondition_WhenConnectionIsConnected_AllPresenceMessageArePublishedImmediately(Protocol protocol)
                 {
@@ -1431,9 +1433,7 @@ namespace IO.Ably.Tests.Realtime
                 [Theory]
                 [ProtocolData]
                 [Trait("spec", "RTP5c2")]
-                public async Task
-                    WhenChannelBecomesAttached_AndSyncInitiatedAsPartOfAttach_AndResumeIsFalseAndSyncNotExpected_ShouldReEnterMembersInInternalMap(
-                        Protocol protocol)
+                public async Task WhenChannelBecomesAttached_AndSyncInitiatedAsPartOfAttach_AndResumeIsFalseAndSyncNotExpected_ShouldReEnterMembersInInternalMap(Protocol protocol)
                 {
                     /*
                      * If the resumed flag is false and a SYNC is not expected...
@@ -1520,6 +1520,82 @@ namespace IO.Ably.Tests.Realtime
 
                     remainingMembers.Should().HaveCount(1);
                     remainingMembers.First().ClientId.Should().Be("local");
+                }
+
+                [Theory]
+                [ProtocolData]
+                [Trait("spec", "RTP5c3")]
+                public async Task WhenAutomaticEnterMessageFails_ShouldEmitUpdateWithErrorInfo(Protocol protocol)
+                {
+                    // members not present in the PresenceMap but present in the internal PresenceMap must be re-entered automatically
+                    var channelName = "RTP5c3".AddRandomSuffix();
+                    var setupClient = await GetRealtimeClient(protocol);
+                    var setupChannel = setupClient.Channels.Get(channelName);
+
+                    // enter 3 client to the channel
+                    for (int i = 0; i < 3; i++)
+                    {
+                        await setupChannel.Presence.EnterClientAsync($"member_{i}", null);
+                    }
+
+                    var client = await GetRealtimeClient(protocol);
+                    await client.WaitForState();
+                    var channel = client.Channels.Get(channelName);
+                    var connectionId = client.Connection.Id;
+                    connectionId.Should().NotBeNullOrEmpty();
+                    var transport = client.GetTestTransport();
+
+                    var localMember = new PresenceMessage(PresenceAction.Enter, "local")
+                    {
+                        ConnectionId = connectionId
+                    };
+
+                    PresenceMessage enterMessage = null;
+                    ChannelStateChange updateMessage = null;
+                    await WaitForMultiple(2, partialDone =>
+                    {
+                        // when the channel becomes attached insert a local member to the presence map
+                        channel.Once(ChannelEvent.Attaching, change =>
+                        {
+                            // insert local member to automatically try to enter
+                            channel.Presence.InternalMap.Put(localMember);
+                            partialDone();
+                        });
+
+                        channel.Presence.Subscribe(PresenceAction.Enter, message =>
+                        {
+                            enterMessage = message; // should not hit
+                        });
+
+                        channel.Once(ChannelEvent.Update, message =>
+                        {
+                            updateMessage = message;
+                            partialDone();
+                        });
+
+                        void TransportMessageSent(ProtocolMessage message)
+                        {
+                            if (message.Presence.Length > 0
+                                && message.Presence[0].Action == PresenceAction.Enter
+                                && message.Presence[0].ClientId == "local")
+                            {
+                                // fail messages, causing callback to be invoked.
+                                client.ConnectionManager.AckProcessor.ClearQueueAndFailMessages(ErrorInfo.ReasonUnknown);
+                            }
+                        }
+
+                        transport.MessageSent = TransportMessageSent;
+                    });
+
+                    enterMessage.Should().BeNull();
+
+                    updateMessage.Should().NotBeNull();
+                    updateMessage.Error.Code.Should().Be(91004);
+                    updateMessage.Error.Message.Should().Contain(localMember.ClientId);
+
+                    // clean up
+                    setupClient.Close();
+                    client.Close();
                 }
             }
         }


### PR DESCRIPTION
- (RTP16b) If the connection is INITIALIZED, CONNECTING or DISCONNECTED or the channel is ATTACHING or INITIALIZED, and ClientOptions#queueMessages has not been explicitly set to false, then all presence messages will be queued and delivered as soon as the connection state returns to CONNECTED and the channel is ATTACHED