### PR TITLE
RunInBackground bug

### DIFF
--- a/src/IO.Ably.Shared/Transport/MsWebSocketTransport.cs
+++ b/src/IO.Ably.Shared/Transport/MsWebSocketTransport.cs
@@ -121,7 +121,7 @@ namespace IO.Ably.Transport
                     DetachEvents();
                 }
 
-                TaskUtils.RunInBackground(async () => await _socket.StopConnectionAsync(), e => Logger.Warning(e.Message));
+                TaskUtils.RunInBackground(_socket.StopConnectionAsync(), e => Logger.Warning(e.Message));
             }
         }
 

--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionConnectedState.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionConnectedState.cs
@@ -33,7 +33,7 @@ namespace IO.Ably.Transport.States.Connection
             switch (message.Action)
             {
                 case ProtocolMessage.MessageAction.Auth:
-                    TaskUtils.RunInBackground(async () => await Context.RetryAuthentication(updateState: false), e => Logger.Warning(e.Message));
+                    TaskUtils.RunInBackground(Context.RetryAuthentication(updateState: false), e => Logger.Warning(e.Message));
                     return true;
                 case ProtocolMessage.MessageAction.Connected:
                     await Context.SetState(new ConnectionConnectedState(Context, new ConnectionInfo(message), message.Error, Logger) { IsUpdate = true });

--- a/src/IO.Ably.Tests.Shared/IO.Ably.Tests.Shared.projitems
+++ b/src/IO.Ably.Tests.Shared/IO.Ably.Tests.Shared.projitems
@@ -112,6 +112,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Samples\DocumentationSamples.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Samples\RealtimeSamples.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StatsParsingTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TaskUtilsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TokenDetailsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TokenParamsTests.cs" />

--- a/src/IO.Ably.Tests.Shared/TaskUtilsTests.cs
+++ b/src/IO.Ably.Tests.Shared/TaskUtilsTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using IO.Ably.Tests.Infrastructure;
+using Xunit;
+
+namespace IO.Ably.Tests
+{
+    public class TaskUtilsTests
+    {
+        class MockBagroundService
+        {
+            public static async Task FailingTask()
+            {
+                await Task.Delay(100);
+                throw new Exception();
+            }
+        }
+
+        [Fact]
+        public async Task FailingTaskShouldHaveExceptionHandled()
+        {
+            var tsc = new TaskCompletionAwaiter(500);
+            TaskUtils.RunInBackground(MockBagroundService.FailingTask(), exception =>
+            {
+                tsc.SetCompleted();
+            });
+
+            var result = await tsc.Task;
+            result.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task FailingTaskWRappingAsyncWillNotHaveExceptionHandled()
+        {
+            /*
+             *  This test demonstrates that wrapping a method that throws an Exception will cause the handler
+             *  to not be assigned at the continuation for the inner task and as such the Exception will not be handled.
+             *  DO NOT USE IN PRODUCTION CODE.
+             */
+            var tsc = new TaskCompletionAwaiter(500);
+            TaskUtils.RunInBackground(async () => await MockBagroundService.FailingTask(), exception =>
+            {
+                tsc.SetCompleted();
+            });
+
+            var result = await tsc.Task;
+            result.Should().BeFalse();
+        }
+    }
+}

--- a/src/IO.Ably.Tests.Shared/TaskUtilsTests.cs
+++ b/src/IO.Ably.Tests.Shared/TaskUtilsTests.cs
@@ -33,7 +33,7 @@ namespace IO.Ably.Tests
         }
 
         [Fact]
-        public async Task FailingTaskWRappingAsyncWillNotHaveExceptionHandled()
+        public async Task FailingTaskWrappingAsyncWillNotHaveExceptionHandled()
         {
             /*
              *  This test demonstrates that wrapping a method that throws an Exception will cause the handler


### PR DESCRIPTION
An error was made when using `TaskUtils.RunInBackground`.
The original call was made like this
```
TaskUtils.RunInBackground(async () => await Context.RetryAuthentication(updateState: false), e => Logger.Warning(e.Message));
```

the method signature was of `RunInBackground` was
```
RunInBackground(Action action, Action<Exception> handler = null)
```

This is wrong and internally this created a Task 'wrapped' in a Task which meant the continuation (the `hander`) was applied to the incorrect (outer) Task allowing the exception on the inner Task to go unhandled.

The simplest solution I could come up with was to create and overload
```
RunInBackground(Task task, Action<Exception> handler = null)
```

and update the way this overload is invoked, thus

```
TaskUtils.RunInBackground(Context.RetryAuthentication(updateState: false), e => Logger.Warning(e.Message));
```

It should be noted that this new overload could still legally be called in the old manner and it would fail in exactly the same way, but the new style invocation would not be legal without the new overload.
