### PR TITLE
Update 'fake-cli' to '5.20.4'

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -21,9 +21,8 @@ jobs:
         with:
           dotnet-version: '3.1.x'
       - name: Download fake-cli
-        run: dotnet tool install fake-cli --tool-path .
+        run: dotnet tool install fake-cli --version 5.20.4 --tool-path .
       - name: Unit tests
         run: ./build.cmd ${{ matrix.target }}.Unit
       - name: Integration tests
         run: ./build.cmd ${{ matrix.target }}.Integration
-          


### PR DESCRIPTION
Update the `fake-cli` version to the latest: `5.20.4` as this
provides explicit support for .NET 5.

Ref: https://www.nuget.org/packages/fake-cli/5.20.4