### PR TITLE
RTL11 test regression fix

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -654,7 +654,7 @@ namespace IO.Ably.Tests.Realtime
 
             var channel = client.Channels.Get("test".AddRandomSuffix());
 
-            var tsc = new TaskCompletionAwaiter(5000);
+            var tsc = new TaskCompletionAwaiter(15000);
             client.Connection.Once(ConnectionEvent.Disconnected, change =>
             {
                 // place a message on the queue


### PR DESCRIPTION
After a recent sandbox release the test for RTL11 started failing. Increasing the timeout form 5000ms to 15000ms seem to solve the issue and doesn't compromise the test, so I am submitting that as the fix