### PR TITLE
RTP17b test identification

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -406,7 +406,7 @@ namespace IO.Ably.Realtime
                             break;
                         case PresenceAction.Leave:
                             broadcast &= Map.Remove(message);
-                            if (updateInternalPresence)
+                            if (updateInternalPresence && !message.IsSynthesized())
                             {
                                 InternalMap.Remove(message);
                             }

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -654,7 +654,7 @@ namespace IO.Ably.Tests.Realtime
 
             var channel = client.Channels.Get("test".AddRandomSuffix());
 
-            var tsc = new TaskCompletionAwaiter(5000);
+            var tsc = new TaskCompletionAwaiter(15000);
             client.Connection.Once(ConnectionEvent.Disconnected, change =>
             {
                 // place a message on the queue

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -382,7 +382,7 @@ namespace IO.Ably.Tests.Realtime
                 channelB.Presence.Map.Members.Should().HaveCount(2);
                 channelB.Presence.InternalMap.Members.Should().HaveCount(1);
 
-                // LEAVE
+                // LEAVE with synthesized message
                 msgA = null;
                 msgB = null;
                 await WaitForMultiple(2, partialDone =>
@@ -417,6 +417,36 @@ namespace IO.Ably.Tests.Realtime
                 msgB.Data.ToString().Should().Be("chB-leave");
                 channelB.Presence.Map.Members.Should().HaveCount(1);
                 channelB.Presence.InternalMap.Members.Should().HaveCount(0);
+
+                msgA = null;
+                msgB = null;
+                await WaitForMultiple(2, partialDone =>
+                {
+                    channelA.Presence.Subscribe(msg =>
+                    {
+                        msgA = msg;
+                        channelA.Presence.Unsubscribe();
+                        partialDone();
+                    });
+
+                    var synthesizedMsg = new PresenceMessage(PresenceAction.Leave, clientB.ClientId) { ConnectionId = null };
+                    synthesizedMsg.IsSynthesized().Should().BeTrue();
+                    channelB.Presence.OnPresence(new[] { synthesizedMsg }, null);
+                    partialDone();
+                });
+
+                msgA.Should().NotBeNull();
+                msgA.Action.Should().Be(PresenceAction.Leave);
+                msgA.ConnectionId.Should().NotBe(clientA.Connection.Id);
+                msgA.Data.ToString().Should().Be("chB-leave");
+                channelA.Presence.Map.Members.Should().HaveCount(1);
+                channelA.Presence.InternalMap.Members.Should().HaveCount(1);
+
+                msgB.Should().BeNull();
+                channelB.Presence.Map.Members.Should().HaveCount(1);
+
+                // message was synthesized so should not have been removed (RTP17b)
+                channelB.Presence.InternalMap.Members.Should().HaveCount(1);
 
                 // clean up
                 clientA.Close();

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -265,6 +265,7 @@ namespace IO.Ably.Tests.Realtime
             [Theory]
             [ProtocolData]
             [Trait("spec", "RTP17")]
+            [Trait("spec", "RTP17b")]
             public async Task Presence_ShouldHaveInternalMapForCurrentConnectionId(Protocol protocol)
             {
                 /*


### PR DESCRIPTION
A quick PR to add a 'trait' to an existing test that covers RTP17b but was not labeled as such.