### PR TITLE
RTN15c1 & RTN15c2

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -410,6 +410,141 @@ namespace IO.Ably.Tests.Realtime
 
         [Theory]
         [ProtocolData]
+        [Trait("spec", "RTN15c1")]
+        public async Task ResumeRequest_ConnectedProtocolMessageWithSameConnectionId_WithNoError(Protocol protocol)
+        {
+            var client = await GetRealtimeClient(protocol);
+            var channel = client.Channels.Get("RTN15c1".AddRandomSuffix()) as RealtimeChannel;
+            await client.WaitForState(ConnectionState.Connected);
+            var connectionId = client.Connection.Id;
+            channel.Attach();
+            await channel.WaitForState(ChannelState.Attached);
+            channel.State.Should().Be(ChannelState.Attached);
+
+            // kill the transport so the connection becomes DISCONNECTED
+            client.ConnectionManager.Transport.Close(false);
+            await client.WaitForState(ConnectionState.Disconnected);
+
+            var awaiter = new TaskCompletionAwaiter(15000);
+            client.Connection.Once(ConnectionEvent.Connected, change =>
+            {
+                change.HasError.Should().BeFalse();
+                awaiter.SetCompleted();
+            });
+
+            channel.Publish(null, "foo");
+
+            // currently disconnected so message is queued
+            client.ConnectionManager.PendingMessages.Should().HaveCount(1);
+
+            // wait for reconnection
+            var didConnect = await awaiter.Task;
+            didConnect.Should().BeTrue();
+
+            // we should have received a CONNECTED Protocol message with a corresponding connectionId
+            client.GetTestTransport().ProtocolMessagesReceived.Count(x => x.Action == ProtocolMessage.MessageAction.Connected).Should().Be(1);
+            var connectedProtocolMessage = client.GetTestTransport().ProtocolMessagesReceived.First(x => x.Action == ProtocolMessage.MessageAction.Connected);
+            connectedProtocolMessage.ConnectionId.Should().Be(connectionId);
+
+            // channel should be attached and pending messages sent
+            channel.State.Should().Be(ChannelState.Attached);
+            client.ConnectionManager.PendingMessages.Should().HaveCount(0);
+
+            // clean up
+            client.Close();
+        }
+
+        [Theory]
+        [ProtocolData]
+        [Trait("spec", "RTN15c2")]
+        public async Task ResumeRequest_ConnectedProtocolMessageWithSameConnectionId_WithError(Protocol protocol)
+        {
+            var client = await GetRealtimeClient(protocol);
+            var channel = client.Channels.Get("RTN15c1".AddRandomSuffix()) as RealtimeChannel;
+            await client.WaitForState(ConnectionState.Connected);
+            var connectionId = client.Connection.Id;
+
+            // tack connection state change
+            ConnectionStateChange stateChange = null;
+            var connectedAwaiter = new TaskCompletionAwaiter(15000);
+            client.Connection.Once(ConnectionEvent.Connected, change =>
+            {
+                stateChange = change;
+                connectedAwaiter.SetCompleted();
+            });
+
+            // track channel stage change
+            ChannelStateChange channelStateChange = null;
+            var attachedAwaiter = new TaskCompletionAwaiter(15000);
+            channel.Once(ChannelEvent.Attached, change =>
+            {
+                channelStateChange = change;
+                attachedAwaiter.SetCompleted();
+            });
+
+            // inject fake error messages into protocol messages
+            var transportFactory = client.Options.TransportFactory as TestTransportFactory;
+            transportFactory.OnTransportCreated += wrapper =>
+            {
+                wrapper.BeforeDataProcessed = message =>
+                {
+                    // inject an error before the protocol message is processed
+                    if (message.Action == ProtocolMessage.MessageAction.Connected)
+                    {
+                        message.Error = new ErrorInfo("Faked error", 0);
+                    }
+
+                    if (message.Action == ProtocolMessage.MessageAction.Attached)
+                    {
+                        message.Error = new ErrorInfo("Faked channel error", 0);
+                    }
+                };
+            };
+
+            // kill the transport so the connection becomes DISCONNECTED
+            client.ConnectionManager.Transport.Close(false);
+            await client.WaitForState(ConnectionState.Disconnected);
+
+            // publish
+            channel.Publish(null, "foo");
+
+            // wait for connection
+            var didConnect = await connectedAwaiter.Task;
+            didConnect.Should().BeTrue();
+
+            // it should have the injected error
+            stateChange.HasError.Should().BeTrue();
+            stateChange.Reason.Message.Should().Be("Faked error");
+
+            // we should have received a CONNECTED Protocol message with a corresponding connectionId
+            client.GetTestTransport().ProtocolMessagesReceived.Count(x => x.Action == ProtocolMessage.MessageAction.Connected).Should().Be(1);
+            var connectedProtocolMessage = client.GetTestTransport().ProtocolMessagesReceived.First(x => x.Action == ProtocolMessage.MessageAction.Connected);
+            connectedProtocolMessage.ConnectionId.Should().Be(connectionId);
+            client.Connection.ErrorReason.Should().Be(stateChange.Reason);
+
+            // wait for the channel to attach
+            await attachedAwaiter.Task;
+
+            // it chanel state change event should have the injected error
+            channelStateChange.Error.Message.Should().Be("Faked channel error");
+
+            // queued messages should now have been sent
+            client.ConnectionManager.PendingMessages.Should().HaveCount(0);
+
+            // clean up
+            client.Close();
+        }
+
+        [Theory]
+        [ProtocolData]
+        [Trait("spec", "RTN15c2")]
+        public async Task ResumeRequest_ConnectedProtocolMessageWithSameConnectionId_WithErrorInError(Protocol protocol)
+        {
+
+        }
+
+        [Theory]
+        [ProtocolData]
         public async Task WithAuthUrlShouldGetTokenFromUrl(Protocol protocol)
         {
             Logger.LogLevel = LogLevel.Debug;


### PR DESCRIPTION

- (RTN15c) The system’s response to a resume request will be one of the following:
- - (RTN15c1) CONNECTED ProtocolMessage with the same connectionId as the current client, and no error. In this case, the server is indicating that the resume succeeded, all channels are still attached, and all backlog messages are available. The client should not change the state of attached channels, and immediately process any queued messages for that channel
- - (RTN15c2) CONNECTED ProtocolMessage with the same connectionId as the current client, and an error. In this case, the server is indicating that the resume succeeded but with a non-fatal error, all channels are still attached, and some backlog messages may be unavailable. The ErrorInfo received should be set as the reason in the CONNECTED event, and the Connection#errorReason should be set. The client should not change the state of attached channels, and immediately process any queued messages for that channel. Any channels that are not resumed in full may receive an ATTACHED ProtocolMessage with an error, see RTL12

