### PR TITLE
RTP16c

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -305,6 +305,21 @@ namespace IO.Ably.Realtime
 
         internal void UpdatePresence(PresenceMessage msg, Action<bool, ErrorInfo> callback)
         {
+            switch (_connection.Connection.State)
+            {
+                case ConnectionState.Initialized:
+                case ConnectionState.Connecting:
+                case ConnectionState.Disconnected:
+                case ConnectionState.Connected:
+                    break;
+                default:
+                    throw new AblyException(
+                        new ErrorInfo(
+                            $"Unable to enter presence channel when connection is in a ${_connection.Connection.State} state",
+                            91001,
+                            HttpStatusCode.BadRequest));
+            }
+
             switch (_channel.State)
             {
                 case ChannelState.Initialized:
@@ -320,7 +335,7 @@ namespace IO.Ably.Realtime
                     _connection.Send(message, callback);
                     break;
                 default:
-                    throw new AblyException("Unable to enter presence channel in detached or failed state", 91001, HttpStatusCode.BadRequest);
+                    throw new AblyException($"Unable to enter presence channel in {_channel.State} state", 91001, HttpStatusCode.BadRequest);
             }
         }
 

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -1223,6 +1223,115 @@ namespace IO.Ably.Tests.Realtime
 
                     client1.Close();
                 }
+
+                [Theory]
+                [ProtocolData]
+                [Trait("spec", "RTP16c")]
+                public async Task ChannelStateCondition_WhenConnectionStateIsInvalid_MessageAreNotPublishedAndExceptionIsThrown(Protocol protocol)
+                {
+                    /*
+                     * Test Connection States
+                     * Entering presence when a connection is Failed, Suspended, Closing and Closed
+                     * should result in an error.
+                     */
+
+                    var client = await GetRealtimeClient(protocol, (options, _) => options.ClientId = "RTP16c".AddRandomSuffix());
+                    int errCount = 0;
+                    async Task TestWithConnectionState(ConnectionStateBase state)
+                    {
+                        var channel = client.Channels.Get("RTP16c".AddRandomSuffix()) as RealtimeChannel;
+                        await client.WaitForState(ConnectionState.Connected);
+
+                        // capture all outbound protocol messages for later inspection
+                        List<ProtocolMessage> messageList = new List<ProtocolMessage>();
+                        client.GetTestTransport().MessageSent = messageList.Add;
+
+                        // force state
+                        await client.ConnectionManager.SetState(state);
+                        await client.WaitForState(state.State);
+
+                        var didError = false;
+                        try
+                        {
+                            channel.Presence.Enter(client.Connection.State.ToString());
+                        }
+                        catch (AblyException e)
+                        {
+                            didError = true;
+                            e.ErrorInfo.Code.Should().Be(91001);
+                            errCount++;
+                        }
+
+                        didError.Should().BeTrue($"should error for state {state.State}");
+
+                        // no presence messages sent
+                        messageList.Any(x => x.Presence != null).Should().BeFalse();
+
+                        client.Close();
+                        client = await GetRealtimeClient(protocol, (options, _) => options.ClientId = "RTP16c".AddRandomSuffix());
+                    }
+
+                    await TestWithConnectionState(new ConnectionFailedState(client.ConnectionManager, ErrorInfo.ReasonFailed, client.Logger));
+                    await TestWithConnectionState(new ConnectionSuspendedState(client.ConnectionManager, ErrorInfo.ReasonFailed, client.Logger));
+                    await TestWithConnectionState(new ConnectionClosingState(client.ConnectionManager, client.Logger));
+                    await TestWithConnectionState(new ConnectionClosedState(client.ConnectionManager, client.Logger));
+
+                    errCount.Should().Be(4);
+
+                    client.Close();
+
+                    /*
+                     * Test Channel States
+                     * Detached, Detaching, Failed and Suspended states should result in an error
+                     */
+
+                    errCount = 0;
+                    async Task TestWithChannelState(ChannelState state)
+                    {
+                        var channel = client.Channels.Get("RTP16c".AddRandomSuffix()) as RealtimeChannel;
+                        await client.WaitForState(ConnectionState.Connected);
+
+                        // capture all outbound protocol messages for later inspection
+                        List<ProtocolMessage> messageList = new List<ProtocolMessage>();
+                        client.GetTestTransport().MessageSent = messageList.Add;
+
+                        // force state
+                        await channel.WaitForState(ChannelState.Attached);
+                        channel.SetChannelState(state);
+                        await channel.WaitForState(state);
+
+                        var didError = false;
+                        try
+                        {
+                            channel.Presence.Enter(client.Connection.State.ToString());
+                        }
+                        catch (AblyException e)
+                        {
+                            didError = true;
+                            e.ErrorInfo.Code.Should().Be(91001);
+                            errCount++;
+                        }
+
+                        didError.Should().BeTrue($"should error for state {state}");
+
+                        // no presence messages sent
+                        messageList.Any(x => x.Presence != null).Should().BeFalse();
+
+                        client.Close();
+                        client = await GetRealtimeClient(protocol, (options, _) => options.ClientId = "RTP16c".AddRandomSuffix());
+                    }
+
+                    // Initialized, Attaching and Attached should queue and/or send
+                    // all other channel states should result in an error
+                    await TestWithChannelState(ChannelState.Detached);
+                    await TestWithChannelState(ChannelState.Detaching);
+                    await TestWithChannelState(ChannelState.Failed);
+                    await TestWithChannelState(ChannelState.Suspended);
+
+                    errCount.Should().Be(4);
+
+                    client.Close();
+                }
             }
         }
 


### PR DESCRIPTION

- (RTP16a) If the connection is CONNECTED and the channel is ATTACHED then all presence messages are published immediately
- (RTP16b) If the connection is INITIALIZED, CONNECTING or DISCONNECTED or the channel is ATTACHING or INITIALIZED, and ClientOptions#queueMessages has not been explicitly set to false, then all presence messages will be queued and delivered as soon as the connection state returns to CONNECTED and the channel is ATTACHED
- **(RTP16c) Else publishing presence messages will result in an error**

