### PR TITLE
Deprecate Presence history methods

### DIFF
--- a/src/IO.Ably.Shared/Realtime/IRealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/IRealtimeChannel.cs
@@ -168,10 +168,24 @@ namespace IO.Ably.Realtime
         /// <summary>
         /// Returns past message of this channel.
         /// </summary>
+        /// <returns><see cref="PaginatedResult{T}"/> of past Messages.</returns>
+        Task<PaginatedResult<Message>> HistoryAsync();
+
+        /// <summary>
+        /// Returns past message of this channel.
+        /// </summary>
         /// <param name="untilAttach">indicates whether it should pass the latest attach serial to 'fromSerial' parameter.</param>
         /// <returns><see cref="PaginatedResult{T}"/> of past Messages.</returns>
         /// <exception cref="AblyException">Throws an error if untilAttach is true and the channel is not currently attached.</exception>
-        Task<PaginatedResult<Message>> HistoryAsync(bool untilAttach = false);
+        [Obsolete("No need for untilAttach param since presence sync happens on attach, use HistoryAsync() instead")]
+        Task<PaginatedResult<Message>> HistoryAsync(bool untilAttach);
+
+        /// <summary>
+        /// Returns past message of this channel.
+        /// </summary>
+        /// <param name="query"><see cref="PaginatedRequestParams"/> query.</param>
+        /// <returns><see cref="PaginatedResult{T}"/> of past Messages.</returns>
+        Task<PaginatedResult<Message>> HistoryAsync(PaginatedRequestParams query);
 
         /// <summary>
         /// Returns past message of this channel.
@@ -180,7 +194,8 @@ namespace IO.Ably.Realtime
         /// <param name="untilAttach">indicates whether it should pass the latest attach serial to 'fromSerial' parameter.</param>
         /// <returns><see cref="PaginatedResult{T}"/> of past Messages.</returns>
         /// <exception cref="AblyException">Throws an error if untilAttach is true and the channel is not currently attached.</exception>
-        Task<PaginatedResult<Message>> HistoryAsync(PaginatedRequestParams query, bool untilAttach = false);
+        [Obsolete("No need for untilAttach param since presence sync happens on attach, use HistoryAsync(PaginatedRequestParams query) instead")]
+        Task<PaginatedResult<Message>> HistoryAsync(PaginatedRequestParams query, bool untilAttach);
 
         /// <summary>
         /// Updates the options for a channel. If the ChannelModes or ChannelParams differ and the channel is Attaching or Attached

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -490,7 +490,13 @@ namespace IO.Ably.Realtime
             return await tw.Task.TimeoutAfter(RealtimeClient.Options.RealtimeRequestTimeout, failResult);
         }
 
-        public Task<PaginatedResult<Message>> HistoryAsync(bool untilAttach = false)
+        public Task<PaginatedResult<Message>> HistoryAsync()
+        {
+            var query = new PaginatedRequestParams();
+            return RestChannel.HistoryAsync(query);
+        }
+
+        public Task<PaginatedResult<Message>> HistoryAsync(bool untilAttach)
         {
             var query = new PaginatedRequestParams();
             if (untilAttach)
@@ -501,7 +507,13 @@ namespace IO.Ably.Realtime
             return RestChannel.HistoryAsync(query);
         }
 
-        public Task<PaginatedResult<Message>> HistoryAsync(PaginatedRequestParams query, bool untilAttach = false)
+        public Task<PaginatedResult<Message>> HistoryAsync(PaginatedRequestParams query)
+        {
+            query = query ?? new PaginatedRequestParams();
+            return RestChannel.HistoryAsync(query);
+        }
+
+        public Task<PaginatedResult<Message>> HistoryAsync(PaginatedRequestParams query, bool untilAttach)
         {
             query = query ?? new PaginatedRequestParams();
             if (untilAttach)

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -1596,7 +1596,9 @@ namespace IO.Ably.Tests.Realtime
                 });
                 await client.ProcessCommands();
 
+#pragma warning disable 618
                 await channel.HistoryAsync(true);
+#pragma warning restore 618
 
                 LastRequest.QueryParameters.Should()
                     .ContainKey("fromSerial")
@@ -1610,7 +1612,9 @@ namespace IO.Ably.Tests.Realtime
 
                 var channel = client.Channels.Get("history");
 
+#pragma warning disable 618
                 var ex = await Assert.ThrowsAsync<AblyException>(() => channel.HistoryAsync(true));
+#pragma warning restore 618
             }
 
             public HistorySpecs(ITestOutputHelper output)

--- a/src/IO.Ably.Tests.Shared/Samples/DocumentationSamples.cs
+++ b/src/IO.Ably.Tests.Shared/Samples/DocumentationSamples.cs
@@ -151,7 +151,9 @@ namespace IO.Ably.Tests.Samples
         {
             AblyRealtime realtime = new AblyRealtime("{{API_KEY}}");
             var channel = realtime.Channels.Get("chatroom");
+#pragma warning disable 618
             var history = await channel.HistoryAsync(true);
+#pragma warning restore 618
             Console.WriteLine($"{history.Items.Count} messages received in the first page");
             if (history.HasNext)
             {
@@ -244,7 +246,9 @@ namespace IO.Ably.Tests.Samples
             var realtime = new AblyRealtime("{{API_KEY}}");
             var channel = realtime.Channels.Get("{{RANDOM_CHANNEL_NAME}}");
             await channel.AttachAsync();
+#pragma warning disable 618
             PaginatedResult<Message> resultPage = await channel.HistoryAsync(true);
+#pragma warning restore 618
             Message lastMessage = resultPage.Items[0];
             Console.WriteLine("Last message before attach: " + lastMessage.Data);
 


### PR DESCRIPTION
- Marked old presence history methods as deprecated.
- Introduced new history methods without ```untilAttach``` param.
- Fixes #449 