### PR TITLE
RTL15/a

### DIFF
--- a/src/IO.Ably.Shared/IO.Ably.Shared.projitems
+++ b/src/IO.Ably.Shared/IO.Ably.Shared.projitems
@@ -121,6 +121,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Transport\TransportParams.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Transport\MsWebSocketTransport.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Transport\MsWebSocketConnection.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Realtime\ChannelProperties.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Types\ConnectionDetailsMessage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Types\ErrorInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpPaginatedResponse.cs" />

--- a/src/IO.Ably.Shared/MessageEncoders/Base64Encoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/Base64Encoder.cs
@@ -9,9 +9,9 @@ namespace IO.Ably.MessageEncoders
 
         public override Result Decode(IMessage payload, ChannelOptions options)
         {
-            if (CurrentEncodingIs(payload, EncodingName) && payload.Data is string)
+            if (CurrentEncodingIs(payload, EncodingName) && payload.Data is string data)
             {
-                payload.Data = ((string)payload.Data).FromBase64();
+                payload.Data = data.FromBase64();
                 RemoveCurrentEncodingPart(payload);
             }
 
@@ -26,8 +26,7 @@ namespace IO.Ably.MessageEncoders
                 return Result.Ok();
             }
 
-            var bytes = data as byte[];
-            if (bytes != null && Protocol == Protocol.Json)
+            if (data is byte[] bytes)
             {
                 payload.Data = bytes.ToBase64();
                 AddEncoding(payload, EncodingName);
@@ -36,8 +35,8 @@ namespace IO.Ably.MessageEncoders
             return Result.Ok();
         }
 
-        public Base64Encoder(Protocol protocol)
-            : base(protocol)
+        public Base64Encoder()
+            : base()
         {
         }
     }

--- a/src/IO.Ably.Shared/MessageEncoders/CipherEncoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/CipherEncoder.cs
@@ -5,13 +5,11 @@ namespace IO.Ably.MessageEncoders
 {
     internal class CipherEncoder : MessageEncoder
     {
-        internal ILogger Logger { get; set; }
-
         public override string EncodingName => "cipher";
 
         public override Result Decode(IMessage payload, ChannelOptions options)
         {
-            Logger = options.Logger ?? IO.Ably.DefaultLogger.LoggerInstance;
+            Logger = options?.Logger ?? DefaultLogger.LoggerInstance;
 
             if (IsEmpty(payload.Data))
             {
@@ -69,9 +67,9 @@ namespace IO.Ably.MessageEncoders
                 return Result.Ok();
             }
 
-            if (payload.Data is string)
+            if (payload.Data is string data)
             {
-                payload.Data = ((string)payload.Data).GetBytes();
+                payload.Data = data.GetBytes();
                 AddEncoding(payload, "utf-8");
             }
 
@@ -87,8 +85,8 @@ namespace IO.Ably.MessageEncoders
             return payload.Encoding.IsNotEmpty() && payload.Encoding.Contains(EncodingName);
         }
 
-        public CipherEncoder(Protocol protocol)
-            : base(protocol)
+        public CipherEncoder()
+            : base()
         {
         }
     }

--- a/src/IO.Ably.Shared/MessageEncoders/JsonEncoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/JsonEncoder.cs
@@ -9,18 +9,13 @@ namespace IO.Ably.MessageEncoders
 {
     internal class JsonEncoder : MessageEncoder
     {
-        internal ILogger Logger { get; set; }
-
-        public override string EncodingName
-        {
-            get { return "json"; }
-        }
+        public override string EncodingName => "json";
 
         public override Result Decode(IMessage payload, ChannelOptions options)
         {
-            Logger = options.Logger;
+            Logger = options?.Logger ?? IO.Ably.DefaultLogger.LoggerInstance;
 
-            if (IsEmpty(payload.Data) || CurrentEncodingIs(payload, EncodingName) == false)
+            if (IsEmpty(payload.Data) || !CurrentEncodingIs(payload, EncodingName))
             {
                 return Result.Ok();
             }
@@ -60,8 +55,8 @@ namespace IO.Ably.MessageEncoders
             return payload.Data is string == false && payload.Data is byte[] == false;
         }
 
-        public JsonEncoder(Protocol protocol)
-            : base(protocol)
+        public JsonEncoder()
+            : base()
         {
         }
     }

--- a/src/IO.Ably.Shared/MessageEncoders/MessageEncoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/MessageEncoder.cs
@@ -6,12 +6,7 @@ namespace IO.Ably.MessageEncoders
 {
     internal abstract class MessageEncoder
     {
-        protected readonly Protocol Protocol;
-
-        protected MessageEncoder(Protocol protocol)
-        {
-            Protocol = protocol;
-        }
+        internal ILogger Logger { get; set; }
 
         public abstract string EncodingName { get; }
 
@@ -21,7 +16,7 @@ namespace IO.Ably.MessageEncoders
 
         public bool IsEmpty(object data)
         {
-            return data == null || (data is string && ((string)data).IsEmpty());
+            return data == null || (data is string s && s.IsEmpty());
         }
 
         public void AddEncoding(IMessage payload, string encoding = null)

--- a/src/IO.Ably.Shared/MessageEncoders/Utf8Encoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/Utf8Encoder.cs
@@ -4,8 +4,8 @@ namespace IO.Ably.MessageEncoders
 {
     internal class Utf8Encoder : MessageEncoder
     {
-        public Utf8Encoder(Protocol protocol)
-            : base(protocol)
+        public Utf8Encoder()
+            : base()
         {
         }
 

--- a/src/IO.Ably.Shared/Realtime/ChannelMessageProcessor.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelMessageProcessor.cs
@@ -1,4 +1,5 @@
 using IO.Ably;
+using IO.Ably.MessageEncoders;
 using IO.Ably.Transport;
 using IO.Ably.Types;
 
@@ -68,7 +69,7 @@ namespace IO.Ably.Realtime
 
                     break;
                 case ProtocolMessage.MessageAction.Message:
-                    var result = _connectionManager.Handler.DecodeProtocolMessage(protocolMessage, channel.Options);
+                    var result = MessageHandler.DecodeProtocolMessage(protocolMessage, channel.Options);
                     if (result.IsFailure)
                     {
                         channel.OnError(result.Error);
@@ -81,11 +82,11 @@ namespace IO.Ably.Realtime
 
                     break;
                 case ProtocolMessage.MessageAction.Presence:
-                    _connectionManager.Handler.DecodeProtocolMessage(protocolMessage, channel.Options);
+                    MessageHandler.DecodeProtocolMessage(protocolMessage, channel.Options);
                     channel.Presence.OnPresence(protocolMessage.Presence, null);
                     break;
                 case ProtocolMessage.MessageAction.Sync:
-                    _connectionManager.Handler.DecodeProtocolMessage(protocolMessage, channel.Options);
+                    MessageHandler.DecodeProtocolMessage(protocolMessage, channel.Options);
                     channel.Presence.OnPresence(protocolMessage.Presence, protocolMessage.ChannelSerial);
                     break;
             }

--- a/src/IO.Ably.Shared/Realtime/ChannelProperties.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelProperties.cs
@@ -1,0 +1,7 @@
+﻿namespace IO.Ably.Realtime
+{
+    public class ChannelProperties
+    {
+        public string AttachSerial { get; internal set; } = null;
+    }
+}

--- a/src/IO.Ably.Shared/Realtime/IRealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/IRealtimeChannel.cs
@@ -16,6 +16,8 @@ namespace IO.Ably.Realtime
 
         ErrorInfo ErrorReason { get; }
 
+        ChannelProperties Properties { get; }
+
         event EventHandler<ChannelStateChange> StateChanged;
 
         event EventHandler<ChannelErrorEventArgs> Error;

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -406,7 +406,7 @@ namespace IO.Ably.Realtime
                             break;
                         case PresenceAction.Leave:
                             broadcast &= Map.Remove(message);
-                            if (updateInternalPresence)
+                            if (updateInternalPresence && !message.IsSynthesized())
                             {
                                 InternalMap.Remove(message);
                             }

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -38,11 +38,10 @@ namespace IO.Ably.Realtime
 
         protected override Action<Action> NotifyClient => RealtimeClient.NotifyExternalClients;
 
-        public string AttachedSerial { get; set; }
-
         public List<MessageAndCallback> QueuedMessages { get; set; } = new List<MessageAndCallback>(16);
 
         public ErrorInfo ErrorReason { get; internal set; }
+        public ChannelProperties Properties { get; } = new ChannelProperties();
 
         public event EventHandler<ChannelStateChange> StateChanged = delegate { };
 
@@ -416,7 +415,7 @@ namespace IO.Ably.Realtime
                 throw new AblyException("Channel is not attached. Cannot use untilAttach parameter");
             }
 
-            query.ExtraParameters.Add("fromSerial", AttachedSerial);
+            query.ExtraParameters.Add("fromSerial", Properties.AttachSerial);
         }
 
         private void PublishImpl(IEnumerable<Message> messages, Action<bool, ErrorInfo> callback)
@@ -557,7 +556,7 @@ namespace IO.Ably.Realtime
                             Presence.SkipSync();
                         }
 
-                        AttachedSerial = protocolMessage.ChannelSerial;
+                        Properties.AttachSerial = protocolMessage.ChannelSerial;
                     }
 
                     if (IsTerminalConnectionState == false)

--- a/src/IO.Ably.Shared/Types/Message.cs
+++ b/src/IO.Ably.Shared/Types/Message.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.Serialization;
+using IO.Ably.MessageEncoders;
 using IO.Ably.Utils;
 using Newtonsoft.Json;
 
@@ -111,6 +112,16 @@ namespace IO.Ably
                 hashCode = (hashCode * 397) ^ (Encoding != null ? Encoding.GetHashCode() : 0);
                 return hashCode;
             }
+        }
+
+        public static Message FromEncoded(Message encoded, ChannelOptions options = null)
+        {
+            return MessageHandler.FromEncoded(encoded, options);
+        }
+
+        public static Message[] FromEncodedArray(Message[] encoded, ChannelOptions options = null)
+        {
+            return MessageHandler.FromEncodedArray(encoded, options);
         }
     }
 }

--- a/src/IO.Ably.Tests.Shared/MessageEncodes/Base64EncoderTests.cs
+++ b/src/IO.Ably.Tests.Shared/MessageEncodes/Base64EncoderTests.cs
@@ -16,7 +16,7 @@ namespace IO.Ably.Tests.MessageEncodes
             _stringData = "random-string";
             _binaryData = _stringData.GetBytes();
             _base64Data = _binaryData.ToBase64();
-            _encoder = new Base64Encoder(protocol ?? Defaults.Protocol);
+            _encoder = new Base64Encoder();
         }
 
         public class Decode : Base64EncoderTests

--- a/src/IO.Ably.Tests.Shared/MessageEncodes/CipherEncoderTests.cs
+++ b/src/IO.Ably.Tests.Shared/MessageEncodes/CipherEncoderTests.cs
@@ -27,7 +27,7 @@ namespace IO.Ably.Tests.MessageEncodes
             _encryptedData = _crypto.Encrypt(_stringData.GetBytes());
             _encryptedBinaryData = _crypto.Encrypt(_binaryData);
 
-            _encoder = new CipherEncoder(Defaults.Protocol);
+            _encoder = new CipherEncoder();
         }
 
         private byte[] GenerateKey(int keyLength)
@@ -42,7 +42,7 @@ namespace IO.Ably.Tests.MessageEncodes
             public void WithInvalidKeyLength_Throws()
             {
                 var options = new ChannelOptions(new CipherParams(Crypto.DefaultAlgorithm, new byte[] { 1, 2, 3 }));
-                var encoder = new CipherEncoder(Defaults.Protocol);
+                var encoder = new CipherEncoder();
                 var error = Assert.Throws<AblyException>(delegate
                 {
                     encoder.Encode(new Message() { Data = "string" }, options);
@@ -55,7 +55,7 @@ namespace IO.Ably.Tests.MessageEncodes
             public void WithInvalidKey_Throws()
             {
                 var options = new ChannelOptions(new CipherParams(Crypto.DefaultAlgorithm, new byte[] { 1, 2, 3 }));
-                var encoder = new CipherEncoder(Defaults.Protocol);
+                var encoder = new CipherEncoder();
                 var error = Assert.Throws<AblyException>(delegate
                 {
                     encoder.Encode(new Message() { Data = "string" }, options);
@@ -71,7 +71,7 @@ namespace IO.Ably.Tests.MessageEncodes
                 var key = keyGen.GetBytes(Crypto.DefaultKeylength / 8);
 
                 var options = new ChannelOptions(new CipherParams("mgg", key));
-                var encoder = new CipherEncoder(Defaults.Protocol);
+                var encoder = new CipherEncoder();
                 var error = Assert.Throws<AblyException>(delegate
                 {
                     encoder.Encode(new Message() { Data = "string" }, options);

--- a/src/IO.Ably.Tests.Shared/MessageEncodes/JsonEncoderTests.cs
+++ b/src/IO.Ably.Tests.Shared/MessageEncodes/JsonEncoderTests.cs
@@ -17,7 +17,7 @@ namespace IO.Ably.Tests.MessageEncodes
         {
             _objectData = new { Test = "test", Best = "best" };
             _jsonData = JsonHelper.Serialize(_objectData);
-            _encoder = new JsonEncoder(Defaults.Protocol);
+            _encoder = new JsonEncoder();
         }
 
         private Message EncodePayload(object data, string encoding = "")

--- a/src/IO.Ably.Tests.Shared/MessageEncodes/Utf8EncoderTests.cs
+++ b/src/IO.Ably.Tests.Shared/MessageEncodes/Utf8EncoderTests.cs
@@ -14,7 +14,7 @@ namespace IO.Ably.Tests.MessageEncodes
         {
             _stringData = "random_string";
             _byteData = _stringData.GetBytes();
-            _encoder = new Utf8Encoder(Defaults.Protocol);
+            _encoder = new Utf8Encoder();
         }
 
         private Message DecodePayload(object data, string encoding = "")

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -654,7 +654,7 @@ namespace IO.Ably.Tests.Realtime
 
             var channel = client.Channels.Get("test".AddRandomSuffix());
 
-            var tsc = new TaskCompletionAwaiter(5000);
+            var tsc = new TaskCompletionAwaiter(15000);
             client.Connection.Once(ConnectionEvent.Disconnected, change =>
             {
                 // place a message on the queue

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -265,6 +265,7 @@ namespace IO.Ably.Tests.Realtime
             [Theory]
             [ProtocolData]
             [Trait("spec", "RTP17")]
+            [Trait("spec", "RTP17b")]
             public async Task Presence_ShouldHaveInternalMapForCurrentConnectionId(Protocol protocol)
             {
                 /*
@@ -379,6 +380,19 @@ namespace IO.Ably.Tests.Realtime
                 msgB.ConnectionId.Should().Be(clientB.Connection.Id);
                 msgB.Data.ToString().Should().Be("chB-update");
                 channelB.Presence.Map.Members.Should().HaveCount(2);
+                channelB.Presence.InternalMap.Members.Should().HaveCount(1);
+
+                // LEAVE with synthesized message
+                msgA = null;
+                msgB = null;
+                var synthesizedMsg = new PresenceMessage(PresenceAction.Leave, clientB.ClientId) { ConnectionId = null };
+                synthesizedMsg.IsSynthesized().Should().BeTrue();
+                channelB.Presence.OnPresence(new[] { synthesizedMsg }, null);
+
+                msgB.Should().BeNull();
+                channelB.Presence.Map.Members.Should().HaveCount(2);
+
+                // message was synthesized so should not have been removed (RTP17b)
                 channelB.Presence.InternalMap.Members.Should().HaveCount(1);
 
                 // LEAVE

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using IO.Ably.Encryption;
@@ -558,6 +559,125 @@ namespace IO.Ably.Tests.Rest
             }
 
             return data;
+        }
+
+        [Trait("spec", "TM3")]
+        public class TM3Spec : SandboxSpecs
+        {
+            [Fact]
+            [Trait("spec", "TM3")]
+            public async Task Message_FromEncoded_WithNoEncoding()
+            {
+                var msg = new Message("name", "some-data");
+                var fromEncoded = Message.FromEncoded(msg);
+
+                fromEncoded.Name.Should().Be("name");
+                fromEncoded.Data.Should().Be("some-data");
+                fromEncoded.Encoding.Should().BeNullOrEmpty();
+            }
+
+            [Fact]
+            [Trait("spec", "TM3")]
+            public async Task Message_FromEncoded_WithEncoding()
+            {
+                var d = new Dictionary<string, string>
+                {
+                    { "foo", "bar" },
+                    { "baz", "qux" }
+                };
+
+                var msg = new Message("name", JsonHelper.Serialize(d)) { Encoding = "json" };
+                var fromEncoded = Message.FromEncoded(msg);
+
+                fromEncoded.Name.Should().Be("name");
+                JsonHelper.Serialize(fromEncoded.Data).Should().Be(JsonHelper.Serialize(d));
+                fromEncoded.Encoding.Should().BeNullOrEmpty();
+            }
+
+            [Fact]
+            [Trait("spec", "TM3")]
+            public async Task Message_FromEncoded_WithCustomEncoding()
+            {
+                var d = new Dictionary<string, string>
+                {
+                    { "foo", "bar" },
+                    { "baz", "qux" }
+                };
+
+                var msg = new Message("name", JsonHelper.Serialize(d)) { Encoding = "foo/json" };
+                var fromEncoded = Message.FromEncoded(msg);
+
+                fromEncoded.Name.Should().Be("name");
+                JsonHelper.Serialize(fromEncoded.Data).Should().Be(JsonHelper.Serialize(d));
+                fromEncoded.Encoding.Should().Be("foo");
+            }
+
+            [Fact]
+            [Trait("spec", "TM3")]
+            public async Task Message_FromEncoded_WithCipherEncoding()
+            {
+                var cipherParams = Crypto.GetDefaultParams(Crypto.GenerateRandomKey(128), null, CipherMode.CBC);
+
+                var crypto = Crypto.GetCipher(cipherParams);
+                var payload = "payload".AddRandomSuffix();
+
+                var msg = new Message("name", crypto.Encrypt(Encoding.UTF8.GetBytes(payload))) { Encoding = "utf-8/cipher+aes-128-cbc" };
+                var fromEncoded = Message.FromEncoded(msg, new ChannelOptions(cipherParams));
+
+                fromEncoded.Name.Should().Be("name");
+                fromEncoded.Data.ShouldBeEquivalentTo(payload);
+                fromEncoded.Encoding.Should().BeNullOrEmpty();
+            }
+
+            [Fact]
+            [Trait("spec", "TM3")]
+            public async Task Message_FromEncoded_WithInvalidCipherEncoding()
+            {
+                var cipherParams = Crypto.GetDefaultParams(Crypto.GenerateRandomKey(128), null, CipherMode.CBC);
+                var payload = "some-invalid-payload".AddRandomSuffix();
+
+                var msg = new Message("name", Encoding.UTF8.GetBytes(payload)) { Encoding = "utf-8/cipher+aes-128-cbc" };
+
+                bool didThrow = false;
+                try
+                {
+                    var fromEncoded = Message.FromEncoded(msg, new ChannelOptions(cipherParams));
+                }
+                catch (Exception e)
+                {
+                    didThrow = true;
+                }
+
+                didThrow.Should().BeTrue();
+            }
+
+            [Fact]
+            [Trait("spec", "TM3")]
+            public async Task Message_FromEncodedArray_WithNoEncoding()
+            {
+                var msg = new[]
+                {
+                    new Message("name1", "some-data1"),
+                    new Message("name2", "some-data2")
+                };
+
+                var fromEncoded = Message.FromEncodedArray(msg);
+
+                fromEncoded.Should().HaveCount(2);
+
+                fromEncoded[0].Name.Should().Be("name1");
+                fromEncoded[0].Data.Should().Be("some-data1");
+                fromEncoded[0].Encoding.Should().BeNullOrEmpty();
+
+                fromEncoded[1].Name.Should().Be("name2");
+                fromEncoded[1].Data.Should().Be("some-data2");
+                fromEncoded[1].Encoding.Should().BeNullOrEmpty();
+            }
+
+            public TM3Spec(AblySandboxFixture fixture, ITestOutputHelper output)
+                : base(fixture, output)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
A minor update for RTL15/a

RealtimeChannel was using a property `AttachedSerial`, per RTL15/a this has been changed to use `channel.Properties.AttachSerial` where `Properties` is an instance of `ChannelProperties` per RTL15/a spec


- (RTL15) Channel#properties attribute is a ChannelProperties object representing properties of the channel state. properties is a publically accessible member of the channel, but it is an experimental and unstable API. It has the following attributes:
- - (RTL15a) attachSerial is null when the channel is instanced, and is updated with the channelSerial from each ATTACHED ProtocolMessage received from Ably with a matching channel attribute. The attachSerial value is used for untilAttach queries, see RTL10b and RTP12b.

