### PR TITLE
Refactor connection serial

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionSerialSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionSerialSpecs.cs
@@ -71,12 +71,6 @@ namespace IO.Ably.Tests.Realtime
             client.Connection.Serial.Should().Be(initialSerial);
         }
 
-        [Fact(Skip = "Need to get back to it")]
-        [Trait("spec", "RTN10b")]
-        public void WhenFirstAckMessageReceived_ShouldSetSerialToZero()
-        {
-        }
-
         public ConnectionSerialSpecs(ITestOutputHelper output)
             : base(output)
         {


### PR DESCRIPTION
- Remove unnecessary tests as per new spec
- As per [RTN10](https://docs.ably.io/client-lib-development-guide/features/#RTN10), we don't need RTN10c and some part 
 of RTN10b