### PR TITLE
Idempotent defaults to off for version < 1.2

### DIFF
--- a/src/IO.Ably.Shared/ClientOptions.cs
+++ b/src/IO.Ably.Shared/ClientOptions.cs
@@ -268,7 +268,7 @@ namespace IO.Ably
         internal void SetIdempotentRestPublishingDefault(int majorVersion, int minorVersion)
         {
             // (TO3n) idempotentRestPublishing defaults to false for clients with version < 1.1, otherwise true.
-            if ((majorVersion == 1 && minorVersion >= 1) || majorVersion > 1)
+            if ((majorVersion == 1 && minorVersion >= 2) || majorVersion > 1)
             {
                 IdempotentRestPublishing = true;
             }

--- a/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
@@ -323,7 +323,7 @@ namespace IO.Ably.Tests
                 var clientOptions = new ClientOptions();
 
                 // Now working against 1.1+ so this should be true
-                clientOptions.IdempotentRestPublishing.Should().BeTrue();
+                clientOptions.IdempotentRestPublishing.Should().BeFalse();
 
                 // Test the internal method that is called from
                 // ClientOptions constructor with different
@@ -335,7 +335,10 @@ namespace IO.Ably.Tests
                 clientOptions.IdempotentRestPublishing.Should().BeFalse();
 
                 clientOptions.SetIdempotentRestPublishingDefault(1, 1);
-                clientOptions.IdempotentRestPublishing.Should().BeTrue();
+                clientOptions.IdempotentRestPublishing.Should().BeFalse();
+
+                clientOptions.SetIdempotentRestPublishingDefault(1, 2);
+                clientOptions.IdempotentRestPublishing.Should().BeFalse();
 
                 clientOptions.SetIdempotentRestPublishingDefault(2, 0);
                 clientOptions.IdempotentRestPublishing.Should().BeTrue();


### PR DESCRIPTION
A fix for idempotent publishing defaulting to on in 1.1.

See Issue #275 for more