### PR TITLE
Fix for issue #346 

### DIFF
--- a/src/IO.Ably.Shared/AblyAuth.cs
+++ b/src/IO.Ably.Shared/AblyAuth.cs
@@ -97,7 +97,7 @@ namespace IO.Ably
             LogCurrentAuthenticationMethod();
         }
 
-        private async void SetServerTimeOffset()
+        private async Task SetServerTimeOffset()
         {
             TimeSpan diff = Now() - await ServerTime();
             ServerTimeOffset = () => Now() - diff;

--- a/src/IO.Ably.Shared/AblyAuth.cs
+++ b/src/IO.Ably.Shared/AblyAuth.cs
@@ -201,7 +201,7 @@ namespace IO.Ably
                 tokenParams.ClientId = ClientId;
             }
 
-            SetTokenParamsTimestamp(authOptions, tokenParams);
+            await SetTokenParamsTimestamp(authOptions, tokenParams);
 
             var request = _rest.CreatePostRequest($"/keys/{keyId}/requestToken");
             request.SkipAuthentication = true;
@@ -332,12 +332,12 @@ namespace IO.Ably
             return result;
         }
 
-        private void SetTokenParamsTimestamp(AuthOptions authOptions, TokenParams tokenParams)
+        private async Task SetTokenParamsTimestamp(AuthOptions authOptions, TokenParams tokenParams)
         {
             if (authOptions.QueryTime.GetValueOrDefault(false)
                 && !ServerTimeOffset().HasValue)
             {
-                SetServerTimeOffset();
+                await SetServerTimeOffset();
             }
 
             if (!tokenParams.Timestamp.HasValue)
@@ -517,7 +517,8 @@ namespace IO.Ably
                 throw new AblyException("No key specified", 40101, HttpStatusCode.Unauthorized);
             }
 
-            SetTokenParamsTimestamp(authOptions, tokenParams);
+            await SetTokenParamsTimestamp(authOptions, tokenParams);
+
             if (authOptions.QueryTime.GetValueOrDefault(false))
             {
                 tokenParams.Timestamp = await _rest.TimeAsync();

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
@@ -201,7 +201,7 @@ namespace IO.Ably.Tests.AuthTests
 
             // the TokenRequest timestamp should have been set using the offset
             tokenRequest.Timestamp.Should().HaveValue();
-            tokenRequest.Timestamp.Should().BeCloseTo(await testAblyAuth.GetServerTime());
+            tokenRequest.Timestamp.Should().BeCloseTo(await testAblyAuth.GetServerTime(), 1000);
 
             tokenRequest = null;
 

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
@@ -260,6 +260,43 @@ namespace IO.Ably.Tests.AuthTests
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
+        [Fact]
+        [Trait("bug", "346")]
+        public async Task Issue336_SetServerTimeExceptionsShouldBeHandled()
+        {
+            /*
+             * This is a test to demonstrate the fix for issue
+             * https://github.com/ably/ably-dotnet/issues/346
+             * against the 1.1.6 release this test would fail
+             */
+
+            var client = GetRestClient();
+            bool serverTimeCalled = false;
+
+            // configure serverTime delegate to throw an exception
+            var testAblyAuth = new TestAblyAuth(client.Options, client, () =>
+                {
+                    serverTimeCalled = true;
+                    throw new Exception("baz");
+                });
+
+            var tokenParams = new TokenParams();
+            testAblyAuth.Options.QueryTime = true;
+
+            Exception exception = null;
+            try
+            {
+                await testAblyAuth.RequestTokenAsync(tokenParams, client.Options);
+            }
+            catch (Exception e)
+            {
+                exception = e;
+            }
+
+            serverTimeCalled.Should().BeTrue();
+            exception.Should().NotBeNull();
+        }
+
         private class TestAblyAuth : AblyAuth
         {
             public bool RequestTokenCalled { get; set; }


### PR DESCRIPTION
Proposed fix for #346 

`SetServerTimeOffset` was returning void, which is generally a bad idea except for specific use cases (async events). This is because async void methods have different error-handling semantics. 
With async void methods, as there is no Task object, any exceptions thrown will be raised directly on the SynchronizationContext (this explains why the try/catch block is not catching).

