### PR TITLE
Transient Publishing

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Connection.cs
+++ b/src/IO.Ably.Shared/Realtime/Connection.cs
@@ -70,6 +70,13 @@ namespace IO.Ably.Realtime
 
         internal Func<DateTimeOffset> Now { get; set; }
 
+        internal bool CanPublishMessages =>
+            State == Realtime.ConnectionState.Connected
+            || ((State == Realtime.ConnectionState.Initialized
+                 || State == Realtime.ConnectionState.Connecting
+                 || State == Realtime.ConnectionState.Disconnected)
+                && RealtimeClient.Options.QueueMessages);
+
         internal Connection(AblyRealtime realtimeClient, Func<DateTimeOffset> nowFunc, ILogger logger = null)
             : base(logger)
         {

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -428,11 +428,9 @@ namespace IO.Ably.Realtime
 
             if (!Connection.CanPublishMessages)
             {
-                // "Message cannot be published. Client is not allowed to queue messages when connection is in state #{connection.state}"
                 throw new AblyException(new ErrorInfo($"Message cannot be published. Client is not allowed to queue messages when connection is in {State} state", 40000, HttpStatusCode.BadRequest));
             }
 
-            // Create protocol message
             var msg = new ProtocolMessage(ProtocolMessage.MessageAction.Message, Name)
             {
                 Messages = messages.ToArray()

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -351,6 +351,7 @@ namespace IO.Ably.Tests.Realtime
 
             var subCh = subClient.Channels.Get(channelName);
             subCh.Attach();
+
             var tsc = new TaskCompletionAwaiter();
             Message msg = null;
             subCh.Subscribe(m =>
@@ -361,9 +362,11 @@ namespace IO.Ably.Tests.Realtime
             await subCh.WaitForState(ChannelState.Attached);
 
             var pubCh = pubClient.Channels.Get(channelName);
-            await pubCh.PublishAsync("foo", "bar");
+            pubCh.Publish("foo", "bar");
 
             pubCh.State.Should().Be(ChannelState.Initialized);
+
+            pubClient.Connect();
 
             var result = await tsc.Task;
             result.Should().BeTrue();

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -30,17 +30,17 @@ namespace IO.Ably.Tests.Realtime
                 var expectedError = new ErrorInfo();
 
                 channel.Attach();
-                channel.Presence.Enter();
-
-                channel.Presence.PendingPresenceQueue.Should().HaveCount(1);
 
                 bool didSucceed = false;
                 ErrorInfo err = null;
-                channel.Publish("test", "data", (success, error) =>
-                    {
-                        didSucceed = success;
-                        err = error;
-                    });
+                channel.Presence.Enter(null,
+                    (b, info) =>
+                        {
+                            didSucceed = b;
+                            err = info;
+                        });
+
+                channel.Presence.PendingPresenceQueue.Should().HaveCount(1);
 
                 channel.SetChannelState(state, expectedError);
                 channel.Presence.PendingPresenceQueue.Should().HaveCount(0);

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -23,23 +23,30 @@ namespace IO.Ably.Tests.Realtime
             [InlineData(ChannelState.Detached)]
             [InlineData(ChannelState.Failed)]
             [Trait("spec", "RTL11")]
-            public void WhenDetachedOrFailed_AllQueuedMessagesShouldBeDeletedAndFailCallbackInvoked(ChannelState state)
+            public void WhenDetachedOrFailed_AllQueuedPresenceMessagesShouldBeDeletedAndFailCallbackInvoked(ChannelState state)
             {
                 var client = GetConnectedClient();
-                var channel = client.Channels.Get("test");
+                var channel = client.Channels.Get("test") as RealtimeChannel;
                 var expectedError = new ErrorInfo();
+
                 channel.Attach();
+                channel.Presence.Enter();
 
+                channel.Presence.PendingPresenceQueue.Should().HaveCount(1);
+
+                bool didSucceed = false;
+                ErrorInfo err = null;
                 channel.Publish("test", "data", (success, error) =>
-                {
-                    success.Should().BeFalse();
-                    error.Should().BeSameAs(expectedError);
-                });
+                    {
+                        didSucceed = success;
+                        err = error;
+                    });
 
-                var realtimeChannel = channel as RealtimeChannel;
-                realtimeChannel.QueuedMessages.Should().HaveCount(1);
-                realtimeChannel.SetChannelState(state, expectedError);
-                realtimeChannel.QueuedMessages.Should().HaveCount(0);
+                channel.SetChannelState(state, expectedError);
+                channel.Presence.PendingPresenceQueue.Should().HaveCount(0);
+
+                didSucceed.Should().BeFalse();
+                err.Should().BeSameAs(expectedError);
             }
 
             [Fact]

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -1227,6 +1227,8 @@ namespace IO.Ably.Tests.Realtime
                     var result = await channel.Presence.EnterClientAsync("123", null);
                     result.IsSuccess.Should().BeTrue();
 
+                    await Task.Delay(10);
+
                     channel.Presence.Map.Members.Should().HaveCount(1);
                     channel.Presence.InternalMap.Members.Should().HaveCount(1);
 


### PR DESCRIPTION
- (RTL6c1) If the connection is CONNECTED and the channel is INITIALIZED, ATTACHED, DETACHED, ATTACHING, or DETACHING then the messages are published immediately
- (RTL6c2) If the connection is INITIALIZED, CONNECTING or DISCONNECTED, and ClientOptions#queueMessages has not been explicitly set to false, then the message will be queued and delivered as soon as the connection is CONNECTED and the channel is in a state in which publishing is permitted per RTL6c1
- (RTL6c4) If the connection is SUSPENDED, CLOSING, CLOSED, or FAILED, or the channel is SUSPENDED or FAILED, the operation will result in an error

