### PR TITLE
RTN16b and RTN16f

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Connection.cs
+++ b/src/IO.Ably.Shared/Realtime/Connection.cs
@@ -114,7 +114,10 @@ namespace IO.Ably.Realtime
 
         public bool ConnectionResumable => Key.IsNotEmpty() && Serial.HasValue;
 
-        public string RecoveryKey => ConnectionResumable ? $"{Key}:{Serial.Value}" : string.Empty;
+        /// <summary>
+        /// - (RTN16b) Connection#recoveryKey is an attribute composed of the connectionKey, and the latest connectionSerial received on the connection, and the current msgSerial
+        /// </summary>
+        public string RecoveryKey => ConnectionResumable ? $"{Key}:{Serial.Value}:{MessageSerial}" : string.Empty;
 
         public TimeSpan ConnectionStateTtl { get; internal set; } = Defaults.ConnectionStateTtl;
 

--- a/src/IO.Ably.Shared/Transport/TransportParams.cs
+++ b/src/IO.Ably.Shared/Transport/TransportParams.cs
@@ -9,6 +9,7 @@ namespace IO.Ably.Transport
 {
     public class TransportParams
     {
+        internal static Regex RecoveryKeyRegex { get; set; } = new Regex(@"^([\w!-]+):(-?\d+):(-?\d+)$");
         internal ILogger Logger { get; private set; }
 
         public string Host { get; private set; }
@@ -112,8 +113,7 @@ namespace IO.Ably.Transport
             }
             else if (RecoverValue.IsNotEmpty())
             {
-                var pattern = new Regex(@"^([\w!-]+):(\-?\w+)$");
-                var match = pattern.Match(RecoverValue);
+                var match = RecoveryKeyRegex.Match(RecoverValue);
                 if (match.Success)
                 {
                     result["recover"] = match.Groups[1].Value;

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -690,7 +690,7 @@ namespace IO.Ably.Tests.Realtime
         {
             var client = await GetRealtimeClient(protocol, (opts, _) =>
             {
-                opts.Recover = "c17a8!WeXvJum2pbuVYZtF-1b63c17a8:-1";
+                opts.Recover = "c17a8!WeXvJum2pbuVYZtF-1b63c17a8:-1:-1";
                 opts.AutoConnect = false;
             });
 

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionRecoverySpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionRecoverySpecs.cs
@@ -26,10 +26,11 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
 
         [Fact]
         [Trait("spec", "RTN16b")]
-        public void RecoveryKey_ShouldBeConnectionKeyPlusConnectionSerial()
+        public void RecoveryKey_ShouldBeConnectionKeyPlusConnectionSerialPlusMsgSerial()
         {
             var client = GetConnectedClient();
-            client.Connection.RecoveryKey.Should().Be($"{client.Connection.Key}:{client.Connection.Serial}");
+            client.Connection.Serial.Should().Be()
+            client.Connection.RecoveryKey.Should().Be($"{client.Connection.Key}:{client.Connection.Serial}:{client.Connection.MessageSerial}");
         }
 
         public ConnectionRecoverySpecs(ITestOutputHelper output)

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionRecoverySpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionRecoverySpecs.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using FluentAssertions;
 using IO.Ably.Realtime;
+using IO.Ably.Transport;
 using IO.Ably.Types;
 using Xunit;
 using Xunit.Abstractions;
@@ -29,8 +30,48 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
         public void RecoveryKey_ShouldBeConnectionKeyPlusConnectionSerialPlusMsgSerial()
         {
             var client = GetConnectedClient();
-            client.Connection.Serial.Should().Be()
             client.Connection.RecoveryKey.Should().Be($"{client.Connection.Key}:{client.Connection.Serial}:{client.Connection.MessageSerial}");
+        }
+
+        [Fact]
+        [Trait("spec", "RTN16f")]
+        public async Task RecoveryKey_MsgSerialShouldNotBeSentToAblyButShouldBeSetOnConnection()
+        {
+            // RecoveryKey should be in the format
+            // LettersOrNumbers:Number:Number
+            TransportParams.RecoveryKeyRegex.Match("a:b:c").Success.Should().BeFalse();
+            TransportParams.RecoveryKeyRegex.Match("a:b:3").Success.Should().BeFalse();
+            TransportParams.RecoveryKeyRegex.Match("a:2:c").Success.Should().BeFalse();
+            TransportParams.RecoveryKeyRegex.Match("$1:2:3").Success.Should().BeFalse();
+            TransportParams.RecoveryKeyRegex.Match("$a:2:3").Success.Should().BeFalse();
+            TransportParams.RecoveryKeyRegex.Match("a:@2:3").Success.Should().BeFalse();
+            TransportParams.RecoveryKeyRegex.Match("a:2:3!").Success.Should().BeFalse();
+
+            // these should be valid
+            TransportParams.RecoveryKeyRegex.Match("1:2:3").Success.Should().BeTrue();
+            TransportParams.RecoveryKeyRegex.Match("a:2:3").Success.Should().BeTrue();
+
+            var recoveryKey = "abcxyz:100:99";
+            var match = TransportParams.RecoveryKeyRegex.Match(recoveryKey);
+            match.Success.Should().BeTrue();
+            match.Groups[1].Value.Should().Be("abcxyz");
+            match.Groups[2].Value.Should().Be("100");
+            match.Groups[3].Value.Should().Be("99");
+
+            var parts = recoveryKey.Split(':');
+
+            var client = GetRealtimeClient(options => { options.Recover = recoveryKey; });
+
+            var transportParams = await client.ConnectionManager.CreateTransportParameters();
+            var paramsDict = transportParams.GetParams();
+            paramsDict.ContainsKey("recover").Should().BeTrue();
+            paramsDict.ContainsKey("connection_serial").Should().BeTrue();
+            paramsDict.ContainsKey("msg_serial").Should().BeFalse();
+
+            paramsDict["recover"].Should().Be(parts[0]);
+            paramsDict["connection_serial"].Should().Be(parts[1]);
+
+            client.Connection.MessageSerial.Should().Be(99);
         }
 
         public ConnectionRecoverySpecs(ITestOutputHelper output)


### PR DESCRIPTION
Updated recoveryKey to include msgSerial per v1.1 spec

- (RTN16b) Connection#recoveryKey is an attribute composed of the connectionKey, and the latest connectionSerial received on the connection, and the current msgSerial

- (RTN16f) The msgSerial component of the recoveryKey, unlike the other two components, is not sent to Ably, but rather is used to set the library internal msgSerial. (If the recover fails, the counter should be reset to 0 per RTN15c3 )

Fixed regression in RTN16e test (It was using a mock key in the old format).