### PR TITLE
Use of ClientId should not force token auth (RSA7e2)

### DIFF
--- a/src/IO.Ably.Shared/AblyAuth.cs
+++ b/src/IO.Ably.Shared/AblyAuth.cs
@@ -129,6 +129,13 @@ namespace IO.Ably
             {
                 var authInfo = Convert.ToBase64String(Options.Key.GetBytes());
                 request.Headers["Authorization"] = "Basic " + authInfo;
+
+                // (RSA7e) If clientId is provided in ClientOptions and RSA4 indicates that basic auth is to be used, then:
+                if (Options.ClientId.IsNotEmpty())
+                {
+                    // (RSA7e2) For REST clients, all requests should include an X-Ably-ClientId header with value set to the clientId, Base64 encoded
+                    request.Headers["X-Ably-ClientId"] = Options.ClientId.ToBase64();
+                }
             }
             else
             {

--- a/src/IO.Ably.Shared/ClientOptions.cs
+++ b/src/IO.Ably.Shared/ClientOptions.cs
@@ -219,8 +219,7 @@ namespace IO.Ably
         {
             get
             {
-                if (ClientId.IsNotEmpty() || AuthUrl != null || AuthCallback != null || Token.IsNotEmpty() ||
-                    TokenDetails != null)
+                if (AuthUrl != null || AuthCallback != null || Token.IsNotEmpty() || TokenDetails != null)
                 {
                     return Ably.AuthMethod.Token;
                 }

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
@@ -498,25 +498,6 @@ namespace IO.Ably.Tests
 
         [Theory]
         [ProtocolData]
-        [Trait("spec", "RSA7a2")]
-        public async Task WithClientId_RequestsATokenOnFirstMessageWithCorrectDefaults(Protocol protocol)
-        {
-            var ably = await GetRestClient(protocol, ablyOptions => ablyOptions.ClientId = "123");
-            var channel = ably.Channels.Get("test");
-            await channel.PublishAsync("test", "true");
-
-            var token = ably.AblyAuth.CurrentToken;
-
-            token.Should().NotBeNull();
-            token.ClientId.Should().Be("123");
-            token.Expires.Should()
-                .BeWithin(TimeSpan.FromSeconds(20))
-                .Before(DateTimeOffset.UtcNow + Defaults.DefaultTokenTtl);
-            token.Capability.ToJson().Should().Be(Defaults.DefaultTokenCapability.ToJson());
-        }
-
-        [Theory]
-        [ProtocolData]
         [Trait("spec", "RSA7b2")]
         [Trait("spec", "RSA10a")]
         public async Task WithoutClientId_WhenAuthorizedWithTokenParamsWithClientId_SetsClientId(Protocol protocol)

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -1550,7 +1550,7 @@ namespace IO.Ably.Tests.Realtime
                 {
                     /* tests disconnecting and connecting states */
 
-                    var client = await GetRealtimeClient(protocol, (options, settings) => { options.ClientId = "RTP16b"; });
+                    var client = await GetRealtimeClient(protocol, (options, settings) => { options.UseTokenAuth = true; });
                     var channel = client.Channels.Get("RTP16a".AddRandomSuffix()) as RealtimeChannel;
 
                     List<int> queueCounts = new List<int>();

--- a/src/IO.Ably.Tests.Shared/Realtime/RealtimeSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/RealtimeSandboxSpecs.cs
@@ -58,7 +58,10 @@ namespace IO.Ably.Tests.Realtime
             // For a realtime client, Auth#authorize instructs the library to obtain
             // a token using the provided tokenParams and authOptions and upgrade
             // the current connection to use that token
-            var client = await GetRealtimeClient(protocol, (opts, _) => { opts.ClientId = validClientId1; });
+            var client = await GetRealtimeClient(protocol, (opts, _) => {
+                opts.ClientId = validClientId1;
+                opts.UseTokenAuth = true;
+            });
 
             var awaiter = new TaskCompletionAwaiter();
             client.Connection.On(ConnectionEvent.Update, args => { awaiter.SetCompleted(); });
@@ -125,11 +128,11 @@ namespace IO.Ably.Tests.Realtime
             var capability = new Capability();
             capability.AddResource("foo").AllowPublish();
 
-            var restClient = await GetRestClient(protocol);
+            var restClient = await GetRestClient(protocol, options => { options.UseTokenAuth = true; });
             var tokenDetails = await restClient.Auth.RequestTokenAsync(new TokenParams
             {
                 ClientId = clientId,
-                Capability = capability
+                Capability = capability,
             });
 
             var realtime = await GetRealtimeClient(protocol, (opts, _) =>

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
@@ -68,6 +68,7 @@ namespace IO.Ably.Tests.Rest
         [Theory]
         [ProtocolData]
         [Trait("spec", "RSL1g1b")]
+        [Trait("spec", "RSA7e2")]
         public async Task WithImplicitClientIdComingFromOptions_ReturnsMessageWithCorrectClientId(Protocol protocol)
         {
             var message = new Message("test", "test") { ClientId = null };

--- a/src/IO.Ably.Tests.Shared/Rest/RestInitSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestInitSpecs.cs
@@ -30,10 +30,11 @@ namespace IO.Ably.Tests
 
             [Fact]
             [Trait("spec", "RSA4")]
-            public void WithKeyAndClientId_ShouldUseTokenAuth()
+            [Trait("spec", "RSA7e2")]
+            public void WithKeyAndClientId_ShouldUseBasicAuth()
             {
                 var client = new AblyRest(new ClientOptions { Key = ValidKey, ClientId = "123" });
-                Assert.Equal(AuthMethod.Token, client.AblyAuth.AuthMethod);
+                Assert.Equal(AuthMethod.Basic, client.AblyAuth.AuthMethod);
             }
 
             [Fact]

--- a/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
@@ -745,6 +745,7 @@ namespace IO.Ably.Tests
             {
                 ClientId = "test",
                 Key = "best",
+                UseTokenAuth = true,
                 UseBinaryProtocol = false,
                 NowFunc = TestHelpers.NowFunc()
             };

--- a/src/IO.Ably.sln
+++ b/src/IO.Ably.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28729.10
 MinimumVisualStudioVersion = 15.0.26730.10
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{1EA29F05-BF68-4BA8-A58F-C7C131E3FC62}"
 	ProjectSection(SolutionItems) = preProject
@@ -66,6 +66,8 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestHelpers", "TestHelpers", "{C36B5947-4944-4360-9D02-74537C91BC40}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SimulateDisconnects", "TestHelpers\SimulateDisconnects\SimulateDisconnects.csproj", "{31008B7D-6734-4A98-9FBC-D33222B64324}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebApplication1", "TestHelper\WebApplication1\WebApplication1.csproj", "{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -908,6 +910,70 @@ Global
 		{31008B7D-6734-4A98-9FBC-D33222B64324}.Release|x64.Build.0 = Release|Any CPU
 		{31008B7D-6734-4A98-9FBC-D33222B64324}.Release|x86.ActiveCfg = Release|Any CPU
 		{31008B7D-6734-4A98-9FBC-D33222B64324}.Release|x86.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.AppStore|Any CPU.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.AppStore|Any CPU.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.AppStore|ARM.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.AppStore|ARM.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.AppStore|x64.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.AppStore|x64.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.AppStore|x86.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.AppStore|x86.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.CI_Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.CI_Release|Any CPU.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.CI_Release|ARM.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.CI_Release|ARM.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.CI_Release|x64.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.CI_Release|x64.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.CI_Release|x86.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.CI_Release|x86.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug 4.0|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug 4.0|Any CPU.Build.0 = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug 4.0|ARM.ActiveCfg = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug 4.0|ARM.Build.0 = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug 4.0|x64.ActiveCfg = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug 4.0|x64.Build.0 = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug 4.0|x86.ActiveCfg = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug 4.0|x86.Build.0 = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug|ARM.Build.0 = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug|x64.Build.0 = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Debug|x86.Build.0 = Debug|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package_netstandard|Any CPU.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package_netstandard|Any CPU.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package_netstandard|ARM.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package_netstandard|ARM.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package_netstandard|x64.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package_netstandard|x64.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package_netstandard|x86.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package_netstandard|x86.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package|Any CPU.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package|Any CPU.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package|ARM.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package|ARM.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package|x64.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package|x64.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package|x86.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.package|x86.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release 4.0|Any CPU.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release 4.0|Any CPU.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release 4.0|ARM.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release 4.0|ARM.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release 4.0|x64.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release 4.0|x64.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release 4.0|x86.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release 4.0|x86.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release|ARM.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release|ARM.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release|x64.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release|x64.Build.0 = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release|x86.ActiveCfg = Release|Any CPU
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -928,6 +994,7 @@ Global
 		{4805A9DA-3412-4BE8-8B95-5A0EFDA1AC01} = {C2F43DB7-AAA0-4687-9897-5D686EC91245}
 		{1609F12C-8216-4E7C-ADE0-240BFE160242} = {C2F43DB7-AAA0-4687-9897-5D686EC91245}
 		{31008B7D-6734-4A98-9FBC-D33222B64324} = {C36B5947-4944-4360-9D02-74537C91BC40}
+		{3B50407F-09B7-4A59-9FB4-ECFA65AB2BC5} = {C36B5947-4944-4360-9D02-74537C91BC40}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F69D4156-FC22-4B8E-AD72-2A7323D42CC4}

--- a/src/TestHelpers/ReEnterPresence/Program.cs
+++ b/src/TestHelpers/ReEnterPresence/Program.cs
@@ -1,0 +1,55 @@
+﻿using System;
+
+namespace ReEnterPresence
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    using IO.Ably;
+    using IO.Ably.Realtime;
+
+    class Program
+    {
+        private const string AblyKey = "oFpaLg.mB7oiw:WP5kW-Mrk96MTaFq";
+
+        private static IRealtimeChannel _channel;
+
+        public static async Task Main(string[] args)
+        {
+            var opts = new ClientOptions(AblyKey);
+            opts.ClientId = Guid.NewGuid().ToString().Substring(0, 8);
+            var ably = new AblyRealtime(opts);
+            ably.Connect();
+            ably.Connection.On(change => Console.WriteLine($"ConnectionState changed to {change.Current}"));
+
+            _channel = ably.Channels.Get("foo_" + Guid.NewGuid().ToString().Substring(0,8));
+
+            _channel.On(ChannelEvent.Attached,_ => LogPresence());
+
+            var result = await _channel.AttachAsync();
+            if (result.IsSuccess)
+            {
+                await _channel.Presence.EnterAsync();
+            }
+            else
+            {
+                Console.WriteLine("channel did not attach");
+            }
+
+            LogPresence();
+
+            Console.ReadLine();
+            ably.Close();
+        }
+
+        private static void LogPresence()
+        {
+            Task.Run(
+                async () =>
+                    {
+                        var p = await _channel.Presence.GetAsync();
+                        Console.WriteLine(p.Count());
+                    });
+        }
+    }
+}

--- a/src/TestHelpers/ReEnterPresence/ReEnterPresence.csproj
+++ b/src/TestHelpers/ReEnterPresence/ReEnterPresence.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\IO.Ably.NETStandard20\IO.Ably.NETStandard20.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/TestHelpers/ReEnterPresenceClassic/App.config
+++ b/src/TestHelpers/ReEnterPresenceClassic/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    </startup>
+</configuration>

--- a/src/TestHelpers/ReEnterPresenceClassic/Program.cs
+++ b/src/TestHelpers/ReEnterPresenceClassic/Program.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using IO.Ably;
+using IO.Ably.Realtime;
+
+namespace ReEnterPresenceClassic
+{
+    class Program
+    {
+        private const string AblyKey = "oFpaLg.mB7oiw:WP5kW-Mrk96MTaFq";
+
+        private static string _channelName = "channel-" + Guid.NewGuid().ToString().Substring(0, 8);
+
+        private static IRealtimeChannel _channel;
+
+        public static async Task Main(string[] args)
+        {
+            var opts = new ClientOptions(AblyKey)
+            {
+                LogHander = new ConsoleLogSink(),
+                LogLevel = LogLevel.Debug,
+                ClientId = $"client-{Guid.NewGuid().ToString().Substring(0, 8)}"
+            };
+
+            var ably = new AblyRealtime(opts);
+            ably.Connect();
+            ably.Connection.On(change =>
+            {
+                WriteLine($"ConnectionState changed to {change.Current}");
+                if (change.Current == ConnectionState.Connected)
+                {
+                    GetPresence();
+                }
+            });
+
+            WriteLine($"curl https://rest.ably.io/channels/{_channelName}/presence -u '{AblyKey}'");
+            _channel = ably.Channels.Get(_channelName);
+
+            _channel.On( state =>
+            {
+                WriteLine($"Channel State: {state.Current}");
+                if (state.Current == ChannelState.Attached)
+                {
+                    GetPresence();
+                }
+            });
+
+            _channel.Presence.Subscribe(message =>
+            {
+                WriteLine($"Presence Action: {message.Action}");
+            });
+
+            var result = await _channel.AttachAsync();
+            if (result.IsSuccess)
+            {
+                await _channel.Presence.EnterAsync();
+            }
+            else
+            {
+                WriteLine("channel did not attach");
+            }
+
+            GetPresence();
+
+            Console.ReadLine();
+            ably.Close();
+        }
+
+        private static void GetPresence()
+        {
+            Task.Run(
+                async () =>
+                    {
+                        try
+                        {
+                            WriteLine($"curl https://rest.ably.io/channels/{_channelName}/presence -u '{AblyKey}'");
+                            var p = await _channel.Presence.GetAsync();
+                            WriteLine($"Presence Count: {p.Count()}");
+                            foreach (var presenceMessage in p)
+                            {
+                                WriteLine($"ClientId: {presenceMessage.ClientId}");
+                            }
+                        }
+                        catch (Exception e)
+                        {
+                            WriteLine(e.ToString());
+                        }
+                        
+                    });
+        }
+
+        private static void WriteLine(string msg)
+        {
+            Console.WriteLine($"({DateTime.UtcNow.ToLongTimeString()}) {msg}");
+        }
+
+        class ConsoleLogSink : ILoggerSink
+        {
+            public void LogEvent(LogLevel level, string message)
+            {
+                WriteLine($"[{level}] {message}");
+            }
+        }
+    }
+}

--- a/src/TestHelpers/ReEnterPresenceClassic/Properties/AssemblyInfo.cs
+++ b/src/TestHelpers/ReEnterPresenceClassic/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ReEnterPresenceClassic")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ReEnterPresenceClassic")]
+[assembly: AssemblyCopyright("Copyright ©  2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("155f7f33-466c-4825-972d-f652d29ed6ed")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/src/TestHelpers/ReEnterPresenceClassic/ReEnterPresenceClassic.csproj
+++ b/src/TestHelpers/ReEnterPresenceClassic/ReEnterPresenceClassic.csproj
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{155F7F33-466C-4825-972D-F652D29ED6ED}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>ReEnterPresenceClassic</RootNamespace>
+    <AssemblyName>ReEnterPresenceClassic</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <LangVersion>7.1</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\IO.Ably.NETFramework\IO.Ably.NETFramework.csproj">
+      <Project>{2d265650-b1ec-4f8d-b043-a2e3dcc23fd8}</Project>
+      <Name>IO.Ably.NETFramework</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>


### PR DESCRIPTION
2nd attempt at this one 🙃

This PR contains changes to provide a fix issue #351, which along the way brought the library in line with RSA7e2 in the v1.1 spec.

The majority of the changes are to fix tests that were expecting token auth when clientId was present.