### PR TITLE
RTN15g and subsections

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Connection.cs
+++ b/src/IO.Ably.Shared/Realtime/Connection.cs
@@ -48,6 +48,12 @@ namespace IO.Ably.Realtime
             OsEventSubscribers.Add(new WeakReference<Action<NetworkState>>(stateAction));
         }
 
+        internal void SetConfirmedAlive()
+        {
+            ConfirmedAliveAt = DateTimeOffset.UtcNow;
+        }
+
+        internal DateTimeOffset? ConfirmedAliveAt { get; set; }
 
         internal AblyRest RestClient => RealtimeClient.RestClient;
 

--- a/src/IO.Ably.Shared/Transport/ConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionManager.cs
@@ -483,6 +483,7 @@ namespace IO.Ably.Transport
         void ITransportListener.OnTransportDataReceived(RealtimeTransportData data)
         {
             var message = Handler.ParseRealtimeData(data);
+            Connection.SetConfirmedAlive();
             OnTransportMessageReceived(message).WaitAndUnwrapException();
         }
 


### PR DESCRIPTION
- (RTN15g) Connection state is only maintained server-side for a brief period, given by the connectionStateTtl in the connectionDetails, see CD2f. If a client has been disconnected for longer than the connectionStateTtl, it should not attempt to resume. Instead, it should clear the local connection state, and any connection attempts should be made as for a fresh connection
- - (RTN15g1) This check should be made before each connection attempt. It is generally not sufficient to merely clear the connection state when moving to SUSPENDED state (though that may be done too), since the device may have been sleeping / suspended, in which case it may have been many hours since it was last actually connected, even though, having been in the CONNECTED state when it was put to sleep, it has only moved out of that state very recently (after waking up and noticing it’s no longer connected)
- - (RTN15g2) Another consequence of that is that the measure of whether the client been disconnected for too long (for the purpose of this check) cannot just be whether the client left the CONNECTED state more than connectionStateTtl ago. Instead, it should be whether the difference between the current time and the last activity time is greater than the sum of the connectionStateTtl and the maxIdleInterval, where the last activity time is the time of the last known actual sign of activity from Ably per RTN23a
- - (RTN15g3) When a connection attempt succeeds after the connection state has been cleared in this way, channels that were previously ATTACHED, ATTACHING, or SUSPENDED must be automatically reattached, just as if the connection was a resume attempt which failed per RTN15c3

