### PR TITLE
RTL6c5

### DIFF
--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -417,11 +417,6 @@ namespace IO.Ably.Realtime
 
             if (State == ChannelState.Initialized || State == ChannelState.Attaching)
             {
-                if (State == ChannelState.Initialized)
-                {
-                    Attach();
-                }
-
                 // Not connected, queue the message
                 lock (_lockQueue)
                 {

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -223,6 +223,10 @@ namespace IO.Ably.Tests.Realtime
                 var client2 = await GetRealtimeClient(protocol);
                 var client3 = await GetRealtimeClient(protocol);
 
+                client1.Channels.Get(channelName).Attach();
+                client2.Channels.Get(channelName).Attach();
+                client3.Channels.Get(channelName).Attach();
+
                 var messages = new List<Message>();
                 for (int i = 0; i < 20; i++)
                 {
@@ -233,10 +237,10 @@ namespace IO.Ably.Tests.Realtime
                 foreach (var message in messages)
                 {
                     client1.Channels.Get(channelName).Publish(new[] { message }, (b, info) =>
-                   {
-                       successes1.Add(b);
-                       awaiter.Tick();
-                   });
+                    {
+                        successes1.Add(b);
+                        awaiter.Tick();
+                    });
                     client2.Channels.Get(channelName).Publish(new[] { message }, (b, info) =>
                     {
                         successes2.Add(b);

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -269,6 +269,27 @@ namespace IO.Ably.Tests.Realtime
 
         [Theory]
         [ProtocolData]
+        [Trait("spec", "RTL6c5")]
+        public async Task PublishShouldNotImplicitlyAttachAChannel(Protocol protocol)
+        {
+            var client = await GetRealtimeClient(protocol);
+            var channel = client.Channels.Get("RTL6c5".AddRandomSuffix());
+
+            var awaiter = new TaskCompletionAwaiter(5000);
+            channel.Once(ChannelEvent.Attached, change =>
+            {
+                awaiter.SetCompleted();
+            });
+
+            await client.WaitForState(ConnectionState.Connected);
+            channel.Publish(null, "foo");
+
+            var result = await awaiter.Task;
+            result.Should().BeFalse("channel should not have become attached");
+        }
+
+        [Theory]
+        [ProtocolData]
         [Trait("spec", "RTL6e")]
         [Trait("spec", "RTL6e1")]
         public async Task WithBasicAuthAndAMessageWithClientId_ShouldReturnTheMessageWithThatClientID(Protocol protocol)

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -666,6 +666,7 @@ namespace IO.Ably.Tests.Realtime
             var channel1 = client.Channels.Get("test");
             channel1.On(x => stateChanges.Add(x));
 
+            channel1.Attach();
             await channel1.PublishAsync("test", "best");
             await channel1.PublishAsync("test", "best");
 

--- a/src/IO.Ably.Tests.Shared/Realtime/RealtimeSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/RealtimeSandboxSpecs.cs
@@ -152,6 +152,7 @@ namespace IO.Ably.Tests.Realtime
                 info.Should().BeNull();
                 fooSuccessAWaiter.SetCompleted();
             });
+            fooChannel.Attach();
             Assert.True(await fooSuccessAWaiter.Task);
 
             var barFailAwaiter = new TaskCompletionAwaiter(5000);
@@ -162,6 +163,7 @@ namespace IO.Ably.Tests.Realtime
                 info.Code.Should().Be(40160);
                 barFailAwaiter.SetCompleted();
             });
+            barChannel.Attach();
             Assert.True(await barFailAwaiter.Task);
 
             // upgrade bar
@@ -221,6 +223,7 @@ namespace IO.Ably.Tests.Realtime
                 info.Should().BeNull();
                 awaiter1.SetCompleted();
             });
+            channel.Attach();
             Assert.True(await awaiter1.Task);
             channel.State.Should().Be(ChannelState.Attached);
 


### PR DESCRIPTION
- (RTL6c5) A publish should not trigger an implicit attach (in contrast to earlier version of this spec)

Removed the implicit attach when publish is called and fixed up regressions in affected tests.