### PR TITLE
Stop exported by default, types for COM interop

### DIFF
--- a/src/IO.Ably.NETFramework/Properties/AssemblyInfo.cs
+++ b/src/IO.Ably.NETFramework/Properties/AssemblyInfo.cs
@@ -16,3 +16,5 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("2d265650-b1ec-4f8d-b043-a2e3dcc23fd8")]
+
+[assembly: ComVisible(false)]


### PR DESCRIPTION
We currently export *all* public types for COM interop.  This is not
a usage pattern we suport, i.e. using the Ably .NET assembly from
anything other than managed code.  Defaulting this to `false` also
addresses a whole bunch of build time warnings around inconsistent
COM visibility attributes.