### PR TITLE
modifications to ErrorInfo to meet TI4 & TI5 spec

### DIFF
--- a/src/IO.Ably.Tests.Shared/ErrorInfoTests.cs
+++ b/src/IO.Ably.Tests.Shared/ErrorInfoTests.cs
@@ -37,23 +37,39 @@ namespace IO.Ably.Tests
         }
 
         [Fact]
-        public void ToString_WithStatusCodeCodeAndReason_ReturnsFormattedString()
+        [Trait("spec", "TI4")]
+        [Trait("spec", "TI5")]
+        public void ToString_WithStatusCodeCodeAndReason_ReturnsFormattedString_WithHrefFromCode()
         {
             // Arrange
-            var errorInfo = new ErrorInfo("Reason", 1000, HttpStatusCode.Accepted);
+            var errorInfo = new ErrorInfo("Error Reason", 1000, HttpStatusCode.Accepted);
 
             // Assert
-            Assert.Equal("Reason: Reason; Code: 1000; HttpStatusCode: 202 (Accepted)", errorInfo.ToString());
+            Assert.Equal("[ErrorInfo Reason: Error Reason (See https://help.ably.io/error/1000); Code: 1000; StatusCode: 202 (Accepted); Href: https://help.ably.io/error/1000;]", errorInfo.ToString());
         }
 
         [Fact]
-        public void ToString_WithCodeAndReasonWithoutStatusCode_ReturnsFormattedString()
+        [Trait("spec", "TI4")]
+        [Trait("spec", "TI5")]
+        public void ToString_WithCodeAndReasonWithoutStatusCodeAndWithoutHref_ReturnsFormattedString_WithHrefFromCode()
         {
             // Arrange
             var errorInfo = new ErrorInfo("Reason", 1000);
 
             // Assert
-            Assert.Equal("Reason: Reason; Code: 1000", errorInfo.ToString());
+            Assert.Equal("[ErrorInfo Reason: Reason (See https://help.ably.io/error/1000); Code: 1000; Href: https://help.ably.io/error/1000;]", errorInfo.ToString());
+        }
+
+        [Fact]
+        [Trait("spec", "TI4")]
+        [Trait("spec", "TI5")]
+        public void ToString_WithCodeAndHref_ReturnsFormattedString_ThatUsesHref()
+        {
+            // Arrange
+            var errorInfo = new ErrorInfo("Reason", 1000, null, "http://example.com");
+
+            // Assert
+            Assert.Equal("[ErrorInfo Reason: Reason (See http://example.com); Code: 1000; Href: http://example.com;]", errorInfo.ToString());
         }
     }
 }


### PR DESCRIPTION

- (TI4) Ably may additionally include a href attribute with a string value. This is included for REST responses to provide a URL for customers to find more help on the error code
- (TI5) Log entries generated from errors, where possible, should include a URL to help developers understand the error and resolve the issue. If the URL is not already present within the contents of the message attribute, then it should be included in the log entry as follows: “See [URL]”. If the href attribute is present, it should be used as the URL. If the href attribute is not present, and the code attribute is present, then the URL should be constructed as follows “https://help.ably.io/error/[CODE]”. If neither the href or code attributes are present, then an additional URL should not be included in the log entry.

