### PR TITLE
Improvements to RTN15h tests

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -859,6 +859,10 @@ namespace IO.Ably.Tests.Realtime
 
             await awaiter.Task;
             stateChanges.Should().HaveCount(3);
+            stateChanges[0].HasError.Should().BeTrue();
+            stateChanges[0].Reason.Code.Should().Be(40142);
+            stateChanges[1].HasError.Should().BeFalse();
+            stateChanges[2].HasError.Should().BeFalse();
         }
 
         [Theory]
@@ -881,18 +885,18 @@ namespace IO.Ably.Tests.Realtime
 
             await client.WaitForState(ConnectionState.Connected);
 
-            var stateChanges = new List<ConnectionState>();
+            var stateChanges = new List<ConnectionStateChange>();
             client.Connection.Once(ConnectionEvent.Disconnected, state =>
             {
-                stateChanges.Add(state.Current);
+                stateChanges.Add(state);
                 client.Connection.Once(ConnectionEvent.Connecting, state2 =>
                 {
-                    stateChanges.Add(state2.Current);
+                    stateChanges.Add(state2);
                     client.Connection.Once(ConnectionEvent.Disconnected, state3 =>
                     {
                         client.Connection.State.Should().Be(ConnectionState.Disconnected);
                         client.Connection.ErrorReason.Should().NotBeNull();
-                        stateChanges.Add(state3.Current);
+                        stateChanges.Add(state3);
                         awaiter.SetCompleted();
                     });
                 });
@@ -901,8 +905,14 @@ namespace IO.Ably.Tests.Realtime
             client.Connection.Once(ConnectionEvent.Failed, state => throw new Exception("should not become FAILED"));
 
             await awaiter.Task;
-            stateChanges.Should().BeEquivalentTo(new[]
+            stateChanges.Select(x => x.Current).Should().BeEquivalentTo(new[]
                 { ConnectionState.Disconnected, ConnectionState.Connecting, ConnectionState.Disconnected });
+
+            stateChanges[0].HasError.Should().BeTrue();
+            stateChanges[0].Reason.Code.Should().Be(40142);
+            stateChanges[1].HasError.Should().BeFalse();
+            stateChanges[2].HasError.Should().BeTrue();
+            stateChanges[2].Reason.Code.Should().Be(80019);
         }
 
         [Theory]
@@ -926,26 +936,32 @@ namespace IO.Ably.Tests.Realtime
 
             await client.WaitForState(ConnectionState.Connected);
 
-            var stateChanges = new List<ConnectionState>();
+            var stateChanges = new List<ConnectionStateChange>();
             client.Connection.Once(ConnectionEvent.Disconnected, state =>
             {
-                stateChanges.Add(state.Current);
+                stateChanges.Add(state);
                 client.Connection.Once(ConnectionEvent.Connecting, state2 =>
                 {
-                    stateChanges.Add(state2.Current);
+                    stateChanges.Add(state2);
                     client.Connection.Once(ConnectionEvent.Failed, state3 =>
                     {
                         client.Connection.State.Should().Be(ConnectionState.Failed);
                         client.Connection.ErrorReason.Should().NotBeNull();
-                        stateChanges.Add(state3.Current);
+                        stateChanges.Add(state3);
                         awaiter.SetCompleted();
                     });
                 });
             });
 
             await awaiter.Task;
-            stateChanges.Should().BeEquivalentTo(new[]
+            stateChanges.Select(x => x.Current).Should().BeEquivalentTo(new[]
                 { ConnectionState.Disconnected, ConnectionState.Connecting, ConnectionState.Failed });
+
+            stateChanges[0].HasError.Should().BeTrue();
+            stateChanges[0].Reason.Code.Should().Be(40142);
+            stateChanges[1].HasError.Should().BeFalse();
+            stateChanges[2].HasError.Should().BeTrue();
+            stateChanges[2].Reason.Code.Should().Be(40300);
         }
 
         [Theory]

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
@@ -74,7 +74,8 @@ namespace IO.Ably.Tests.Realtime
 
             _renewTokenCalled.Should().BeTrue();
             Assert.Equal(new[] { ConnectionState.Disconnected, ConnectionState.Connecting, ConnectionState.Connected }, states);
-            errors.Should().BeEmpty("There should be no errors emitted by the client");
+            errors.Should().HaveCount(1);
+            errors[0].Should().Be(_tokenErrorInfo);
 
             var currentToken = client.RestClient.AblyAuth.CurrentToken;
             currentToken.Token.Should().Be(_returnedDummyTokenDetails.Token);

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
@@ -143,7 +143,8 @@ namespace IO.Ably.Tests.Realtime
             }, states);
 
             errors.Should().NotBeEmpty();
-            errors.First().Code.Should().Be(_failedRenewalErorrCode);
+            errors.Should().HaveCount(2);
+            errors[1].Code.Should().Be(_failedRenewalErorrCode);
         }
 
         [Fact]


### PR DESCRIPTION
When adding the test for RTN15c5 is picked up a bug where the ErrorInfo was not being passed through when the DISCONNECT state change was emitted, this should have been covered by RTN15h tests, this PR fixes that.