### PR TITLE
Update changelog and bump assembly version to 1.1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.1.20](https://github.com/ably/ably-dotnet/tree/1.1.20) (2020-04-24)
+[Full Changelog](https://github.com/ably/ably-dotnet/compare/1.1.19...1.1.20)
+
+**Closed issues:**
+
+- Signed version of the .Net Standard 2.x assembly [\#412](https://github.com/ably/ably-dotnet/issues/412)
+
 [Full Changelog](https://github.com/ably/ably-dotnet/compare/1.1.18...1.1.19)
 
 **Fixed bugs:**

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -5,14 +5,14 @@ using System.Reflection;
 [assembly: AssemblyCompany("Ably Realtime")]
 [assembly: AssemblyDescription("Client for ably.io realtime service")]
 [assembly: AssemblyProduct("Ably .Net Library")]
-[assembly: AssemblyVersion("1.1.19")]
-[assembly: AssemblyFileVersion("1.1.19")]
+[assembly: AssemblyVersion("1.1.20")]
+[assembly: AssemblyFileVersion("1.1.20")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyCompany = "Ably Realtime";
         internal const System.String AssemblyDescription = "Client for ably.io realtime service";
         internal const System.String AssemblyProduct = "Ably .Net Library";
-        internal const System.String AssemblyVersion = "1.1.19";
-        internal const System.String AssemblyFileVersion = "1.1.19";
+        internal const System.String AssemblyVersion = "1.1.20";
+        internal const System.String AssemblyFileVersion = "1.1.20";
     }
 }


### PR DESCRIPTION
**Closed issues:**

- Signed version of the .Net Standard 2.x assembly [\#412](https://github.com/ably/ably-dotnet/issues/412)