### PR TITLE
HistoryRequestParams fix

### DIFF
--- a/src/IO.Ably.Shared/PaginatedRequestParams.cs
+++ b/src/IO.Ably.Shared/PaginatedRequestParams.cs
@@ -28,6 +28,7 @@ namespace IO.Ably
 
         public object Body { get; set; }
 
+
         public string Path { get; set; }
 
         /// <summary>
@@ -237,4 +238,13 @@ namespace IO.Ably
             }
         }
     }
+
+    /// <inheritdoc />
+    /// <summary>
+    ///     Data request query used for querying history.
+    ///     Functionally identical to <see cref="PaginatedRequestParams"/> and present for backwards compatibility with 0.8 release
+    /// </summary>
+    public class HistoryRequestParams
+        : PaginatedRequestParams
+    { }
 }

--- a/src/IO.Ably.Shared/PaginatedRequestParams.cs
+++ b/src/IO.Ably.Shared/PaginatedRequestParams.cs
@@ -28,7 +28,6 @@ namespace IO.Ably
 
         public object Body { get; set; }
 
-
         public string Path { get; set; }
 
         /// <summary>
@@ -244,6 +243,7 @@ namespace IO.Ably
     ///     Data request query used for querying history.
     ///     Functionally identical to <see cref="PaginatedRequestParams"/> and present for backwards compatibility with 0.8 release
     /// </summary>
+    [Obsolete("HistoryRequestParams may be removed in future versions, please use PaginatedRequestParams instead.")]
     public class HistoryRequestParams
         : PaginatedRequestParams
     { }

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
@@ -289,6 +289,33 @@ namespace IO.Ably.Tests.Rest
 
             [Fact]
             [Trait("spec", "RSL2b")]
+            public async Task WithOptions_AddsParametersToRequest_UsingCompatHistoryParams()
+            {
+                /*
+                 * In a breaking change in the 1.1 release HistoryRequestParams was replaced with PaginatedRequestParams.
+                 * To fix this backward compatibility issue a new HistoryRequestParams class the inherits from PaginatedRequestParams
+                 * has been created.
+                 *
+                 * This test demonstrates that HistoryRequestParams can be used to call
+                 * HistoryAsync (which accepts a PaginatedRequestParams instance as a parameter.
+                 */
+
+                var query = new HistoryRequestParams();
+                var now = DateTimeOffset.Now;
+                query.Start = now.AddHours(-1);
+                query.End = now;
+                query.Direction = QueryDirection.Forwards;
+                query.Limit = 1000;
+                await _channel.HistoryAsync(query);
+
+                LastRequest.AssertContainsParameter("start", query.Start.Value.ToUnixTimeInMilliseconds().ToString());
+                LastRequest.AssertContainsParameter("end", query.End.Value.ToUnixTimeInMilliseconds().ToString());
+                LastRequest.AssertContainsParameter("direction", query.Direction.ToString().ToLower());
+                LastRequest.AssertContainsParameter("limit", query.Limit.Value.ToString());
+            }
+
+            [Fact]
+            [Trait("spec", "RSL2b")]
             public async Task WithStartBeforeEnd_Throws()
             {
                 var ex = await Assert.ThrowsAsync<AblyException>(() =>


### PR DESCRIPTION
When upgrading to 1.1 `HistoryRequestParams` was replaced with PaginatedRequestParams (as part of a process of reducing code duplication) which has created a breaking change for people moving from 0.8.

The fix presented here is to create new `HistoryRequestParams` class that inherits from `PaginatedRequestParams`.