### PR TITLE
Add ConnectionKey property to messages

### DIFF
--- a/src/IO.Ably.Shared/Types/IEncodedMessage.cs
+++ b/src/IO.Ably.Shared/Types/IEncodedMessage.cs
@@ -19,6 +19,8 @@ namespace IO.Ably
 
         string ConnectionId { get; set; }
 
+        string ConnectionKey { get; set; }
+
         object Data { get; set; }
 
         string ClientId { get; set; }

--- a/src/IO.Ably.Shared/Types/Message.cs
+++ b/src/IO.Ably.Shared/Types/Message.cs
@@ -51,6 +51,10 @@ namespace IO.Ably
         [JsonProperty("connectionId")]
         public string ConnectionId { get; set; }
 
+        /// <summary>The connection key of the publisher of the message. Used for impersonation.</summary>
+        [JsonProperty("connectionKey")]
+        public string ConnectionKey { get; set; }
+
         /// <summary>The event name, if available.</summary>
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/src/IO.Ably.Shared/Types/PresenceMessage.cs
+++ b/src/IO.Ably.Shared/Types/PresenceMessage.cs
@@ -94,6 +94,10 @@ namespace IO.Ably
         [JsonProperty("connectionId")]
         public string ConnectionId { get; set; }
 
+        /// <summary>The connection key of the publisher of the message. Used for impersonation.</summary>
+        [JsonProperty("connectionKey")]
+        public string ConnectionKey { get; set; }
+
         /// <summary>
         /// Custom data object associated with the message.
         /// </summary>


### PR DESCRIPTION
Proposed fix for Issue #499. Added ConnectionKey property to Message class, PresenceMessage class, and IMessage interface. With these modifications, I have successfully published Ably messages via REST using the connectionKey of an active real-time client, which is the desired behavior.