### PR TITLE
RTP16b fix

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -349,7 +349,7 @@ namespace IO.Ably.Realtime
             {
                 msg.Callback?.Invoke(
                     false,
-                    new ErrorInfo("Unable enqueue message because Options.QueueMessages is set to False.", 50000, HttpStatusCode.InternalServerError));
+                    new ErrorInfo("Unable enqueue message because Options.QueueMessages is set to False.", _connection.Connection.ConnectionState.DefaultErrorInfo.Code, HttpStatusCode.ServiceUnavailable));
 
                 return false;
             }

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -323,18 +323,14 @@ namespace IO.Ably.Realtime
             switch (_channel.State)
             {
                 case ChannelState.Initialized:
-                    if (_connection.Options.QueueMessages)
+                    if (PendingPresenceEnqueue(new QueuedPresenceMessage(msg, callback)))
                     {
-                        PendingPresenceQueue.Enqueue(new QueuedPresenceMessage(msg, callback));
                         _channel.Attach();
                     }
 
                     break;
                 case ChannelState.Attaching:
-                    if (_connection.Options.QueueMessages)
-                    {
-                        PendingPresenceQueue.Enqueue(new QueuedPresenceMessage(msg, callback));
-                    }
+                    PendingPresenceEnqueue(new QueuedPresenceMessage(msg, callback));
 
                     break;
                 case ChannelState.Attached:
@@ -345,6 +341,21 @@ namespace IO.Ably.Realtime
                 default:
                     throw new AblyException($"Unable to enter presence channel in {_channel.State} state", 91001, HttpStatusCode.BadRequest);
             }
+        }
+
+        private bool PendingPresenceEnqueue(QueuedPresenceMessage msg)
+        {
+            if (!_connection.Options.QueueMessages)
+            {
+                msg.Callback?.Invoke(
+                    false,
+                    new ErrorInfo("Unable enqueue message because Options.QueueMessages is set to False.", 50000, HttpStatusCode.InternalServerError));
+
+                return false;
+            }
+
+            PendingPresenceQueue.Enqueue(msg);
+            return true;
         }
 
         internal void ResumeSync()

--- a/src/IO.Ably.Shared/Transport/ConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading.Tasks;
 using IO.Ably.MessageEncoders;
 using IO.Ably.Realtime;
@@ -352,7 +353,9 @@ namespace IO.Ably.Transport
                 }
                 else
                 {
-                    throw new AblyException($"Current state is [{State.State}] which supports queuing but Options.QueueMessages is set to False.");
+                    throw new AblyException($"Current state is [{State.State}] which supports queuing but Options.QueueMessages is set to False.",
+                        Connection.ConnectionState.DefaultErrorInfo.Code,
+                        HttpStatusCode.ServiceUnavailable);
                 }
 
                 return;

--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionClosedState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionClosedState.cs
@@ -6,6 +6,8 @@ namespace IO.Ably.Transport.States.Connection
 {
     internal class ConnectionClosedState : ConnectionStateBase
     {
+        public new ErrorInfo DefaultErrorInfo => ErrorInfo.ReasonClosed;
+
         public ConnectionClosedState(IConnectionContext context, ILogger logger)
             : this(context, null, logger)
         {

--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionDisconnectedState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionDisconnectedState.cs
@@ -8,6 +8,8 @@ namespace IO.Ably.Transport.States.Connection
     {
         private readonly ICountdownTimer _timer;
 
+        public new ErrorInfo DefaultErrorInfo => ErrorInfo.ReasonDisconnected;
+
         public ConnectionDisconnectedState(IConnectionContext context, ILogger logger)
             : this(context, null, new CountdownTimer("Disconnected state timer", logger), logger)
         {

--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionFailedState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionFailedState.cs
@@ -6,6 +6,8 @@ namespace IO.Ably.Transport.States.Connection
 {
     internal class ConnectionFailedState : ConnectionStateBase
     {
+        public new ErrorInfo DefaultErrorInfo => ErrorInfo.ReasonFailed;
+
         public ConnectionFailedState(IConnectionContext context, ErrorInfo error, ILogger logger)
             : base(context, logger)
         {

--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionState.cs
@@ -33,6 +33,8 @@ namespace IO.Ably.Transport.States.Connection
 
         public virtual bool IsUpdate { get; protected set; }
 
+        public ErrorInfo DefaultErrorInfo => ErrorInfo.ReasonUnknown;
+
         public virtual void Connect()
         {
         }

--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionSuspendedState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionSuspendedState.cs
@@ -7,6 +7,8 @@ namespace IO.Ably.Transport.States.Connection
     {
         private readonly ICountdownTimer _timer;
 
+        public new ErrorInfo DefaultErrorInfo => ErrorInfo.ReasonSuspended;
+
         public ConnectionSuspendedState(IConnectionContext context, ILogger logger)
             : this(context, null, new CountdownTimer("Suspended state timer", logger), logger)
         {

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -654,7 +654,7 @@ namespace IO.Ably.Tests.Realtime
 
             var channel = client.Channels.Get("test".AddRandomSuffix());
 
-            var tsc = new TaskCompletionAwaiter(5000);
+            var tsc = new TaskCompletionAwaiter(20000);
             client.Connection.Once(ConnectionEvent.Disconnected, change =>
             {
                 // place a message on the queue


### PR DESCRIPTION
Changes to address comments in issue #298 

> If queueMessages is false, and the message is not queued, then it should be rejected at this stage, so there should be a check here for the relevant error.

The message was not being rejected, so I have added that functionality and updated the test