### PR TITLE
Update build to copy all required dlls when packaging

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -327,6 +327,11 @@ Target.create "Package - Merge json.net" (fun _ ->
               |> Seq.map (Path.combine "src")
               |> Seq.map (fun path -> sprintf "%s/bin/%s" path buildMode)
 
+  // Copy all files necessary
+  paths 
+  |> Seq.iter ( fun path -> !! (Path.combine path "IO.Ably*") |> Shell.copy (Path.combine path "packaged"))
+  
+  // Merge newtonsoft json inside ably and overwrite the files in the package folder with the merged ones
   paths 
   |> Seq.iter ( fun path -> mergeJsonNet path (Path.combine path "packaged"))
 


### PR DESCRIPTION
Fixes: #419
The problem was that for Xamarin and .net framework we have an extra step that merges newtonsoft json and it didn't copy all the required dlls.