### PR TITLE
Issue/380 allow to disable networkstate monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Here is a list of the significant changes. You can find a full list in the relea
 4. IRealtimeClient implements IDisposable - If you want to clean up after the library you can now safely call `Dispose()`. Please note that you can no longer use this instance and have to create a new one.
 5. Logging has been greatly improved. We've removed a lot of verbose messages that brought little value. There is a helpful debug method called `.GetCurrentState()` on the realtime client that will dump the whole library's state as a json string. This will be helpful to include in the support tickets.
 
+
 ## Supported platforms
 
 * .NET 4.6.2+ &ast;

--- a/src/IO.Ably.Android/Platform.cs
+++ b/src/IO.Ably.Android/Platform.cs
@@ -6,14 +6,25 @@ namespace IO.Ably
 {
     internal class Platform : IPlatform
     {
+        internal static bool _hookedUpToNetworkEvents = false;
+        private static readonly object _lock = new object();
+
         public string PlatformId => "xamarin-android";
         public bool SyncContextDefault => true;
         public ITransportFactory TransportFactory => null;
 
-        static Platform()
+        public void RegisterOsNetworkStateChanged()
         {
-            NetworkChange.NetworkAvailabilityChanged += (sender, eventArgs) =>
-                Connection.NotifyOperatingSystemNetworkState(eventArgs.IsAvailable ? NetworkState.Online : NetworkState.Offline);
+            lock (_lock)
+            {
+                if (_hookedUpToNetworkEvents == false)
+                {
+                    NetworkChange.NetworkAvailabilityChanged += (sender, eventArgs) =>
+                        Connection.NotifyOperatingSystemNetworkState(eventArgs.IsAvailable ? NetworkState.Online : NetworkState.Offline);
+                }
+
+                _hookedUpToNetworkEvents = true;
+            }
         }
     }
 }

--- a/src/IO.Ably.NETFramework/Platform.cs
+++ b/src/IO.Ably.NETFramework/Platform.cs
@@ -6,14 +6,25 @@ namespace IO.Ably
 {
     internal class Platform : IPlatform
     {
+        internal static bool _hookedUpToNetworkEvents = false;
+        private static readonly object _lock = new object();
+
         public string PlatformId => "framework";
 
         public ITransportFactory TransportFactory => null;
 
-        static Platform()
+        public void RegisterOsNetworkStateChanged()
         {
-            NetworkChange.NetworkAvailabilityChanged += (sender, eventArgs) =>
-                Connection.NotifyOperatingSystemNetworkState(eventArgs.IsAvailable ? NetworkState.Online : NetworkState.Offline);
+            lock (_lock)
+            {
+                if (_hookedUpToNetworkEvents == false)
+                {
+                    NetworkChange.NetworkAvailabilityChanged += (sender, eventArgs) =>
+                        Connection.NotifyOperatingSystemNetworkState(eventArgs.IsAvailable ? NetworkState.Online : NetworkState.Offline);
+                }
+
+                _hookedUpToNetworkEvents = true;
+            }
         }
     }
 }

--- a/src/IO.Ably.NETStandard20/Platform.cs
+++ b/src/IO.Ably.NETStandard20/Platform.cs
@@ -6,14 +6,25 @@ namespace IO.Ably
 {
     internal class Platform : IPlatform
     {
+        internal static bool _hookedUpToNetworkEvents = false;
+        private static readonly object _lock = new object();
+
         public string PlatformId => "netstandard20";
 
         public ITransportFactory TransportFactory => null;
 
-        static Platform()
+        public void RegisterOsNetworkStateChanged()
         {
-            NetworkChange.NetworkAvailabilityChanged += (sender, eventArgs) =>
-                Connection.NotifyOperatingSystemNetworkState(eventArgs.IsAvailable ? NetworkState.Online : NetworkState.Offline);
+            lock (_lock)
+            {
+                if (_hookedUpToNetworkEvents == false)
+                {
+                    NetworkChange.NetworkAvailabilityChanged += (sender, eventArgs) =>
+                        Connection.NotifyOperatingSystemNetworkState(eventArgs.IsAvailable ? NetworkState.Online : NetworkState.Offline);
+                }
+
+                _hookedUpToNetworkEvents = true;
+            }
         }
     }
 }

--- a/src/IO.Ably.Shared/AblyRealtime.cs
+++ b/src/IO.Ably.Shared/AblyRealtime.cs
@@ -50,7 +50,7 @@ namespace IO.Ably
             Connection = new Connection(this, options.NowFunc, options.Logger);
             Connection.Initialise();
 
-            if (options.DisableAutomaticNetworkStateMonitoring == false)
+            if (options.AutomaticNetworkStateMonitoring)
             {
                 IoC.RegisterOsNetworkStateChanged();
             }

--- a/src/IO.Ably.Shared/AblyRealtime.cs
+++ b/src/IO.Ably.Shared/AblyRealtime.cs
@@ -50,6 +50,11 @@ namespace IO.Ably
             Connection = new Connection(this, options.NowFunc, options.Logger);
             Connection.Initialise();
 
+            if (options.DisableAutomaticNetworkStateMonitoring == false)
+            {
+                IoC.RegisterOsNetworkStateChanged();
+            }
+
             Channels = new RealtimeChannels(this, Connection);
             RestClient.AblyAuth.OnAuthUpdated = ConnectionManager.OnAuthUpdated;
 

--- a/src/IO.Ably.Shared/ClientOptions.cs
+++ b/src/IO.Ably.Shared/ClientOptions.cs
@@ -297,6 +297,15 @@ namespace IO.Ably
         [Obsolete("We will no longer support the SynchronizationContext in the library. This property will be removed in future versions")]
         public SynchronizationContext CustomContext { get; set; }
 
+        /// <summary>
+        /// Allows developers to disable Automatic network state monitoring. When set to `true` the library will not subscribe to
+        /// `NetworkChange.NetworkAvailabilityChanged` events. Developers can manually notify the Connection for changes by calling
+        /// `Connection.NotifyOperatingSystemNetworkState(NetworkState.Online or NetworkState.Offline)`
+        /// Unity and some Mono environments don't have the feature implemented and the library cannot initialize.
+        /// Default: false.
+        /// </summary>
+        public bool DisableAutomaticNetworkStateMonitoring { get; set; } = false;
+
         [JsonIgnore]
         internal Func<DateTimeOffset> NowFunc
         {

--- a/src/IO.Ably.Shared/ClientOptions.cs
+++ b/src/IO.Ably.Shared/ClientOptions.cs
@@ -298,13 +298,14 @@ namespace IO.Ably
         public SynchronizationContext CustomContext { get; set; }
 
         /// <summary>
-        /// Allows developers to disable Automatic network state monitoring. When set to `true` the library will not subscribe to
+        /// Allows developers to control Automatic network state monitoring. When set to `false` the library will not subscribe to
         /// `NetworkChange.NetworkAvailabilityChanged` events. Developers can manually notify the Connection for changes by calling
-        /// `Connection.NotifyOperatingSystemNetworkState(NetworkState.Online or NetworkState.Offline)`
-        /// Unity and some Mono environments don't have the feature implemented and the library cannot initialize.
-        /// Default: false.
+        /// `Connection.NotifyOperatingSystemNetworkState(NetworkState.Online or NetworkState.Offline)`.
+        /// Unity and some Mono environments don't have `NetworkChange.NetworkAvailabilityChanged` event implemented and
+        /// which used to prevent the library from initialising.
+        /// Default: true.
         /// </summary>
-        public bool DisableAutomaticNetworkStateMonitoring { get; set; } = false;
+        public bool AutomaticNetworkStateMonitoring { get; set; } = true;
 
         [JsonIgnore]
         internal Func<DateTimeOffset> NowFunc

--- a/src/IO.Ably.Shared/IPlatform.cs
+++ b/src/IO.Ably.Shared/IPlatform.cs
@@ -11,5 +11,7 @@ namespace IO.Ably
         string PlatformId { get; }
 
         ITransportFactory TransportFactory { get; }
+
+        void RegisterOsNetworkStateChanged();
     }
 }

--- a/src/IO.Ably.Shared/IPlatform.cs
+++ b/src/IO.Ably.Shared/IPlatform.cs
@@ -6,12 +6,27 @@ namespace IO.Ably
         "StyleCop.CSharp.DocumentationRules",
         "SA1600:Elements should be documented",
         Justification = "Internal interface")]
+
+    /// <summary>
+    /// This interface is implemented for each platform .NETFramework, NetStandard,
+    /// iOS, Android and UWP. The library dynamically creates an instance of Platform in
+    /// IoC.cs. It lets us deal with the differences in the various platforms.
+    /// </summary>
     internal interface IPlatform
     {
         string PlatformId { get; }
 
         ITransportFactory TransportFactory { get; }
 
+        /// <summary>
+        /// This method when implemented in each Platform class includes logic to subscribe to
+        /// NetworkStatus changes from the operating system. It is then exposed through
+        /// IoC.RegisterOsNetworkStateChanged to the rest of the library and should be called
+        /// when the Realtime library is initialised only if the ClientOption `AutomaticNetworkStateMonitoring`
+        /// is set to true.
+        /// The implementation will only allow one registration to operating system network state events even
+        /// thought this method can be called multiple times.
+        /// </summary>
         void RegisterOsNetworkStateChanged();
     }
 }

--- a/src/IO.Ably.Shared/IoC.cs
+++ b/src/IO.Ably.Shared/IoC.cs
@@ -37,6 +37,8 @@ namespace IO.Ably
 
         public static ITransportFactory TransportFactory => Platform?.TransportFactory ?? new MsWebSocketTransport.TransportFactory();
 
+        public static void RegisterOsNetworkStateChanged() => Platform.RegisterOsNetworkStateChanged();
+
         public static string PlatformId => Platform?.PlatformId ?? string.Empty;
     }
 }

--- a/src/IO.Ably.Shared/Realtime/Connection.cs
+++ b/src/IO.Ably.Shared/Realtime/Connection.cs
@@ -44,8 +44,10 @@ namespace IO.Ably.Realtime
         /// the network state.
         /// </summary>
         /// <param name="state">The current state of the OS network connection.</param>
-        /// <param name="logger">Current logger.</param>
-        internal static void NotifyOperatingSystemNetworkState(NetworkState state, ILogger logger = null)
+        public static void NotifyOperatingSystemNetworkState(NetworkState state) =>
+            NotifyOperatingSystemNetworkState(state, null);
+
+        internal static void NotifyOperatingSystemNetworkState(NetworkState state, ILogger logger)
         {
             if (logger == null)
             {

--- a/src/IO.Ably.Tests.Shared/Infrastructure/FakeConnectionContext.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/FakeConnectionContext.cs
@@ -153,11 +153,6 @@ namespace IO.Ably.Tests
             CloseConnectionCalled = true;
         }
 
-        public void ilure(ErrorInfo error, Exception ex, bool clearConnectionKey)
-        {
-            HandledConnectionFailureCalled = true;
-        }
-
         public void SendPendingMessages(bool resumed)
         {
             SendPendingMessagesCalled = true;

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -1153,7 +1153,7 @@ namespace IO.Ably.Tests.Realtime
             stateChange2.Error.Message.Should().Be(detachedMessage.Error.Message);
 
             // retry should happen after SuspendedRetryTimeout has elapsed
-            (end - start).Should().BeCloseTo(requestTimeout, 500);
+            (end - start).Should().BeCloseTo(requestTimeout, 2000);
         }
 
         [Theory]

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -393,9 +393,8 @@ namespace IO.Ably.Tests.Realtime
         {
             var client = await GetRealtimeClient(protocol, (options, _) =>
             {
-                options.RealtimeHost = "127.0.0.1";
                 options.AutoConnect = false;
-                options.RealtimeRequestTimeout = TimeSpan.FromMilliseconds(500);
+                options.RealtimeRequestTimeout = TimeSpan.FromMilliseconds(50);
             });
 
             client.Connect();

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -393,7 +393,7 @@ namespace IO.Ably.Tests.Realtime
         {
             var client = await GetRealtimeClient(protocol, (options, _) =>
             {
-                options.RealtimeHost = "localhost";
+                options.RealtimeHost = "127.0.0.1";
                 options.AutoConnect = false;
                 options.RealtimeRequestTimeout = TimeSpan.FromMilliseconds(500);
             });

--- a/src/IO.Ably.Tests.Shared/Realtime/RealtimeSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/RealtimeSpecs.cs
@@ -127,6 +127,20 @@ namespace IO.Ably.Tests
             Assert.NotNull(realtime.Auth);
         }
 
+        [Theory(Skip = "This test can only be run on its own without any other tests because it depends on static values. Make sure you run each test case individually.")]
+        [InlineData(false)]
+        [InlineData(true)]
+        [Trait("issue", "380")]
+        public void AutomaticNetworkDetectionCanBeDisabledByClientOption(bool disable)
+        {
+            var realtime = new AblyRealtime(new ClientOptions(ValidKey)
+            {
+                DisableAutomaticNetworkStateMonitoring = disable,
+            });
+
+            Platform._hookedUpToNetworkEvents.Should().Be(!disable);
+        }
+
         public RealtimeSpecs(ITestOutputHelper output)
             : base(output)
         {

--- a/src/IO.Ably.Tests.Shared/Realtime/RealtimeSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/RealtimeSpecs.cs
@@ -131,14 +131,22 @@ namespace IO.Ably.Tests
         [InlineData(false)]
         [InlineData(true)]
         [Trait("issue", "380")]
-        public void AutomaticNetworkDetectionCanBeDisabledByClientOption(bool disable)
+        public void AutomaticNetworkDetectionCanBeDisabledByClientOption(bool enabled)
         {
             var realtime = new AblyRealtime(new ClientOptions(ValidKey)
             {
-                DisableAutomaticNetworkStateMonitoring = disable,
+                AutomaticNetworkStateMonitoring = enabled,
             });
 
-            Platform._hookedUpToNetworkEvents.Should().Be(!disable);
+            Platform._hookedUpToNetworkEvents.Should().Be(enabled);
+        }
+
+        [Fact]
+        [Trait("issue", "380")]
+        public void AutomaticNetworkStateMonitoring_ShouldBeEnabledByDefault()
+        {
+            var clientOptions = new ClientOptions(ValidKey);
+            clientOptions.AutomaticNetworkStateMonitoring.Should().Be(true);
         }
 
         public RealtimeSpecs(ITestOutputHelper output)

--- a/src/IO.Ably.Tests.Shared/Realtime/RealtimeWorkflowSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/RealtimeWorkflowSpecs.cs
@@ -16,8 +16,6 @@ namespace IO.Ably.Tests.NETFramework.Realtime
 {
     public class RealtimeWorkflowSpecs : AblyRealtimeSpecs
     {
-
-
         public class GeneralSpecs : AblyRealtimeSpecs
         {
             [Fact]
@@ -62,7 +60,8 @@ namespace IO.Ably.Tests.NETFramework.Realtime
              client.State.Connection.Id.Should().BeEmpty();
             }
 
-            public GeneralSpecs(ITestOutputHelper output) : base(output)
+            public GeneralSpecs(ITestOutputHelper output)
+                : base(output)
             {
             }
         }
@@ -92,7 +91,6 @@ namespace IO.Ably.Tests.NETFramework.Realtime
             {
             }
         }
-
 
         public class ConnectingCommandSpecs : AblyRealtimeSpecs
         {

--- a/src/IO.Ably.UWP/Platform.cs
+++ b/src/IO.Ably.UWP/Platform.cs
@@ -9,18 +9,29 @@ namespace IO.Ably
 {
     internal class Platform : IPlatform
     {
+        internal static bool _hookedUpToNetworkEvents = false;
+        private static readonly object _lock = new object();
+
         public string PlatformId => "uwp";
 
         public ITransportFactory TransportFactory => null;
 
-        static Platform()
+        public void RegisterOsNetworkStateChanged()
         {
-            NetworkInformation.NetworkStatusChanged += sender =>
+            lock (_lock)
+            {
+                if (_hookedUpToNetworkEvents == false)
                 {
-                    ConnectionProfile InternetConnectionProfile = NetworkInformation.GetInternetConnectionProfile();
-                    Connection.NotifyOperatingSystemNetworkState(
-                        InternetConnectionProfile == null ? NetworkState.Offline : NetworkState.Online);
-                };
+                    NetworkInformation.NetworkStatusChanged += sender =>
+                    {
+                        ConnectionProfile InternetConnectionProfile = NetworkInformation.GetInternetConnectionProfile();
+                        Connection.NotifyOperatingSystemNetworkState(
+                            InternetConnectionProfile == null ? NetworkState.Offline : NetworkState.Online);
+                    };
+                }
+
+                _hookedUpToNetworkEvents = true;
+            }
         }
     }
 }

--- a/src/IO.Ably.iOS/Platform.cs
+++ b/src/IO.Ably.iOS/Platform.cs
@@ -6,13 +6,24 @@ namespace IO.Ably
 {
     internal class Platform : IPlatform
     {
+        internal static bool _hookedUpToNetworkEvents = false;
+        private static readonly object _lock = new object();
+
         public string PlatformId => "xamarin-ios";
         public ITransportFactory TransportFactory => null;
 
-        static Platform()
+        public void RegisterOsNetworkStateChanged()
         {
-            NetworkChange.NetworkAvailabilityChanged += (sender, eventArgs) =>
-                Connection.NotifyOperatingSystemNetworkState(eventArgs.IsAvailable ? NetworkState.Online : NetworkState.Offline);
+            lock (_lock)
+            {
+                if (_hookedUpToNetworkEvents == false)
+                {
+                    NetworkChange.NetworkAvailabilityChanged += (sender, eventArgs) =>
+                        Connection.NotifyOperatingSystemNetworkState(eventArgs.IsAvailable ? NetworkState.Online : NetworkState.Offline);
+                }
+
+                _hookedUpToNetworkEvents = true;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #380 

Originally we subscribed to Operating system events in the static constructor of the Platform class. However this proved problematic for Unity (#371) and developers have asked to control the notifications (#332). 
This PR addresses the issue. We still automatically subscribe for OS NetworkState change events but there is a new option `ClientOptions.AutomaticNetworkStateMonitoring` which can be switched off. 

If switched off developers will need to notify Ably about changes in the network state. Otherwise the library will not behave as expected until we also implement (https://docs.ably.io/client-lib-development-guide/features/#RTN23). To do that one can call `Connection.NotifyOperatingSystemNetworkState`. 