### PR TITLE
Fix for issue #299. 

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -450,6 +450,10 @@ namespace IO.Ably.Tests.Realtime
             channel.State.Should().Be(ChannelState.Attached);
             client.ConnectionManager.PendingMessages.Should().HaveCount(0);
 
+            var history = await channel.HistoryAsync();
+            history.Items.Should().HaveCount(1);
+            history.Items[0].Data.Should().Be("foo");
+
             // clean up
             client.Close();
         }
@@ -532,6 +536,10 @@ namespace IO.Ably.Tests.Realtime
 
             // queued messages should now have been sent
             client.ConnectionManager.PendingMessages.Should().HaveCount(0);
+
+            var history = await channel.HistoryAsync();
+            history.Items.Should().HaveCount(1);
+            history.Items[0].Data.Should().Be("foo");
 
             // clean up
             client.Close();


### PR DESCRIPTION
A fix for issue #299 

These changes to test for RTN15c1 and RTN15c2 verify that the message was processed (ie publish…ed) and not just discarded.

This is demonstrated by pulling the history for the channel.

