### PR TITLE
Presence not re-entering after connect disconnect fix

### DIFF
--- a/src/IO.Ably.NETFramework/Platform.cs
+++ b/src/IO.Ably.NETFramework/Platform.cs
@@ -16,8 +16,6 @@ namespace IO.Ably
         {
             NetworkChange.NetworkAvailabilityChanged += (sender, eventArgs) =>
                 Connection.NotifyOperatingSystemNetworkState(eventArgs.IsAvailable ? NetworkState.Online : NetworkState.Offline);
-
-            SystemEvents.PowerModeChanged += OnSystemEventsOnPowerModeChanged;
         }
 
         private static void OnSystemEventsOnPowerModeChanged(object sender, PowerModeChangedEventArgs eventArgs)

--- a/src/IO.Ably.Shared/Http/AblyHttpClient.cs
+++ b/src/IO.Ably.Shared/Http/AblyHttpClient.cs
@@ -177,7 +177,8 @@ namespace IO.Ably
                 return;
             }
 
-            StringBuilder logMessage = new StringBuilder($"Response from: {url}");
+            StringBuilder logMessage = new StringBuilder();
+            logMessage.AppendLine($"Response from: {url}");
             logMessage.AppendLine($"Status code: {(int)ablyResponse.StatusCode} {ablyResponse.StatusCode}");
 
             logMessage.AppendLine("---- Response Headers ----");

--- a/src/IO.Ably.Shared/Realtime/ChannelAwaiter.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelAwaiter.cs
@@ -89,9 +89,9 @@ namespace IO.Ably.Realtime
             return await TaskWrapper.Wrap(func);
         }
 
-        public bool StartWait(Action<bool, ErrorInfo> callback, TimeSpan timeout)
+        public bool StartWait(Action<bool, ErrorInfo> callback, TimeSpan timeout, bool restart = false)
         {
-            if (_channel.State == _awaitedState)
+            if (_channel.State == _awaitedState && !restart)
             {
                 try
                 {

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -480,6 +480,7 @@ namespace IO.Ably.Realtime
                         {
                             /* Message is new to presence map, send it */
                             var itemToSend = item.ShallowClone();
+                            itemToSend.ConnectionId = null;
                             itemToSend.Action = PresenceAction.Enter;
                             UpdatePresence(itemToSend, (success, info) =>
                             {

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -21,6 +21,8 @@ namespace IO.Ably.Realtime
 
         private Connection Connection => RealtimeClient.Connection;
 
+        private string PreviousConnectionId { get; set; }
+
         private ConnectionState ConnectionState => Connection.State;
 
         private readonly Handlers<Message> _handlers = new Handlers<Message>();
@@ -118,6 +120,12 @@ namespace IO.Ably.Realtime
 
         internal void InternalOnInternalStateChanged(object sender, ConnectionStateChange connectionStateChange)
         {
+            var connectionRefreshed = PreviousConnectionId != Connection.Id;
+            if (connectionRefreshed)
+            {
+                PreviousConnectionId = Connection.Id;
+            }
+
             switch (connectionStateChange.Current)
             {
                 case ConnectionState.Connected:
@@ -134,6 +142,27 @@ namespace IO.Ably.Realtime
                         if (AttachedAwaiter.StartWait(null, ConnectionManager.Options.RealtimeRequestTimeout))
                         {
                             SetChannelState(ChannelState.Attaching, true);
+                        }
+                    }
+
+                    /*
+                     * Connection state is only maintained server-side for a brief period,
+                     * given by the connectionStateTtl in the connectionDetails (2 minutes at time of writing, see CD2f).
+                     * If a client has been disconnected for longer than the connectionStateTtl
+                     * it should clear the local connection state and any connection attempts should be made as for a fresh connection
+                     *
+                     * (RTN15g3) When a connection attempt succeeds after the connection state has been cleared in this way,
+                     * channels that were previously ATTACHED, ATTACHING, or SUSPENDED must be automatically reattached,
+                     * just as if the connection was a resume attempt which failed per RTN15c3
+                     *
+                     * Given the above, if the channel is ATTACHED and the connection is fresh
+                     * then set the channel to ATTACHING to trigger an ATTACH attempt
+                     */
+                    //if (State == ChannelState.Attached && connectionRefreshed)
+                    {
+                        if (AttachedAwaiter.StartWait(null, ConnectionManager.Options.RealtimeRequestTimeout, restart: true))
+                        {
+                            SetChannelState(ChannelState.Attaching, false);
                         }
                     }
 

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -158,7 +158,7 @@ namespace IO.Ably.Realtime
                      * Given the above, if the channel is ATTACHED and the connection is fresh
                      * then set the channel to ATTACHING to trigger an ATTACH attempt
                      */
-                    //if (State == ChannelState.Attached && connectionRefreshed)
+                    if (State == ChannelState.Attached && connectionRefreshed)
                     {
                         if (AttachedAwaiter.StartWait(null, ConnectionManager.Options.RealtimeRequestTimeout, restart: true))
                         {

--- a/src/IO.Ably.Shared/Transport/ConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionManager.cs
@@ -602,7 +602,7 @@ namespace IO.Ably.Transport
 
                         SetState(new ConnectionDisconnectedState(this, new ErrorInfo("Connection closed due to Operating system network going offline", 80017), Logger)
                         {
-                            RetryInstantly = true
+                            RetryInstantly = false
                         });
                     }
 

--- a/src/IO.Ably.Shared/Transport/ConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionManager.cs
@@ -600,9 +600,10 @@ namespace IO.Ably.Transport
                             Logger.Debug("Network state is Offline. Moving to disconnected.");
                         }
 
-                        SetState(new ConnectionDisconnectedState(this, new ErrorInfo("Connection closed due to Operating system network going offline", 80017), Logger)
+                        // RTA20a
+                        SetState(new ConnectionDisconnectedState(this, new ErrorInfo("Connection disconnected due to Operating system network going offline", 80017), Logger)
                         {
-                            RetryInstantly = false
+                            RetryInstantly = true
                         });
                     }
 

--- a/src/IO.Ably.Shared/Transport/ConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionManager.cs
@@ -607,7 +607,7 @@ namespace IO.Ably.Transport
                             Logger.Debug("Network state is Offline. Moving to disconnected.");
                         }
 
-                        // RTA20a
+                        // RTN20a
                         SetState(new ConnectionDisconnectedState(this, new ErrorInfo("Connection disconnected due to Operating system network going offline", 80017), Logger)
                         {
                             RetryInstantly = true

--- a/src/IO.Ably.Shared/Transport/ConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionManager.cs
@@ -9,6 +9,7 @@ using IO.Ably.MessageEncoders;
 using IO.Ably.Realtime;
 using IO.Ably.Transport.States.Connection;
 using IO.Ably.Types;
+using Microsoft.Win32;
 
 namespace IO.Ably.Transport
 {
@@ -324,6 +325,12 @@ namespace IO.Ably.Transport
             if (Logger.IsDebug)
             {
                 Logger.Debug($"Current state: {Connection.State}. Sending message: {message}");
+            }
+
+            if (message.ConnectionId.IsNotEmpty())
+            {
+                Logger.Warning("Setting ConnectionId to null. ConnectionId should never be included in an outbound message on a realtime connection, it’s always implicit");
+                message.ConnectionId = null;
             }
 
             var result = VerifyMessageHasCompatibleClientId(message);

--- a/src/IO.Ably.Shared/Transport/MsWebSocketConnection.cs
+++ b/src/IO.Ably.Shared/Transport/MsWebSocketConnection.cs
@@ -155,7 +155,7 @@ namespace IO.Ably.Transport
         {
             if (Logger != null && Logger.IsDebug)
             {
-                Logger.Debug("Sending text");
+                Logger.Debug("SendText: Enqueue text for sending");
             }
 
             EnqueueForSending(message.GetBytes(), WebSocketMessageType.Binary);
@@ -165,7 +165,7 @@ namespace IO.Ably.Transport
         {
             if (Logger != null && Logger.IsDebug)
             {
-                Logger.Debug("Sending binary data");
+                Logger.Debug("SendData: Enqueue binary data for sending");
             }
 
             EnqueueForSending(data, WebSocketMessageType.Binary);

--- a/src/IO.Ably.Shared/Transport/MsWebSocketTransport.cs
+++ b/src/IO.Ably.Shared/Transport/MsWebSocketTransport.cs
@@ -133,6 +133,11 @@ namespace IO.Ably.Transport
             }
             else
             {
+                if (Logger.IsDebug)
+                {
+                    Logger.Debug("Sending Text: " + data.Text);
+                }
+
                 _socket?.SendText(data.Text);
             }
         }

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -670,8 +670,11 @@ namespace IO.Ably.Tests.Realtime
         [Trait("spec", "RTN15c4")]
         public async Task ResumeRequest_WithFatalErrorInConnection_ClientAndChannelsShouldBecomeFailed(Protocol protocol)
         {
-            var client = await GetRealtimeClient(protocol);
-            var channel = client.Channels.Get("RTN15c3".AddRandomSuffix()) as RealtimeChannel;
+            var client = await GetRealtimeClient(protocol, (options, settings) =>
+            {
+                options.DisconnectedRetryTimeout = TimeSpan.FromSeconds(2);
+            });
+            var channel = client.Channels.Get("RTN15c4".AddRandomSuffix()) as RealtimeChannel;
             channel.Attach();
             await client.WaitForState(ConnectionState.Connected);
 

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -825,8 +825,6 @@ namespace IO.Ably.Tests.Realtime
                     await client.ConnectionManager.SetState(new ConnectionSuspendedState(client.ConnectionManager, new ErrorInfo("RTP19 test"), client.Logger));
                     await client.WaitForState(ConnectionState.Suspended);
 
-                    //await Task.Delay(500);
-
                     Output.WriteLine("SET CONNECTED");
                     await client.ConnectionManager.SetState(new ConnectionConnectedState(client.ConnectionManager, null));
                     await client.WaitForState(ConnectionState.Connected);
@@ -1824,13 +1822,13 @@ namespace IO.Ably.Tests.Realtime
                         // simulate disconnect
                         await ably.Connection.ConnectionManager.SetState(new ConnectionDisconnectedState(
                             ably.Connection.ConnectionManager,
-                            new ErrorInfo("Connection disconnected due to Operating system network going offline", 80017), ably.Logger));
+                            new ErrorInfo("Connection disconnected due to Operating system network going offline", 80017),
+                            ably.Logger));
 
                         await Task.Delay(2000);
 
                         // simulate reconnect
                         await ably.Connection.ConnectionManager.SetState(new ConnectionConnectingState(ably.Connection.ConnectionManager, ably.Logger));
-
                     });
 
                     p1.Should().NotBeNull();

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -696,76 +696,6 @@ namespace IO.Ably.Tests.Realtime
 
             [Theory]
             [ProtocolData]
-            [Trait("spec", "RTP3")]
-            public async Task Presence_AfterReconnectingShouldReattachChannelAndResumeBrokenSync(Protocol protocol)
-            {
-                var channelName = "RTP3".AddRandomSuffix();
-
-                // must be greater than 100 to break up sync into multiple messages
-                var enterCount = 150;
-
-                var setupClient = await GetRealtimeClient(protocol);
-                await setupClient.WaitForState(ConnectionState.Connected);
-
-                // setup: enter clients on channel
-                var testChannel = setupClient.Channels.Get(channelName);
-                await testChannel.WaitForState(ChannelState.Attached);
-                testChannel.Presence.Subscribe(PresenceAction.Enter, message => { });
-                for (int i = 0; i < enterCount; i++)
-                {
-                    var clientId = $"fakeclient:{i}";
-                    await testChannel.Presence.EnterClientAsync(clientId, $"RTP3 test entry {i}");
-                }
-
-                var client = await GetRealtimeClient(protocol, (options, _) =>
-                {
-                    Logger.LogLevel = LogLevel.Debug;
-                });
-                await client.WaitForState();
-
-                var channel = client.Channels.Get(channelName);
-
-                var transport = client.GetTestTransport();
-                int syncCount = 0;
-                transport.AfterDataReceived = protocolMessage =>
-                {
-                    if (protocolMessage.Action == ProtocolMessage.MessageAction.Sync)
-                    {
-                        syncCount++;
-
-                        // interrupt after first page of results
-                        if (syncCount == 2)
-                        {
-                            transport.Close(false);
-                        }
-                    }
-                };
-
-                channel.Attach();
-                await channel.WaitForState(ChannelState.Attached);
-                channel.State.Should().Be(ChannelState.Attached);
-
-                await client.WaitForState(ConnectionState.Disconnected);
-                client.Connection.State.Should().Be(ConnectionState.Disconnected);
-
-                await client.WaitForState(ConnectionState.Connected);
-                client.Connection.State.Should().Be(ConnectionState.Connected);
-
-                await Task.Delay(500);
-
-                var messages = await channel.Presence.GetAsync();
-                var messageList = messages as IList<PresenceMessage> ?? messages.ToList();
-                messageList.Count.ShouldBeEquivalentTo(enterCount, "Message count should match enterCount");
-
-                syncCount.Should().Be(2);
-
-                transport.AfterDataReceived = null;
-                setupClient.Close();
-                client.Close();
-            }
-
-            [Theory]
-            [ProtocolData]
             [Trait("spec", "RTP11")]
             [Trait("spec", "RTP11b")]
             [Trait("spec", "RTP11c")]
@@ -847,13 +777,19 @@ namespace IO.Ably.Tests.Realtime
             public async Task PresenceMap_WithExistingMembers_WhenSync_ShouldRemoveLocalMembers_RTP19(Protocol protocol)
             {
                 var channelName = "RTP19".AddRandomSuffix();
-                var client = await GetRealtimeClient(protocol);
+                var client = await GetRealtimeClient(protocol, (options, settings) =>
+                {
+                    options.LogHander = new OutputLoggerSink(Output);
+                    options.LogLevel = LogLevel.Debug;
+                });
                 var channel = client.Channels.Get(channelName);
 
                 // ENTER presence on a channel
                 await channel.Presence.EnterClientAsync("1", "one");
-                await channel.Presence.EnterClientAsync("2", "two");
-                channel.Presence.Map.Members.Should().HaveCount(2);
+
+                await Task.Delay(100);
+
+                channel.Presence.Map.Members.Should().HaveCount(1);
 
                 var localMessage = new PresenceMessage()
                 {
@@ -867,37 +803,47 @@ namespace IO.Ably.Tests.Realtime
 
                 // inject a member directly into the local PresenceMap
                 channel.Presence.Map.Members[localMessage.MemberKey] = localMessage;
-                channel.Presence.Map.Members.Should().HaveCount(3);
+                channel.Presence.Map.Members.Should().HaveCount(2);
                 channel.Presence.Map.Members.ContainsKey(localMessage.MemberKey).Should().BeTrue();
 
                 var members = (await channel.Presence.GetAsync()).ToArray();
-                members.Should().HaveCount(3);
+                members.Should().HaveCount(2);
                 members.Where(m => m.ClientId == "1").Should().HaveCount(1);
 
                 var leaveMessages = new List<PresenceMessage>();
-                await WaitFor(async done =>
+                await WaitFor(10000, async done =>
                 {
                     channel.Presence.Subscribe(PresenceAction.Leave, message =>
                     {
+                        Output.WriteLine($"LEAVE message: {message.ToJson()} ");
                         leaveMessages.Add(message);
                         done();
                     });
 
                     // trigger a server initiated SYNC
+                    Output.WriteLine("SET SUSPENDED");
                     await client.ConnectionManager.SetState(new ConnectionSuspendedState(client.ConnectionManager, new ErrorInfo("RTP19 test"), client.Logger));
                     await client.WaitForState(ConnectionState.Suspended);
 
+                    //await Task.Delay(500);
+
+                    Output.WriteLine("SET CONNECTED");
                     await client.ConnectionManager.SetState(new ConnectionConnectedState(client.ConnectionManager, null));
                     await client.WaitForState(ConnectionState.Connected);
                 });
+
+                var serverPresence = await client.RestClient.Channels.Get(channelName).Presence.GetAsync();
+                serverPresence.Items.Count.Should().Be(1);
 
                 // A LEAVE event should have be published for the injected member
                 leaveMessages.Should().HaveCount(1);
                 leaveMessages[0].ClientId.Should().Be(localMessage.ClientId);
 
+                await Task.Delay(10000);
+
                 // valid members entered for this connection are still present
                 members = (await channel.Presence.GetAsync()).ToArray();
-                members.Should().HaveCount(2);
+                members.Should().HaveCount(1);
                 members.Any(m => m.ClientId == localMessage.ClientId).Should().BeFalse();
             }
 


### PR DESCRIPTION
This a fix for an issue where by presence was not re-entered after a connection became disconnected (but remained in the local presence map), which is related to issue #332.

This problem was caused by some changes that were added to support the now defunct RTP3 being incorrectly implemented such that upon every connection state change a `SYNC` message was sent to the Realtime service, this had the effect of putting the Realtime service into an unexpected state (An issue has been raised internally about this by @SimonWoolf).

As RTP3 is no longer required the solution was to remove the changes relating to that (no public facing methods are affected, so this is not a breaking change) and then fix some regressions, most notably for RTP19, which seemed to just be an incorrect test. I have refactored and updated the RTP19 test based on the Java implementation and it now passes.  

I have added a test for the bug, derived from the console application I made for debugging, possible there is a spec item that this test covers, but I have not identified it as yet (any help appreciated!).

Additionally I have made some minor improvements, such as logging the content of outbound messages when the `LogLevel==Debug`