### PR TITLE
PublishAsync improvement

### DIFF
--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -359,7 +359,7 @@ namespace IO.Ably.Realtime
                 tw.SetException(ex);
             }
 
-            var result = await Task.WhenAny(Task.Delay(RealtimeClient.Options.RealtimeRequestTimeout), tw.Task);
+            var result = await Task.WhenAny(Task.Delay(RealtimeClient.Options.RealtimeRequestTimeout), tw.Task).ConfigureAwait(false);
             if (result == tw.Task)
             {
                 return await tw.Task.ConfigureAwait(false);

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -362,7 +362,7 @@ namespace IO.Ably.Realtime
             var result = await Task.WhenAny(Task.Delay(RealtimeClient.Options.RealtimeRequestTimeout), tw.Task);
             if (result == tw.Task)
             {
-                return tw.Task.Result;
+                return await tw.Task.ConfigureAwait(false);
             }
 
             return Result.Fail(new ErrorInfo("PublishAsync timeout expired. Message was not confirmed by the server"));


### PR DESCRIPTION
Related to #314 

Whilst I have not been able to repeat this issue, after some investigation it was apparent that `PublishAsync` had the potential to deadlock due to a returning a `Task.Result`.

We should instead be `await`ing the `Task`, additionally as we are writing library code we can make use of `ConfigureAwait(false)` as we do not need the calling context.  

For more details of why this is so see https://msdn.microsoft.com/en-us/magazine/jj991977.aspx