### PR TITLE
fix test for idempotent rest publishing for version 1.1 of spec.

### DIFF
--- a/src/IO.Ably.Shared/ClientOptions.cs
+++ b/src/IO.Ably.Shared/ClientOptions.cs
@@ -269,9 +269,13 @@ namespace IO.Ably
         internal void SetIdempotentRestPublishingDefault(int majorVersion, int minorVersion)
         {
             // (TO3n) idempotentRestPublishing defaults to false for clients with version < 1.1, otherwise true.
-            if (majorVersion >= 1 && minorVersion >= 1)
+            if (majorVersion == 1 && minorVersion >= 1 || majorVersion > 1)
             {
                 IdempotentRestPublishing = true;
+            }
+            else
+            {
+                IdempotentRestPublishing = false;
             }
         }
     }

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
@@ -150,7 +150,11 @@ namespace IO.Ably.Tests.Rest
             [Trait("spec", "RSL1e")]
             public async Task WithNoData_ShouldOnlySendNameProperty()
             {
-                var client = GetRestClient();
+                var client = GetRestClient(null, options =>
+                {
+                    // Idempotent publishing will add an id to the message, so disable for this test
+                    options.IdempotentRestPublishing = false;
+                });
 
                 var messageWithNoData = new Message() { Name = "NoData" };
                 await client.Channels.Get("nodata").PublishAsync(messageWithNoData);
@@ -162,7 +166,11 @@ namespace IO.Ably.Tests.Rest
             [Trait("spec", "RSL1e")]
             public async Task WithNoName_ShouldOnlySendDataProperty()
             {
-                var client = GetRestClient();
+                var client = GetRestClient(null, options =>
+                {
+                    // Idempotent publishing will add an id to the message, so disable for this test
+                    options.IdempotentRestPublishing = false;
+                });
 
                 var messageWithNoName = new Message() { Data = "NoName" };
                 await client.Channels.Get("noname").PublishAsync(messageWithNoName);
@@ -174,7 +182,11 @@ namespace IO.Ably.Tests.Rest
             [Trait("spec", "RSL1e")]
             public async Task WithBlankMessage_ShouldSendBlankMessage()
             {
-                var client = GetRestClient();
+                var client = GetRestClient(null, options =>
+                {
+                    // Idempotent publishing will add an id to the message, so disable for this test
+                    options.IdempotentRestPublishing = false;
+                });
 
                 var messageWithNoName = new Message();
                 await client.Channels.Get("blank-message").PublishAsync(messageWithNoName);

--- a/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
@@ -318,8 +318,8 @@ namespace IO.Ably.Tests
             {
                 var clientOptions = new ClientOptions();
 
-                // Currently working against 1.0 so this should be false
-                clientOptions.IdempotentRestPublishing.Should().BeFalse();
+                // Now working against 1.1+ so this should be true
+                clientOptions.IdempotentRestPublishing.Should().BeTrue();
 
                 // Test the internal method that is called from
                 // ClientOptions constructor with different


### PR DESCRIPTION
fix test ClientOptions_IdempotentPublishingDefaultToFalseForVersionsBelow1_1 as it assumed v1.0 was current and we are now on version 1.1