### PR TITLE
Fix issue where incorrect time was used to check Token validity

### DIFF
--- a/src/IO.Ably.Shared/AblyAuth.cs
+++ b/src/IO.Ably.Shared/AblyAuth.cs
@@ -149,7 +149,9 @@ namespace IO.Ably
                 throw new AblyException("AuthMethod is set to Auth so there is no current valid token.");
             }
 
-            if (CurrentToken.IsValidToken())
+
+
+            if (CurrentToken.IsValidToken(ServerTimeOffset() ?? Now()))
             {
                 return CurrentToken;
             }
@@ -157,13 +159,14 @@ namespace IO.Ably
             if (TokenRenewable)
             {
                 var token = await AuthorizeAsync();
-                if (token.IsValidToken())
+                var now = ServerTimeOffset() ?? Now();
+                if (token.IsValidToken(now))
                 {
                     CurrentToken = token;
                     return token;
                 }
 
-                if (token != null && token.IsExpired())
+                if (token != null && token.IsExpired(now))
                 {
                     throw new AblyException("Token has expired: " + CurrentToken, 40142, HttpStatusCode.Unauthorized);
                 }
@@ -328,6 +331,9 @@ namespace IO.Ably
             {
                 throw new AblyException("Invalid token response returned", 80019);
             }
+
+            //TODO: Very ugly stuff
+            result.Now = Now;
 
             return result;
         }

--- a/src/IO.Ably.Shared/TokenDetails.cs
+++ b/src/IO.Ably.Shared/TokenDetails.cs
@@ -124,7 +124,7 @@ namespace IO.Ably
 
     public static class TokenDetailsExtensions
     {
-        public static bool IsValidToken(this TokenDetails token)
+        public static bool IsValidToken(this TokenDetails token, DateTimeOffset now)
         {
             if (token == null)
             {
@@ -136,12 +136,12 @@ namespace IO.Ably
                 return true;
             }
 
-            return !token.IsExpired();
+            return !token.IsExpired(now);
         }
 
-        public static bool IsExpired(this TokenDetails token)
+        public static bool IsExpired(this TokenDetails token, DateTimeOffset now)
         {
-            return token.Expires < token.Now();
+            return token.Expires < now;
         }
     }
 }

--- a/src/IO.Ably.Tests.Shared/Rest/RestSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestSandBoxSpecs.cs
@@ -70,7 +70,8 @@ namespace IO.Ably.Tests
                 });
 
                 await client.StatsAsync();
-                client.AblyAuth.CurrentToken.IsValidToken().Should().BeTrue();
+                var now = DateTimeOffset.UtcNow;
+                client.AblyAuth.CurrentToken.IsValidToken(now).Should().BeTrue();
             }
         }
     }


### PR DESCRIPTION
Even when the QueryTime time was on the library was using the default
time to verify the token returned.

Now we are using the correct time using the offset we calculated after
getting server time

Please ignore the TODO. I left it there so I can fix it in my poc branch. Otherwise there will be too many conflicts

Addresses Issue: #374 