### PR TITLE
Network changed events

### DIFF
--- a/src/IO.Ably.Android/Platform.cs
+++ b/src/IO.Ably.Android/Platform.cs
@@ -1,4 +1,6 @@
 ﻿using IO.Ably.Transport;
+using System.Net.NetworkInformation;
+using IO.Ably.Realtime;
 
 namespace IO.Ably
 {
@@ -6,5 +8,11 @@ namespace IO.Ably
     {
         public string PlatformId => "xamarin-android";
         public ITransportFactory TransportFactory => null;
+
+        static Platform()
+        {
+            NetworkChange.NetworkAvailabilityChanged += (sender, eventArgs) =>
+                Connection.NotifyOperatingSystemNetworkState(eventArgs.IsAvailable ? NetworkState.Online : NetworkState.Offline);
+        }
     }
 }

--- a/src/IO.Ably.NETStandard20/Platform.cs
+++ b/src/IO.Ably.NETStandard20/Platform.cs
@@ -1,4 +1,6 @@
 ﻿using IO.Ably.Transport;
+using System.Net.NetworkInformation;
+using IO.Ably.Realtime;
 
 namespace IO.Ably
 {
@@ -7,5 +9,11 @@ namespace IO.Ably
         public string PlatformId => "netstandard20";
 
         public ITransportFactory TransportFactory => null;
+
+        static Platform()
+        {
+            NetworkChange.NetworkAvailabilityChanged += (sender, eventArgs) =>
+                Connection.NotifyOperatingSystemNetworkState(eventArgs.IsAvailable ? NetworkState.Online : NetworkState.Offline);
+        }
     }
 }

--- a/src/IO.Ably.Shared/Realtime/Connection.cs
+++ b/src/IO.Ably.Shared/Realtime/Connection.cs
@@ -12,6 +12,8 @@ using IO.Ably.Types;
 
 namespace IO.Ably.Realtime
 {
+    using System.Net.NetworkInformation;
+
     public enum NetworkState
     {
         Online,
@@ -27,8 +29,13 @@ namespace IO.Ably.Realtime
 
         protected override Action<Action> NotifyClient => RealtimeClient.NotifyExternalClients;
 
-        internal static void NotifyOperatingSystemNetworkState(NetworkState state, ILogger logger)
+        internal static void NotifyOperatingSystemNetworkState(NetworkState state, ILogger logger = null)
         {
+            if (logger == null)
+            {
+                logger = DefaultLogger.LoggerInstance;
+            }
+
             if (logger.IsDebug)
             {
                 logger.Debug("OS Network connection state: " + state);

--- a/src/IO.Ably.UWP/Platform.cs
+++ b/src/IO.Ably.UWP/Platform.cs
@@ -1,10 +1,25 @@
 ﻿using IO.Ably.Transport;
+using System.Net.NetworkInformation;
+using Windows.Networking.Connectivity;
+using Windows.UI.Core;
+using IO.Ably.Realtime;
 
 namespace IO.Ably
 {
     internal class Platform : IPlatform
     {
         public string PlatformId => "uwp";
+
         public ITransportFactory TransportFactory => null;
+
+        static Platform()
+        {
+            NetworkInformation.NetworkStatusChanged += sender =>
+                {
+                    ConnectionProfile InternetConnectionProfile = NetworkInformation.GetInternetConnectionProfile();
+                    Connection.NotifyOperatingSystemNetworkState(
+                        InternetConnectionProfile == null ? NetworkState.Offline : NetworkState.Online);
+                };
+        }
     }
 }

--- a/src/IO.Ably.iOS/Platform.cs
+++ b/src/IO.Ably.iOS/Platform.cs
@@ -1,10 +1,19 @@
 ﻿using IO.Ably.Transport;
+using System.Net.NetworkInformation;
+using IO.Ably.Realtime;
 
 namespace IO.Ably
 {
     internal class Platform : IPlatform
     {
         public string PlatformId => "xamarin-ios";
+
         public ITransportFactory TransportFactory => null;
+
+        static Platform()
+        {
+            NetworkChange.NetworkAvailabilityChanged += (sender, eventArgs) =>
+                Connection.NotifyOperatingSystemNetworkState(eventArgs.IsAvailable ? NetworkState.Online : NetworkState.Offline);
+        }
     }
 }


### PR DESCRIPTION
This PR is a solution to the issues raised in #331 and #332.

Regarding #332, I have added sleep/resume handling as if that were a network outage to the .NET Framework (see src/IO.Ably.NETFramework/Platform.cs below).

Instinctively I feel like this shouldn't be required for the client lib to resume from a system sleep but without it when a (Windows) system comes back from sleep the connection doesn't recover. So, perhaps this is a bit of a hack but it makes the library work as expected, so the pragmatist in me says that is OK.

It is possible that similar solutions could be added for iOS and Android, but right now I am not sure what the best options are and no one is complaining of having issues with Xamarin in that regard and testing those solutions is harder, I prefer to push that to another work item.

I should probably have split this up into 2 PRs, but the changes are quite small so hopefully whoever reviews this can overlook that slight faux pas!