### PR TITLE
TM3

### DIFF
--- a/src/IO.Ably.Shared/MessageEncoders/Base64Encoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/Base64Encoder.cs
@@ -5,8 +5,6 @@ namespace IO.Ably.MessageEncoders
 {
     internal class Base64Encoder : MessageEncoder
     {
-        private readonly Protocol _protocol;
-
         public override string EncodingName => "base64";
 
         public override Result Decode(IMessage payload, ChannelOptions options)

--- a/src/IO.Ably.Shared/MessageEncoders/Base64Encoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/Base64Encoder.cs
@@ -5,13 +5,15 @@ namespace IO.Ably.MessageEncoders
 {
     internal class Base64Encoder : MessageEncoder
     {
+        private readonly Protocol _protocol;
+
         public override string EncodingName => "base64";
 
         public override Result Decode(IMessage payload, ChannelOptions options)
         {
-            if (CurrentEncodingIs(payload, EncodingName) && payload.Data is string)
+            if (CurrentEncodingIs(payload, EncodingName) && payload.Data is string data)
             {
-                payload.Data = ((string)payload.Data).FromBase64();
+                payload.Data = data.FromBase64();
                 RemoveCurrentEncodingPart(payload);
             }
 
@@ -26,8 +28,7 @@ namespace IO.Ably.MessageEncoders
                 return Result.Ok();
             }
 
-            var bytes = data as byte[];
-            if (bytes != null && Protocol == Protocol.Json)
+            if (data is byte[] bytes)
             {
                 payload.Data = bytes.ToBase64();
                 AddEncoding(payload, EncodingName);
@@ -36,8 +37,8 @@ namespace IO.Ably.MessageEncoders
             return Result.Ok();
         }
 
-        public Base64Encoder(Protocol protocol)
-            : base(protocol)
+        public Base64Encoder()
+            : base()
         {
         }
     }

--- a/src/IO.Ably.Shared/MessageEncoders/CipherEncoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/CipherEncoder.cs
@@ -5,13 +5,11 @@ namespace IO.Ably.MessageEncoders
 {
     internal class CipherEncoder : MessageEncoder
     {
-        internal ILogger Logger { get; set; }
-
         public override string EncodingName => "cipher";
 
         public override Result Decode(IMessage payload, ChannelOptions options)
         {
-            Logger = options.Logger ?? IO.Ably.DefaultLogger.LoggerInstance;
+            Logger = options?.Logger ?? DefaultLogger.LoggerInstance;
 
             if (IsEmpty(payload.Data))
             {

--- a/src/IO.Ably.Shared/MessageEncoders/CipherEncoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/CipherEncoder.cs
@@ -69,9 +69,9 @@ namespace IO.Ably.MessageEncoders
                 return Result.Ok();
             }
 
-            if (payload.Data is string)
+            if (payload.Data is string data)
             {
-                payload.Data = ((string)payload.Data).GetBytes();
+                payload.Data = data.GetBytes();
                 AddEncoding(payload, "utf-8");
             }
 
@@ -87,8 +87,8 @@ namespace IO.Ably.MessageEncoders
             return payload.Encoding.IsNotEmpty() && payload.Encoding.Contains(EncodingName);
         }
 
-        public CipherEncoder(Protocol protocol)
-            : base(protocol)
+        public CipherEncoder()
+            : base()
         {
         }
     }

--- a/src/IO.Ably.Shared/MessageEncoders/JsonEncoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/JsonEncoder.cs
@@ -11,16 +11,13 @@ namespace IO.Ably.MessageEncoders
     {
         internal ILogger Logger { get; set; }
 
-        public override string EncodingName
-        {
-            get { return "json"; }
-        }
+        public override string EncodingName => "json";
 
         public override Result Decode(IMessage payload, ChannelOptions options)
         {
             Logger = options.Logger;
 
-            if (IsEmpty(payload.Data) || CurrentEncodingIs(payload, EncodingName) == false)
+            if (IsEmpty(payload.Data) || !CurrentEncodingIs(payload, EncodingName))
             {
                 return Result.Ok();
             }
@@ -60,8 +57,8 @@ namespace IO.Ably.MessageEncoders
             return payload.Data is string == false && payload.Data is byte[] == false;
         }
 
-        public JsonEncoder(Protocol protocol)
-            : base(protocol)
+        public JsonEncoder()
+            : base()
         {
         }
     }

--- a/src/IO.Ably.Shared/MessageEncoders/JsonEncoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/JsonEncoder.cs
@@ -9,13 +9,11 @@ namespace IO.Ably.MessageEncoders
 {
     internal class JsonEncoder : MessageEncoder
     {
-        internal ILogger Logger { get; set; }
-
         public override string EncodingName => "json";
 
         public override Result Decode(IMessage payload, ChannelOptions options)
         {
-            Logger = options.Logger;
+            Logger = options?.Logger ?? IO.Ably.DefaultLogger.LoggerInstance;
 
             if (IsEmpty(payload.Data) || !CurrentEncodingIs(payload, EncodingName))
             {

--- a/src/IO.Ably.Shared/MessageEncoders/MessageEncoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/MessageEncoder.cs
@@ -6,6 +6,8 @@ namespace IO.Ably.MessageEncoders
 {
     internal abstract class MessageEncoder
     {
+        internal ILogger Logger { get; set; }
+
         public abstract string EncodingName { get; }
 
         public abstract Result Encode(IMessage payload, ChannelOptions options);

--- a/src/IO.Ably.Shared/MessageEncoders/MessageEncoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/MessageEncoder.cs
@@ -6,13 +6,6 @@ namespace IO.Ably.MessageEncoders
 {
     internal abstract class MessageEncoder
     {
-        protected readonly Protocol Protocol;
-
-        protected MessageEncoder(Protocol protocol)
-        {
-            Protocol = protocol;
-        }
-
         public abstract string EncodingName { get; }
 
         public abstract Result Encode(IMessage payload, ChannelOptions options);
@@ -21,7 +14,7 @@ namespace IO.Ably.MessageEncoders
 
         public bool IsEmpty(object data)
         {
-            return data == null || (data is string && ((string)data).IsEmpty());
+            return data == null || (data is string s && s.IsEmpty());
         }
 
         public void AddEncoding(IMessage payload, string encoding = null)

--- a/src/IO.Ably.Shared/MessageEncoders/MessageHandler.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/MessageHandler.cs
@@ -485,8 +485,23 @@ namespace IO.Ably.MessageEncoders
 
         internal static T FromEncoded<T>(T encoded, ChannelOptions options = null) where T : IMessage
         {
-            DecodePayload(encoded, options);
+            var result = DecodePayload(encoded, options);
+            if (result.IsFailure)
+            {
+                throw new AblyException(result.Error);
+            }
+
             return encoded;
+        }
+
+        internal static T[] FromEncodedArray<T>(T[] encodedArray, ChannelOptions options = null) where T : IMessage
+        {
+            foreach (var encoded in encodedArray)
+            {
+                DecodePayload(encoded, options);
+            }
+
+            return encodedArray;
         }
     }
 }

--- a/src/IO.Ably.Shared/MessageEncoders/MessageHandler.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/MessageHandler.cs
@@ -15,14 +15,28 @@ namespace IO.Ably.MessageEncoders
     {
         internal ILogger Logger { get; private set; }
 
+        public static List<MessageEncoder> Encoders
+        {
+            get
+            {
+                if (_encoders == null)
+                {
+                    InitializeMessageEncoders();
+                }
+
+                return _encoders;
+            }
+        }
+
         private static readonly Type[] UnsupportedTypes = new[]
             {
                 typeof(short), typeof(int), typeof(double), typeof(float), typeof(decimal), typeof(DateTime), typeof(DateTimeOffset), typeof(byte), typeof(bool),
                 typeof(long), typeof(uint), typeof(ulong), typeof(ushort), typeof(sbyte)
             };
 
+        private static object _syncLock = new object();
         private readonly Protocol _protocol;
-        public readonly List<MessageEncoder> Encoders = new List<MessageEncoder>();
+        public static List<MessageEncoder> _encoders = null;
 
         public MessageHandler()
             : this(IO.Ably.DefaultLogger.LoggerInstance, Defaults.Protocol) { }
@@ -35,35 +49,42 @@ namespace IO.Ably.MessageEncoders
             Logger = logger;
             _protocol = protocol;
 
-            InitializeMessageEncoders(protocol);
+            InitializeMessageEncoders();
         }
 
-        private void InitializeMessageEncoders(Protocol protocol)
+        private static void InitializeMessageEncoders()
         {
-            Encoders.Add(new JsonEncoder(protocol));
-            Encoders.Add(new Utf8Encoder(protocol));
-            Encoders.Add(new CipherEncoder(protocol));
-            Encoders.Add(new Base64Encoder(protocol));
+            if (_encoders != null)
+            {
+                return;
+            }
 
-            Logger.Debug(
-                $"Initializing message encodings. {string.Join(",", Encoders.Select(x => x.EncodingName))} initialized");
+            lock (_syncLock)
+            {
+                _encoders = new List<MessageEncoder>
+                {
+                    new JsonEncoder(), new Utf8Encoder(), new CipherEncoder(), new Base64Encoder()
+                };
+            }
         }
 
         public IEnumerable<PresenceMessage> ParsePresenceMessages(AblyResponse response, ChannelOptions options)
         {
-            if (response.Type == ResponseType.Json)
+            if (response.Type != ResponseType.Json)
             {
-                var messages = JsonHelper.Deserialize<List<PresenceMessage>>(response.TextResponse);
-                ProcessMessages(messages, options);
-                return messages;
+                throw new AblyException(
+                    $"Response of type '{response.Type}' is invalid because MsgPack support was not enabled for this build.");
             }
+
+            var messages = JsonHelper.Deserialize<List<PresenceMessage>>(response.TextResponse);
+            ProcessMessages(messages, options);
+            return messages;
 
 #if MSGPACK
             var payloads = MsgPackHelper.Deserialise(response.Body, typeof(List<PresenceMessage>)) as List<PresenceMessage>;
             ProcessMessages(payloads, options);
             return payloads;
 #else
-            throw new AblyException($"Response of type '{response.Type}' is invalid because MsgPack support was not enabled for this build.");
 
 #endif
         }
@@ -177,7 +198,7 @@ namespace IO.Ably.MessageEncoders
             return result;
         }
 
-        internal Result DecodePayloads(ChannelOptions options, IEnumerable<IMessage> payloads)
+        internal static Result DecodePayloads(ChannelOptions options, IEnumerable<IMessage> payloads)
         {
             var result = Result.Ok();
             foreach (var payload in payloads)
@@ -188,7 +209,7 @@ namespace IO.Ably.MessageEncoders
             return result;
         }
 
-        private Result EncodePayload(IMessage payload, ChannelOptions options)
+        private static Result EncodePayload(IMessage payload, ChannelOptions options)
         {
             ValidatePayloadDataType(payload);
             var result = Result.Ok();
@@ -200,7 +221,7 @@ namespace IO.Ably.MessageEncoders
             return result;
         }
 
-        private void ValidatePayloadDataType(IMessage payload)
+        private static void ValidatePayloadDataType(IMessage payload)
         {
             if (payload.Data == null)
             {
@@ -225,7 +246,7 @@ namespace IO.Ably.MessageEncoders
             return Nullable.GetUnderlyingType(type);
         }
 
-        private Result DecodePayload(IMessage payload, ChannelOptions options)
+        private static Result DecodePayload(IMessage payload, ChannelOptions options)
         {
             var result = Result.Ok();
             foreach (var encoder in (Encoders as IEnumerable<MessageEncoder>).Reverse())
@@ -391,7 +412,7 @@ namespace IO.Ably.MessageEncoders
             return result;
         }
 
-        public Result DecodeProtocolMessage(ProtocolMessage protocolMessage, ChannelOptions channelOptions)
+        public static Result DecodeProtocolMessage(ProtocolMessage protocolMessage, ChannelOptions channelOptions)
         {
             var options = channelOptions ?? new ChannelOptions();
 
@@ -400,7 +421,7 @@ namespace IO.Ably.MessageEncoders
                 DecodeMessages(protocolMessage, protocolMessage.Presence, options));
         }
 
-        private Result DecodeMessages(ProtocolMessage protocolMessage, IEnumerable<IMessage> messages, ChannelOptions options)
+        private static Result DecodeMessages(ProtocolMessage protocolMessage, IEnumerable<IMessage> messages, ChannelOptions options)
         {
             var result = Result.Ok();
             var index = 0;
@@ -460,6 +481,12 @@ namespace IO.Ably.MessageEncoders
             isMsgPack = _protocol == Protocol.MsgPack;
 #endif
             return isMsgPack;
+        }
+
+        internal static T FromEncoded<T>(T encoded, ChannelOptions options = null) where T : IMessage
+        {
+            DecodePayload(encoded, options);
+            return encoded;
         }
     }
 }

--- a/src/IO.Ably.Shared/MessageEncoders/Utf8Encoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/Utf8Encoder.cs
@@ -4,8 +4,8 @@ namespace IO.Ably.MessageEncoders
 {
     internal class Utf8Encoder : MessageEncoder
     {
-        public Utf8Encoder(Protocol protocol)
-            : base(protocol)
+        public Utf8Encoder()
+            : base()
         {
         }
 

--- a/src/IO.Ably.Shared/Realtime/ChannelMessageProcessor.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelMessageProcessor.cs
@@ -1,4 +1,5 @@
 using IO.Ably;
+using IO.Ably.MessageEncoders;
 using IO.Ably.Transport;
 using IO.Ably.Types;
 
@@ -68,7 +69,7 @@ namespace IO.Ably.Realtime
 
                     break;
                 case ProtocolMessage.MessageAction.Message:
-                    var result = _connectionManager.Handler.DecodeProtocolMessage(protocolMessage, channel.Options);
+                    var result = MessageHandler.DecodeProtocolMessage(protocolMessage, channel.Options);
                     if (result.IsFailure)
                     {
                         channel.OnError(result.Error);
@@ -81,11 +82,11 @@ namespace IO.Ably.Realtime
 
                     break;
                 case ProtocolMessage.MessageAction.Presence:
-                    _connectionManager.Handler.DecodeProtocolMessage(protocolMessage, channel.Options);
+                    MessageHandler.DecodeProtocolMessage(protocolMessage, channel.Options);
                     channel.Presence.OnPresence(protocolMessage.Presence, null);
                     break;
                 case ProtocolMessage.MessageAction.Sync:
-                    _connectionManager.Handler.DecodeProtocolMessage(protocolMessage, channel.Options);
+                    MessageHandler.DecodeProtocolMessage(protocolMessage, channel.Options);
                     channel.Presence.OnPresence(protocolMessage.Presence, protocolMessage.ChannelSerial);
                     break;
             }

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -406,7 +406,7 @@ namespace IO.Ably.Realtime
                             break;
                         case PresenceAction.Leave:
                             broadcast &= Map.Remove(message);
-                            if (updateInternalPresence)
+                            if (updateInternalPresence && !message.IsSynthesized())
                             {
                                 InternalMap.Remove(message);
                             }

--- a/src/IO.Ably.Shared/Types/Message.cs
+++ b/src/IO.Ably.Shared/Types/Message.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.Runtime.Serialization;
+using IO.Ably.MessageEncoders;
 using IO.Ably.Utils;
 using Newtonsoft.Json;
 
@@ -111,6 +112,16 @@ namespace IO.Ably
                 hashCode = (hashCode * 397) ^ (Encoding != null ? Encoding.GetHashCode() : 0);
                 return hashCode;
             }
+        }
+
+        public static Message FromEncoded(Message encoded, ChannelOptions options = null)
+        {
+            return MessageHandler.FromEncoded(encoded, options);
+        }
+
+        public static Message[] FromEncodedArray(Message[] encoded, ChannelOptions options = null)
+        {
+            return MessageHandler.FromEncodedArray(encoded, options);
         }
     }
 }

--- a/src/IO.Ably.Tests.Shared/MessageEncodes/Base64EncoderTests.cs
+++ b/src/IO.Ably.Tests.Shared/MessageEncodes/Base64EncoderTests.cs
@@ -16,7 +16,7 @@ namespace IO.Ably.Tests.MessageEncodes
             _stringData = "random-string";
             _binaryData = _stringData.GetBytes();
             _base64Data = _binaryData.ToBase64();
-            _encoder = new Base64Encoder(protocol ?? Defaults.Protocol);
+            _encoder = new Base64Encoder();
         }
 
         public class Decode : Base64EncoderTests

--- a/src/IO.Ably.Tests.Shared/MessageEncodes/CipherEncoderTests.cs
+++ b/src/IO.Ably.Tests.Shared/MessageEncodes/CipherEncoderTests.cs
@@ -27,7 +27,7 @@ namespace IO.Ably.Tests.MessageEncodes
             _encryptedData = _crypto.Encrypt(_stringData.GetBytes());
             _encryptedBinaryData = _crypto.Encrypt(_binaryData);
 
-            _encoder = new CipherEncoder(Defaults.Protocol);
+            _encoder = new CipherEncoder();
         }
 
         private byte[] GenerateKey(int keyLength)
@@ -42,7 +42,7 @@ namespace IO.Ably.Tests.MessageEncodes
             public void WithInvalidKeyLength_Throws()
             {
                 var options = new ChannelOptions(new CipherParams(Crypto.DefaultAlgorithm, new byte[] { 1, 2, 3 }));
-                var encoder = new CipherEncoder(Defaults.Protocol);
+                var encoder = new CipherEncoder();
                 var error = Assert.Throws<AblyException>(delegate
                 {
                     encoder.Encode(new Message() { Data = "string" }, options);
@@ -55,7 +55,7 @@ namespace IO.Ably.Tests.MessageEncodes
             public void WithInvalidKey_Throws()
             {
                 var options = new ChannelOptions(new CipherParams(Crypto.DefaultAlgorithm, new byte[] { 1, 2, 3 }));
-                var encoder = new CipherEncoder(Defaults.Protocol);
+                var encoder = new CipherEncoder();
                 var error = Assert.Throws<AblyException>(delegate
                 {
                     encoder.Encode(new Message() { Data = "string" }, options);
@@ -71,7 +71,7 @@ namespace IO.Ably.Tests.MessageEncodes
                 var key = keyGen.GetBytes(Crypto.DefaultKeylength / 8);
 
                 var options = new ChannelOptions(new CipherParams("mgg", key));
-                var encoder = new CipherEncoder(Defaults.Protocol);
+                var encoder = new CipherEncoder();
                 var error = Assert.Throws<AblyException>(delegate
                 {
                     encoder.Encode(new Message() { Data = "string" }, options);

--- a/src/IO.Ably.Tests.Shared/MessageEncodes/JsonEncoderTests.cs
+++ b/src/IO.Ably.Tests.Shared/MessageEncodes/JsonEncoderTests.cs
@@ -17,7 +17,7 @@ namespace IO.Ably.Tests.MessageEncodes
         {
             _objectData = new { Test = "test", Best = "best" };
             _jsonData = JsonHelper.Serialize(_objectData);
-            _encoder = new JsonEncoder(Defaults.Protocol);
+            _encoder = new JsonEncoder();
         }
 
         private Message EncodePayload(object data, string encoding = "")

--- a/src/IO.Ably.Tests.Shared/MessageEncodes/Utf8EncoderTests.cs
+++ b/src/IO.Ably.Tests.Shared/MessageEncodes/Utf8EncoderTests.cs
@@ -14,7 +14,7 @@ namespace IO.Ably.Tests.MessageEncodes
         {
             _stringData = "random_string";
             _byteData = _stringData.GetBytes();
-            _encoder = new Utf8Encoder(Defaults.Protocol);
+            _encoder = new Utf8Encoder();
         }
 
         private Message DecodePayload(object data, string encoding = "")

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -654,7 +654,7 @@ namespace IO.Ably.Tests.Realtime
 
             var channel = client.Channels.Get("test".AddRandomSuffix());
 
-            var tsc = new TaskCompletionAwaiter(5000);
+            var tsc = new TaskCompletionAwaiter(15000);
             client.Connection.Once(ConnectionEvent.Disconnected, change =>
             {
                 // place a message on the queue

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -265,6 +265,7 @@ namespace IO.Ably.Tests.Realtime
             [Theory]
             [ProtocolData]
             [Trait("spec", "RTP17")]
+            [Trait("spec", "RTP17b")]
             public async Task Presence_ShouldHaveInternalMapForCurrentConnectionId(Protocol protocol)
             {
                 /*
@@ -379,6 +380,19 @@ namespace IO.Ably.Tests.Realtime
                 msgB.ConnectionId.Should().Be(clientB.Connection.Id);
                 msgB.Data.ToString().Should().Be("chB-update");
                 channelB.Presence.Map.Members.Should().HaveCount(2);
+                channelB.Presence.InternalMap.Members.Should().HaveCount(1);
+
+                // LEAVE with synthesized message
+                msgA = null;
+                msgB = null;
+                var synthesizedMsg = new PresenceMessage(PresenceAction.Leave, clientB.ClientId) { ConnectionId = null };
+                synthesizedMsg.IsSynthesized().Should().BeTrue();
+                channelB.Presence.OnPresence(new[] { synthesizedMsg }, null);
+
+                msgB.Should().BeNull();
+                channelB.Presence.Map.Members.Should().HaveCount(2);
+
+                // message was synthesized so should not have been removed (RTP17b)
                 channelB.Presence.InternalMap.Members.Should().HaveCount(1);
 
                 // LEAVE

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;
 using IO.Ably.Encryption;
@@ -558,6 +559,125 @@ namespace IO.Ably.Tests.Rest
             }
 
             return data;
+        }
+
+        [Trait("spec", "TM3")]
+        public class TM3Spec : SandboxSpecs
+        {
+            [Fact]
+            [Trait("spec", "TM3")]
+            public async Task Message_FromEncoded_WithNoEncoding()
+            {
+                var msg = new Message("name", "some-data");
+                var fromEncoded = Message.FromEncoded(msg);
+
+                fromEncoded.Name.Should().Be("name");
+                fromEncoded.Data.Should().Be("some-data");
+                fromEncoded.Encoding.Should().BeNullOrEmpty();
+            }
+
+            [Fact]
+            [Trait("spec", "TM3")]
+            public async Task Message_FromEncoded_WithEncoding()
+            {
+                var d = new Dictionary<string, string>
+                {
+                    { "foo", "bar" },
+                    { "baz", "qux" }
+                };
+
+                var msg = new Message("name", JsonHelper.Serialize(d)) { Encoding = "json" };
+                var fromEncoded = Message.FromEncoded(msg);
+
+                fromEncoded.Name.Should().Be("name");
+                fromEncoded.Data.ShouldBeEquivalentTo(d);
+                fromEncoded.Encoding.Should().BeNullOrEmpty();
+            }
+
+            [Fact]
+            [Trait("spec", "TM3")]
+            public async Task Message_FromEncoded_WithCustomEncoding()
+            {
+                var d = new Dictionary<string, string>
+                {
+                    { "foo", "bar" },
+                    { "baz", "qux" }
+                };
+
+                var msg = new Message("name", JsonHelper.Serialize(d)) { Encoding = "foo/json" };
+                var fromEncoded = Message.FromEncoded(msg);
+
+                fromEncoded.Name.Should().Be("name");
+                fromEncoded.Data.ShouldBeEquivalentTo(d);
+                fromEncoded.Encoding.Should().Be("foo");
+            }
+
+            [Fact]
+            [Trait("spec", "TM3")]
+            public async Task Message_FromEncoded_WithCipherEncoding()
+            {
+                var cipherParams = Crypto.GetDefaultParams(Crypto.GenerateRandomKey(128), null, CipherMode.CBC);
+
+                var crypto = Crypto.GetCipher(cipherParams);
+                var payload = "payload".AddRandomSuffix();
+
+                var msg = new Message("name", crypto.Encrypt(Encoding.UTF8.GetBytes(payload))) { Encoding = "utf-8/cipher+aes-128-cbc" };
+                var fromEncoded = Message.FromEncoded(msg, new ChannelOptions(cipherParams));
+
+                fromEncoded.Name.Should().Be("name");
+                fromEncoded.Data.ShouldBeEquivalentTo(payload);
+                fromEncoded.Encoding.Should().BeNullOrEmpty();
+            }
+
+            [Fact]
+            [Trait("spec", "TM3")]
+            public async Task Message_FromEncoded_WithInvalidCipherEncoding()
+            {
+                var cipherParams = Crypto.GetDefaultParams(Crypto.GenerateRandomKey(128), null, CipherMode.CBC);
+                var payload = "some-invalid-payload".AddRandomSuffix();
+
+                var msg = new Message("name", Encoding.UTF8.GetBytes(payload)) { Encoding = "utf-8/cipher+aes-128-cbc" };
+
+                bool didThrow = false;
+                try
+                {
+                    var fromEncoded = Message.FromEncoded(msg, new ChannelOptions(cipherParams));
+                }
+                catch (Exception e)
+                {
+                    didThrow = true;
+                }
+
+                didThrow.Should().BeTrue();
+            }
+
+            [Fact]
+            [Trait("spec", "TM3")]
+            public async Task Message_FromEncodedArray_WithNoEncoding()
+            {
+                var msg = new[]
+                {
+                    new Message("name1", "some-data1"),
+                    new Message("name2", "some-data2")
+                };
+
+                var fromEncoded = Message.FromEncodedArray(msg);
+
+                fromEncoded.Should().HaveCount(2);
+
+                fromEncoded[0].Name.Should().Be("name1");
+                fromEncoded[0].Data.Should().Be("some-data1");
+                fromEncoded[0].Encoding.Should().BeNullOrEmpty();
+
+                fromEncoded[1].Name.Should().Be("name2");
+                fromEncoded[1].Data.Should().Be("some-data2");
+                fromEncoded[1].Encoding.Should().BeNullOrEmpty();
+            }
+
+            public TM3Spec(AblySandboxFixture fixture, ITestOutputHelper output)
+                : base(fixture, output)
+            {
+            }
         }
     }
 }

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
@@ -590,7 +590,7 @@ namespace IO.Ably.Tests.Rest
                 var fromEncoded = Message.FromEncoded(msg);
 
                 fromEncoded.Name.Should().Be("name");
-                fromEncoded.Data.ShouldBeEquivalentTo(d);
+                JsonHelper.Serialize(fromEncoded.Data).Should().Be(JsonHelper.Serialize(d));
                 fromEncoded.Encoding.Should().BeNullOrEmpty();
             }
 
@@ -608,7 +608,7 @@ namespace IO.Ably.Tests.Rest
                 var fromEncoded = Message.FromEncoded(msg);
 
                 fromEncoded.Name.Should().Be("name");
-                fromEncoded.Data.ShouldBeEquivalentTo(d);
+                JsonHelper.Serialize(fromEncoded.Data).Should().Be(JsonHelper.Serialize(d));
                 fromEncoded.Encoding.Should().Be("foo");
             }
 


### PR DESCRIPTION
Message.FromEncoded and Message.FromEncodedArray

Adding this required quite a bit of refactoring as the message encoders were instanced with in the MessageHandler class and that was initialised with the AblyRealtime instance so I had to move something things around to make it work with the static methods. In addition to enabling the new methods to be added more easily I think the design is simpler now (and thus better).

The tests that I have added are based on those in the Ruby lib.

- (TM3) fromEncoded and fromEncodedArray are alternative constructors that take an (already deserialized) Message-like object (or array of such objects), and optionally a channelOptions, and return a Message (or array of such Messages) that's decoded and decrypted as specified in RSL6, using the cipher in the channelOptions if the message is encrypted, with any residual transforms (ones that the library cannot decode or decrypt) left in the encoding property per RSL6b. This is intended for users receiving messages other than from a REST or Realtime channel (for example, from a queue), to avoid them having to parse the encoding string themselves.