### PR TITLE
Add InnerException to ErrorInfo proposal

### DIFF
--- a/src/IO.Ably.Shared/AblyAuth.cs
+++ b/src/IO.Ably.Shared/AblyAuth.cs
@@ -253,6 +253,7 @@ namespace IO.Ably
             }
             else if (authOptions.AuthUrl.IsNotEmpty())
             {
+                var responseText = String.Empty;
                 try
                 {
                     var response = await CallAuthUrl(authOptions, tokenParams);
@@ -265,15 +266,15 @@ namespace IO.Ably
                         return new TokenDetails(response.TextResponse, Now);
                     }
 
-                    var signedData = response.TextResponse;
-                    var jData = JObject.Parse(signedData);
+                    responseText = response.TextResponse;
+                    var jData = JObject.Parse(responseText);
 
                     if (TokenDetails.IsToken(jData))
                     {
                         return JsonHelper.DeserializeObject<TokenDetails>(jData);
                     }
 
-                    postData = JsonHelper.Deserialize<TokenRequest>(signedData);
+                    postData = JsonHelper.Deserialize<TokenRequest>(responseText);
 
                     request.Url = $"/keys/{postData.KeyName}/requestToken";
                 }
@@ -283,7 +284,31 @@ namespace IO.Ably
                         new ErrorInfo(
                             "Error calling Auth URL, token request failed. See the InnerException property for details of the underlying exception.",
                             80019,
-                            ex.ErrorInfo.StatusCode == HttpStatusCode.Forbidden ? ex.ErrorInfo.StatusCode : HttpStatusCode.Unauthorized),
+                            ex.ErrorInfo.StatusCode == HttpStatusCode.Forbidden
+                                ? ex.ErrorInfo.StatusCode
+                                : HttpStatusCode.Unauthorized,
+                            null,
+                            ex),
+                        ex);
+                }
+                catch (Exception ex)
+                {
+                    string reason =
+                        "Error handling Auth URL, token request failed. See the InnerException property for details of the underlying exception.";
+
+                    if (ex is JsonReaderException)
+                    {
+                        reason =
+                            $"Error parsing JSON response '{responseText}' from Auth URL.See the InnerException property for details of the underlying exception.";
+                    }
+
+                    throw new AblyException(
+                        new ErrorInfo(
+                            reason,
+                            80019,
+                            HttpStatusCode.InternalServerError,
+                            null,
+                            ex),
                         ex);
                 }
             }

--- a/src/IO.Ably.Shared/AblyAuth.cs
+++ b/src/IO.Ably.Shared/AblyAuth.cs
@@ -287,7 +287,6 @@ namespace IO.Ably
                             ex.ErrorInfo.StatusCode == HttpStatusCode.Forbidden
                                 ? ex.ErrorInfo.StatusCode
                                 : HttpStatusCode.Unauthorized,
-                            null,
                             ex),
                         ex);
                 }
@@ -307,7 +306,6 @@ namespace IO.Ably
                             reason,
                             80019,
                             HttpStatusCode.InternalServerError,
-                            null,
                             ex),
                         ex);
                 }

--- a/src/IO.Ably.Shared/AblyException.cs
+++ b/src/IO.Ably.Shared/AblyException.cs
@@ -62,7 +62,7 @@ namespace IO.Ably
         /// Creates AblyException with supplied error info.
         /// </summary>
         public AblyException(ErrorInfo info)
-            : base(info.ToString())
+            : base(info.ToString(), info.InnerException)
         {
             ErrorInfo = info;
         }
@@ -71,16 +71,11 @@ namespace IO.Ably
         /// Creates AblyException with ErrorInfo and sets the supplied exception as innerException
         /// </summary>
         public AblyException(ErrorInfo info, Exception innerException)
-            : base(info.ToString(), innerException)
+            : base(info.ToString(), innerException ?? info.InnerException)
         {
             ErrorInfo = info;
         }
 
-        /* protected AblyException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
-        {
-
-        } */
         public ErrorInfo ErrorInfo { get; set; }
 
         internal static AblyException FromResponse(AblyResponse response)

--- a/src/IO.Ably.Shared/ClientOptions.cs
+++ b/src/IO.Ably.Shared/ClientOptions.cs
@@ -268,7 +268,7 @@ namespace IO.Ably
         internal void SetIdempotentRestPublishingDefault(int majorVersion, int minorVersion)
         {
             // (TO3n) idempotentRestPublishing defaults to false for clients with version < 1.1, otherwise true.
-            if ((majorVersion == 1 && minorVersion >= 1) || majorVersion > 1)
+            if ((majorVersion == 1 && minorVersion >= 2) || majorVersion > 1)
             {
                 IdempotentRestPublishing = true;
             }

--- a/src/IO.Ably.Shared/Types/ErrorInfo.cs
+++ b/src/IO.Ably.Shared/Types/ErrorInfo.cs
@@ -60,6 +60,14 @@ namespace IO.Ably
         public bool IsTokenError => Code >= Defaults.TokenErrorCodesRangeStart &&
                                     Code <= Defaults.TokenErrorCodesRangeEnd;
 
+        /// <summary>
+        /// Get or Sets the InnerException
+        /// </summary>
+        public Exception InnerException { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ErrorInfo"/> class.
+        /// </summary>
         public ErrorInfo() { }
 
         public ErrorInfo(string reason)
@@ -68,11 +76,11 @@ namespace IO.Ably
         }
 
         public ErrorInfo(string reason, int code)
-            : this(reason, code, null)
+            : this(reason, code, null, null, null)
         {
         }
 
-        public ErrorInfo(string reason, int code, HttpStatusCode? statusCode = null, string href = null)
+        public ErrorInfo(string reason, int code, HttpStatusCode? statusCode = null, string href = null, Exception innerException = null)
         {
             Code = code;
             StatusCode = statusCode;
@@ -85,6 +93,8 @@ namespace IO.Ably
             {
                 Href = href;
             }
+
+            InnerException = innerException;
         }
 
         public override string ToString()

--- a/src/IO.Ably.Shared/Types/ErrorInfo.cs
+++ b/src/IO.Ably.Shared/Types/ErrorInfo.cs
@@ -10,6 +10,7 @@ namespace IO.Ably
     /// <summary>
     /// An exception type encapsulating error informaiton containing an Ably specific error code and generic status code
     /// </summary>
+    [Serializable]
     public class ErrorInfo
     {
         internal static readonly ErrorInfo ReasonClosed = new ErrorInfo("Connection closed by client", 10000);
@@ -27,15 +28,21 @@ namespace IO.Ably
         internal const string ReasonPropertyName = "message";
         internal const string HrefBase = "https://help.ably.io/error/";
 
-        /// <summary>Ably error code (see https://github.com/ably/ably-common/blob/master/protocol/errors.json) </summary>
+        /// <summary>
+        /// Ably error code (see https://github.com/ably/ably-common/blob/master/protocol/errors.json)
+        /// </summary>
         [JsonProperty("code")]
         public int Code { get; set; }
 
-        /// <summary>The http status code corresponding to this error</summary>
+        /// <summary>
+        /// The http status code corresponding to this error
+        /// </summary>
         [JsonProperty("statusCode")]
         public HttpStatusCode? StatusCode { get; set; }
 
-        /// <summary>Additional reason information, where available</summary>
+        /// <summary>
+        /// Additional reason information, where available
+        /// </summary>
         [JsonProperty("message")]
         public string Message { get; set; }
 
@@ -44,6 +51,8 @@ namespace IO.Ably
         /// </summary>
         [JsonProperty("href")]
         public string Href { get; set; }
+
+        public ErrorInfo Cause { get; set; }
 
         /// <summary>
         /// Is this Error as result of a 401 Unauthorized HTTP response
@@ -80,7 +89,12 @@ namespace IO.Ably
         {
         }
 
-        public ErrorInfo(string reason, int code, HttpStatusCode? statusCode = null, string href = null, Exception innerException = null)
+        public ErrorInfo(string reason, int code, HttpStatusCode? statusCode, Exception innerException)
+            : this(reason, code, statusCode, null, null, innerException)
+        {
+        }
+
+        public ErrorInfo(string reason, int code, HttpStatusCode? statusCode = null, string href = null, ErrorInfo cause = null, Exception innerException = null)
         {
             Code = code;
             StatusCode = statusCode;
@@ -93,7 +107,7 @@ namespace IO.Ably
             {
                 Href = href;
             }
-
+            Cause = cause;
             InnerException = innerException;
         }
 

--- a/src/IO.Ably.Shared/Types/ErrorInfo.cs
+++ b/src/IO.Ably.Shared/Types/ErrorInfo.cs
@@ -52,6 +52,10 @@ namespace IO.Ably
         [JsonProperty("href")]
         public string Href { get; set; }
 
+        /// <summary>
+        /// Additional cause information, where available
+        /// </summary>
+        [JsonProperty("cause")]
         public ErrorInfo Cause { get; set; }
 
         /// <summary>
@@ -114,23 +118,34 @@ namespace IO.Ably
         public override string ToString()
         {
             StringBuilder result = new StringBuilder("[ErrorInfo ");
-            result.Append("Reason: ").Append(LogMessage()).Append("; ");
+            result.Append("Reason: ").Append(LogMessage());
             if (Code > 0)
             {
-                result.Append("Code: ").Append(Code).Append("; ");
+                result.Append("; Code: ").Append(Code);
             }
 
             if (StatusCode != null)
             {
-                result.Append("StatusCode: ").Append((int)StatusCode).Append(" (").Append(StatusCode.ToString()).Append(")").Append("; ");
+                result.Append("; StatusCode: ").Append((int)StatusCode).Append(" (").Append(StatusCode.ToString())
+                    .Append(")");
             }
 
             if (Href != null)
             {
-                result.Append("Href: ").Append(Href).Append(";");
+                result.Append("; Href: ").Append(Href);
             }
 
-            result.Append(']');
+            if (Cause != null)
+            {
+                result.Append("; Cause: ").Append(Cause);
+            }
+
+            if (InnerException != null)
+            {
+                result.Append("; InnerException: ").Append(InnerException);
+            }
+
+            result.Append("]");
             return result.ToString();
         }
 

--- a/src/IO.Ably.Tests.DotNetCore20/IO.Ably.Tests.DotNetCore20.csproj
+++ b/src/IO.Ably.Tests.DotNetCore20/IO.Ably.Tests.DotNetCore20.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.2.1" />
+    <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.Build" Version="15.5.180" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
@@ -34,10 +34,13 @@
     <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="System.Runtime" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.analyzers" Version="0.8.0" />
-    <PackageReference Include="xunit.assert" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.analyzers" Version="0.10.0" />
+    <PackageReference Include="xunit.assert" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="XunitRetry" Version="2.0.0" />
   </ItemGroup>
 

--- a/src/IO.Ably.Tests.NETFramework/IO.Ably.Tests.NETFramework.csproj
+++ b/src/IO.Ably.Tests.NETFramework/IO.Ably.Tests.NETFramework.csproj
@@ -88,7 +88,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Castle.Core">
-      <Version>4.2.1</Version>
+      <Version>4.4.0</Version>
     </PackageReference>
     <PackageReference Include="FluentAssertions">
       <Version>4.19.4</Version>
@@ -97,7 +97,7 @@
       <Version>15.5.180</Version>
     </PackageReference>
     <PackageReference Include="Moq">
-      <Version>4.8.1</Version>
+      <Version>4.10.1</Version>
     </PackageReference>
     <PackageReference Include="MsgPack.Cli">
       <Version>0.9.2</Version>
@@ -109,16 +109,18 @@
       <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="StyleCop.Analyzers">
-      <Version>1.0.2</Version>
+      <Version>1.1.118</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="System.Net.Http">
       <Version>4.3.3</Version>
     </PackageReference>
     <PackageReference Include="xunit">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="xunit.assert">
-      <Version>2.3.1</Version>
+      <Version>2.4.1</Version>
     </PackageReference>
     <PackageReference Include="XunitRetry">
       <Version>2.0.0</Version>

--- a/src/IO.Ably.Tests.Shared/ErrorInfoTests.cs
+++ b/src/IO.Ably.Tests.Shared/ErrorInfoTests.cs
@@ -3,6 +3,8 @@ using Xunit;
 
 namespace IO.Ably.Tests
 {
+    using System;
+
     public class ErrorInfoTests
     {
         [Fact]
@@ -45,7 +47,7 @@ namespace IO.Ably.Tests
             var errorInfo = new ErrorInfo("Error Reason", 1000, HttpStatusCode.Accepted);
 
             // Assert
-            Assert.Equal("[ErrorInfo Reason: Error Reason (See https://help.ably.io/error/1000); Code: 1000; StatusCode: 202 (Accepted); Href: https://help.ably.io/error/1000;]", errorInfo.ToString());
+            Assert.Equal("[ErrorInfo Reason: Error Reason (See https://help.ably.io/error/1000); Code: 1000; StatusCode: 202 (Accepted); Href: https://help.ably.io/error/1000]", errorInfo.ToString());
         }
 
         [Fact]
@@ -57,7 +59,7 @@ namespace IO.Ably.Tests
             var errorInfo = new ErrorInfo("Reason", 1000);
 
             // Assert
-            Assert.Equal("[ErrorInfo Reason: Reason (See https://help.ably.io/error/1000); Code: 1000; Href: https://help.ably.io/error/1000;]", errorInfo.ToString());
+            Assert.Equal("[ErrorInfo Reason: Reason (See https://help.ably.io/error/1000); Code: 1000; Href: https://help.ably.io/error/1000]", errorInfo.ToString());
         }
 
         [Fact]
@@ -69,7 +71,29 @@ namespace IO.Ably.Tests
             var errorInfo = new ErrorInfo("Reason", 1000, null, "http://example.com");
 
             // Assert
-            Assert.Equal("[ErrorInfo Reason: Reason (See http://example.com); Code: 1000; Href: http://example.com;]", errorInfo.ToString());
+            Assert.Equal("[ErrorInfo Reason: Reason (See http://example.com); Code: 1000; Href: http://example.com]", errorInfo.ToString());
+        }
+
+        [Fact]
+        public void ToString_WithCause_ReturnsFormattedString_ThatUsesCause()
+        {
+            // Arrange
+            var cause = new ErrorInfo("The Cause", 999);
+            var errorInfo = new ErrorInfo("The Reason", 1000, null, null, cause);
+
+            // Assert
+            Assert.Equal("[ErrorInfo Reason: The Reason (See https://help.ably.io/error/1000); Code: 1000; Href: https://help.ably.io/error/1000; Cause: [ErrorInfo Reason: The Cause (See https://help.ably.io/error/999); Code: 999; Href: https://help.ably.io/error/999]]", errorInfo.ToString());
+        }
+
+        [Fact]
+        public void ToString_WithInnerException_ReturnsFormattedString_ThatUsesInnerException()
+        {
+            // Arrange
+            var inner = new Exception("Inner Exception Message");
+            var errorInfo = new ErrorInfo("The Reason", 1000, null, null, null, inner);
+
+            // Assert
+            Assert.Equal("[ErrorInfo Reason: The Reason (See https://help.ably.io/error/1000); Code: 1000; Href: https://help.ably.io/error/1000; InnerException: System.Exception: Inner Exception Message]", errorInfo.ToString());
         }
     }
 }

--- a/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
@@ -323,7 +323,7 @@ namespace IO.Ably.Tests
                 var clientOptions = new ClientOptions();
 
                 // Now working against 1.1+ so this should be true
-                clientOptions.IdempotentRestPublishing.Should().BeTrue();
+                clientOptions.IdempotentRestPublishing.Should().BeFalse();
 
                 // Test the internal method that is called from
                 // ClientOptions constructor with different
@@ -335,7 +335,10 @@ namespace IO.Ably.Tests
                 clientOptions.IdempotentRestPublishing.Should().BeFalse();
 
                 clientOptions.SetIdempotentRestPublishingDefault(1, 1);
-                clientOptions.IdempotentRestPublishing.Should().BeTrue();
+                clientOptions.IdempotentRestPublishing.Should().BeFalse();
+
+                clientOptions.SetIdempotentRestPublishingDefault(1, 2);
+                clientOptions.IdempotentRestPublishing.Should().BeFalse();
 
                 clientOptions.SetIdempotentRestPublishingDefault(2, 0);
                 clientOptions.IdempotentRestPublishing.Should().BeTrue();

--- a/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
@@ -338,7 +338,7 @@ namespace IO.Ably.Tests
                 clientOptions.IdempotentRestPublishing.Should().BeFalse();
 
                 clientOptions.SetIdempotentRestPublishingDefault(1, 2);
-                clientOptions.IdempotentRestPublishing.Should().BeFalse();
+                clientOptions.IdempotentRestPublishing.Should().BeTrue();
 
                 clientOptions.SetIdempotentRestPublishingDefault(2, 0);
                 clientOptions.IdempotentRestPublishing.Should().BeTrue();


### PR DESCRIPTION
This is a proposal for an improvement to ErrorInfo.

I have added an InnerException property to the ErrorInfo class for situations when an ErrorInfo is created from an Exception this can be assigned, hopefully making it easier to track down issues.

I have  have also updated AuthURL error handling to make use of the InnerException property and added a test to demonstrate it, this in in response to issue #325