### PR TITLE
ChannelStateChange (TH)

### DIFF
--- a/src/IO.Ably.Shared/Realtime/ChannelStateChangedEventArgs.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelStateChangedEventArgs.cs
@@ -5,15 +5,16 @@ namespace IO.Ably.Realtime
 {
     public class ChannelStateChange : EventArgs
     {
-        public ChannelStateChange(ChannelState state, ChannelState previous, ErrorInfo error = null, ProtocolMessage protocolMessage = null)
-            : this(state, previous, error, false)
+        public ChannelStateChange(ChannelEvent e, ChannelState state, ChannelState previous, ErrorInfo error = null, ProtocolMessage protocolMessage = null)
+            : this(e, state, previous, error, false)
         {
             ProtocolMessage = protocolMessage;
             Resumed = protocolMessage != null && protocolMessage.HasFlag(ProtocolMessage.Flag.Resumed);
         }
 
-        public ChannelStateChange(ChannelState state, ChannelState previous, ErrorInfo error = null, bool resumed = false)
+        public ChannelStateChange(ChannelEvent e, ChannelState state, ChannelState previous, ErrorInfo error = null, bool resumed = false)
         {
+            Event = e;
             Previous = previous;
             Current = state;
             Error = error;
@@ -27,6 +28,8 @@ namespace IO.Ably.Realtime
         public ErrorInfo Error { get; }
 
         public bool Resumed { get;  }
+
+        public ChannelEvent Event { get; }
 
         internal ProtocolMessage ProtocolMessage { get; set; } = null;
     }

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -489,7 +489,7 @@ namespace IO.Ably.Realtime
                 channelEvent = (ChannelEvent) state;
             }
 
-            var channelStateChange = new ChannelStateChange(state, State, error, protocolMessage);
+            var channelStateChange = new ChannelStateChange(channelEvent, state, State, error, protocolMessage);
             HandleStateChange(state, error, protocolMessage);
             InternalStateChanged.Invoke(this, channelStateChange);
 
@@ -756,7 +756,7 @@ namespace IO.Ably.Realtime
         {
             if (State == ChannelState.Attached)
             {
-                Emit(ChannelEvent.Update, new ChannelStateChange(State, State, errorInfo, resumed));
+                Emit(ChannelEvent.Update, new ChannelStateChange(ChannelEvent.Update, State, State, errorInfo, resumed));
             }
         }
 

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -101,12 +101,14 @@ namespace IO.Ably.Tests.Realtime
             [Trait("spec", "RTL2d")]
             [Trait("spec", "TH1")]
             [Trait("spec", "TH2")]
+            [Trait("spec", "TH5")]
             public void ShouldEmitTheFollowingStates(ChannelEvent channelEvent)
             {
                 var chanName = "test".AddRandomSuffix();
                 var client = GetConnectedClient();
                 var channel = client.Channels.Get(chanName);
 
+                ChannelEvent sourceEvent = ChannelEvent.Update;
                 ChannelState previousState = ChannelState.Failed;
                 ChannelState newState = ChannelState.Initialized;
                 channel.On(channelStateChange =>
@@ -122,6 +124,9 @@ namespace IO.Ably.Tests.Realtime
 
                     // should always be Initialized
                     previousState = channelStateChange.Previous;
+
+                    // TH5
+                    sourceEvent = channelStateChange.Event;
                     Done();
                 });
 
@@ -132,6 +137,7 @@ namespace IO.Ably.Tests.Realtime
                 channel.State.Should().Be((ChannelState)channelEvent);
                 newState.Should().Be((ChannelState)channelEvent);
                 previousState.Should().Be(ChannelState.Initialized);
+                sourceEvent.Should().Be(channelEvent);
             }
 
             [Theory]

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -99,6 +99,8 @@ namespace IO.Ably.Tests.Realtime
             [Trait("spec", "RTL2a")]
             [Trait("spec", "RTL2b")]
             [Trait("spec", "RTL2d")]
+            [Trait("spec", "TH1")]
+            [Trait("spec", "TH2")]
             public void ShouldEmitTheFollowingStates(ChannelEvent channelEvent)
             {
                 var chanName = "test".AddRandomSuffix();
@@ -200,6 +202,9 @@ namespace IO.Ably.Tests.Realtime
             [Trait("spec", "RTL2f")]
             [Trait("spec", "RTL2g")]
             [Trait("spec", "RTL12")]
+            [Trait("spec", "TH2")]
+            [Trait("spec", "TH3")]
+            [Trait("spec", "TH4")]
             async Task WhenAttachedProtocolMessageWithResumedFlagReceived_EmittedChannelStateChangeShouldIndicateResumed()
             {
                 var client = GetConnectedClient();
@@ -231,7 +236,7 @@ namespace IO.Ably.Tests.Realtime
                 // RTL2g / RTL12
                 channel.Once(ChannelEvent.Update, stateChange =>
                 {
-                    // RTL2f
+                    // RTL2f, TH2, TH4
                     stateChange.Current.Should().Be(ChannelState.Attached);
                     stateChange.Previous.Should().Be(ChannelState.Attached);
                     stateChange.Resumed.Should().BeFalse();
@@ -264,8 +269,10 @@ namespace IO.Ably.Tests.Realtime
 
                 channel.Once(ChannelEvent.Attached, stateChange =>
                 {
-                    // RTL2f
+                    // RTL2f, TH4
                     stateChange.Resumed.Should().BeTrue();
+
+                    // TH3
                     stateChange.Error.Message.Should().Be("test error");
                     tsc.SetCompleted();
                 });


### PR DESCRIPTION

ChannelStateChange

Added the source ChannelEvent to ChannelStateChange and updated existing channel spec tests to tag the various TH1-TH5 spec items that are covered

- (TH1) Whenever the channel state changes, a ChannelStateChange object is emitted on the Channel object
- (TH2) The ChannelStateChange object contains the current state in attribute current, the previous state in attribute previous
- (TH5) The ConnectionStateChange object contains the event that generated the channel state change
- (TH3) If the connection state change includes error information, then the reason attribute will contain an ErrorInfo object describing the reason for the error
- (TH4) The ChannelStateChange object contains an attribute resumed which in combination with an ATTACHED state, indicates whether the channel attach successfully resumed its state following the connection being resumed or recovered. If resumed is true, then the attribute indicates that the attach within Ably successfully recovered the state for the channel, and as such there is no loss of message continuity. In all other cases, resumed is false, and may be accompanied with a channel state change error reason

