### PR TITLE
Add 'heartbeat=true' to the default connection Uri

### DIFF
--- a/src/IO.Ably.Shared/Transport/TransportParams.cs
+++ b/src/IO.Ably.Shared/Transport/TransportParams.cs
@@ -211,6 +211,8 @@ namespace IO.Ably.Transport
                 return AdditionalParameters.Merge(result);
             }
 
+            result["heartbeats"] = "true";
+
             return result;
         }
     }


### PR DESCRIPTION
Currently we receive the `heartbeat` protocol message from the
server without explicitly requesting it.  As .NET does not allow
users of the `ClientWebSocket` to observe ping-pong keep-alive
frames we are reliant on the protocol message when it comes to
knowing if the pub / sub connection is still good, end to end.

This small change *explicitly* request the protocol `heartbeat`
so we can be sure such is not redacted in the future.

This PR is part of providing support for `RTN23` in the .NET  SDK.