### PR TITLE
Bump version and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.2.1](https://github.com/ably/ably-dotnet/tree/1.2.1) (2020-06-12)
 [Full Changelog](https://github.com/ably/ably-dotnet/compare/1.2.0...1.2.1)
 
-Fix packaging issue for .net framework, Xamarin.iOS, Xamarin.Android
+Fixes packaging issue for .net framework, Xamarin.iOS and Xamarin.Android
 
 - Close issue \#419. Failed to resolve IO.Ably.DeltaCodec [\#419](https://github.com/ably/ably-dotnet/issues/419) ([marto83](https://github.com/marto83))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [1.2.1](https://github.com/ably/ably-dotnet/tree/1.2.1) (2020-06-12)
 [Full Changelog](https://github.com/ably/ably-dotnet/compare/1.2.0...1.2.1)
 
-Fixes packaging issue for .net framework, Xamarin.iOS and Xamarin.Android
+Fixes packaging issue for .NET Framework, Xamarin.iOS and Xamarin.Android
 
 - Close issue \#419. Failed to resolve IO.Ably.DeltaCodec [\#419](https://github.com/ably/ably-dotnet/issues/419) ([marto83](https://github.com/marto83))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [1.2.1](https://github.com/ably/ably-dotnet/tree/1.2.1) (2020-06-12)
+[Full Changelog](https://github.com/ably/ably-dotnet/compare/1.2.0...1.2.1)
+
+Fix packaging issue for .net framework, Xamarin.iOS, Xamarin.Android
+
+- Close issue \#419. Failed to resolve IO.Ably.DeltaCodec [\#419](https://github.com/ably/ably-dotnet/issues/419) ([marto83](https://github.com/marto83))
+
 ## [1.2.0](https://github.com/ably/ably-dotnet/tree/1.2.0) (2020-06-08)
 [Full Changelog](https://github.com/ably/ably-dotnet/compare/1.1.20...1.2.0)
 

--- a/build.fsx
+++ b/build.fsx
@@ -323,16 +323,16 @@ Target.create "Package - Build All" (fun _ ->
 
 Target.create "Package - Merge json.net" (fun _ -> 
   let projectsToMerge = [ "IO.Ably.Android"; "IO.Ably.iOS"; "IO.Ably.NETFramework" ]
-  let paths = projectsToMerge 
+  let binFolderPaths = projectsToMerge 
               |> Seq.map (Path.combine "src")
               |> Seq.map (fun path -> sprintf "%s/bin/%s" path buildMode)
 
-  // Copy all files necessary
-  paths 
+  // Copy all IO.Ably* files to the `packaged folder` 
+  binFolderPaths 
   |> Seq.iter ( fun path -> !! (Path.combine path "IO.Ably*") |> Shell.copy (Path.combine path "packaged"))
   
-  // Merge newtonsoft json inside ably and overwrite the files in the package folder with the merged ones
-  paths 
+  // Merge newtonsoft json into ably.dll and overwrite IO.Ably.dll in the packaged folder with the merged one
+  binFolderPaths 
   |> Seq.iter ( fun path -> mergeJsonNet path (Path.combine path "packaged"))
 
 )

--- a/build.fsx
+++ b/build.fsx
@@ -324,8 +324,8 @@ Target.create "Package - Build All" (fun _ ->
 Target.create "Package - Merge json.net" (fun _ -> 
   let projectsToMerge = [ "IO.Ably.Android"; "IO.Ably.iOS"; "IO.Ably.NETFramework" ]
   let binFolderPaths = projectsToMerge 
-              |> Seq.map (Path.combine "src")
-              |> Seq.map (fun path -> sprintf "%s/bin/%s" path buildMode)
+                        |> Seq.map (Path.combine "src")
+                        |> Seq.map (fun path -> sprintf "%s/bin/%s" path buildMode)
 
   // Copy all IO.Ably* files to the `packaged folder` 
   binFolderPaths 

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -5,14 +5,14 @@ using System.Reflection;
 [assembly: AssemblyCompany("Ably Realtime")]
 [assembly: AssemblyDescription("Client for ably.io realtime service")]
 [assembly: AssemblyProduct("Ably .Net Library")]
-[assembly: AssemblyVersion("1.2.0")]
-[assembly: AssemblyFileVersion("1.2.0")]
+[assembly: AssemblyVersion("1.2.1")]
+[assembly: AssemblyFileVersion("1.2.1")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyCompany = "Ably Realtime";
         internal const System.String AssemblyDescription = "Client for ably.io realtime service";
         internal const System.String AssemblyProduct = "Ably .Net Library";
-        internal const System.String AssemblyVersion = "1.2.0";
-        internal const System.String AssemblyFileVersion = "1.2.0";
+        internal const System.String AssemblyVersion = "1.2.1";
+        internal const System.String AssemblyFileVersion = "1.2.1";
     }
 }


### PR DESCRIPTION
Fix packaging issue for .net framework, Xamarin.iOS, Xamarin.Android

- Close issue \#419. Failed to resolve IO.Ably.DeltaCodec [\#419](https://github.com/ably/ably-dotnet/issues/419) ([marto83](https://github.com/marto83))