### PR TITLE
Disable failing tests

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,3 @@
 @echo off
 cls
-if "%~1"=="" (fake -v run build.fsx) else (fake -v run build.fsx -t %*)
+if "%~1"=="" (fake run build.fsx) else (fake run build.fsx -t %*)

--- a/build.cmd
+++ b/build.cmd
@@ -1,3 +1,3 @@
 @echo off
 cls
-if "%~1"=="" (fake run build.fsx) else (fake run build.fsx -t %*)
+if "%~1"=="" (fake -v run build.fsx) else (fake -v run build.fsx -t %*)

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -685,7 +685,7 @@ namespace IO.Ably.Tests.Realtime
             err.Reason.Should().Be(channel.ErrorReason);
         }
 
-        [Theory]
+        [Theory(Skip = "Intermittently fails")]
         [ProtocolData]
         [Trait("spec", "RTN15c4")]
         public async Task ResumeRequest_WithFatalErrorInConnection_ClientAndChannelsShouldBecomeFailed(Protocol protocol)

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandboxTransportSideEffectsSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandboxTransportSideEffectsSpecs.cs
@@ -79,7 +79,7 @@ namespace IO.Ably.Tests.Realtime
             client.Close();
         }
 
-        [Theory]
+        [Theory(Skip = "Intermittently fails")]
         [ProtocolData]
         [Trait("spec", "RTN19b")]
         [Trait("intermittent", "true")] // I think the logic behind resending the detach message has an issue

--- a/src/IO.Ably.Tests.Shared/Realtime/DeltaSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/DeltaSpecs.cs
@@ -130,7 +130,7 @@ namespace IO.Ably.Tests.DotNetCore20.Realtime
             lastMessageSend.ChannelSerial.Should().Be("testSerial");
         }
 
-        [Fact]
+        [Fact(Skip = "Intermittently fails")]
         [Trait("spec", "RSL6f")]
         [Trait("linux", "skip")]
         public async Task

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -84,7 +84,7 @@ namespace IO.Ably.Tests.Realtime
             * Test presence message map behaviour (RTP2 features)
             * Tests RTP2a, RTP2b1, RTP2b2, RTP2c, RTP2d, RTP2g, RTP18c, RTP6a features
             */
-            [Theory]
+            [Theory(Skip = "Intermittently fails")]
             [ProtocolData]
             [Trait("spec", "RTP2")]
             [Trait("spec", "RTP2a")]
@@ -631,7 +631,7 @@ namespace IO.Ably.Tests.Realtime
                 channel.Presence.Map.Members.ContainsKey(actualMemberKey).Should().BeFalse();
             }
 
-            [Theory]
+            [Theory(Skip = "Intermittently fails")]
             [ProtocolData]
             [Trait("spec", "RTP2f")]
             [Trait("spec", "RTP18a")]

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -29,7 +29,7 @@ namespace IO.Ably.Tests.Realtime
             }
 
             // TODO: Add tests to makes sure Presense messages id, timestamp and connectionId are set
-            [Theory]
+            [Theory(Skip = "Intermittently fails")]
             [ProtocolData]
             [Trait("spec", "RTP1")]
             public async Task WhenAttachingToAChannelWithNoMembers_PresenceShouldBeConsideredInSync(Protocol protocol)
@@ -374,7 +374,7 @@ namespace IO.Ably.Tests.Realtime
                 }
             }
 
-            [Theory]
+            [Theory(Skip = "Intermittently fails")]
             [ProtocolData]
             [Trait("spec", "RTP17")]
             [Trait("spec", "RTP17b")]
@@ -949,7 +949,7 @@ namespace IO.Ably.Tests.Realtime
                 members.Any(m => m.ClientId == localMessage.ClientId).Should().BeFalse();
             }
 
-            [Theory]
+            [Theory(Skip = "Intermittently fails")]
             [ProtocolData]
             [Trait("spec", "RTP19a")]
             [Trait("spec", "RTP6b")]
@@ -1393,7 +1393,7 @@ namespace IO.Ably.Tests.Realtime
                     remainingMembers.First().ClientId.Should().Be("local");
                 }
 
-                [Theory]
+                [Theory(Skip = "Intermittently fails")]
                 [ProtocolData]
                 [Trait("spec", "RTP5b")]
                 public async Task WhenChannelBecomesAttached_ShouldSendQueuedMessagesAndInitiateSYNC(Protocol protocol)

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -882,7 +882,7 @@ namespace IO.Ably.Tests.Realtime
                 }
             }
 
-            [Theory]
+            [Theory(Skip = "Intermittently fails")]
             [ProtocolData]
             [Trait("spec", "RTP19")]
             public async Task

--- a/src/IO.Ably.Tests.Shared/Realtime/RealtimeSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/RealtimeSandboxSpecs.cs
@@ -172,7 +172,7 @@ namespace IO.Ably.Tests.Realtime
             }
         }
 
-        [Theory]
+        [Theory(Skip = "Intermittently fails")]
         [ProtocolData]
         [Trait("spec", "RTC8a1")]
         public async Task WithConnectedClient_WhenUpgradingCapabilities_ConnectionShouldNotBeImpaired(Protocol protocol)

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
@@ -217,7 +217,7 @@ namespace IO.Ably.Tests.Rest
                 ((AblyException)ex).ErrorInfo.Code); // Invalid publish request (invalid client-specified id), see https://github.com/ably/ably-common/pull/30
         }
 
-        [Theory]
+        [Theory(Skip = "Intermittently fails")]
         [ProtocolData]
         [Trait("spec", "RSL1k4")]
         public async Task IdempotentPublishing_SimulateErrorAndRetry(Protocol protocol)
@@ -388,7 +388,7 @@ namespace IO.Ably.Tests.Rest
             }
         }
 
-        [Theory]
+        [Theory(Skip = "Intermittently fails")]
         [ProtocolData]
         [Trait("spec", "RSL5b")]
         [Trait("spec", "RSL5c")]

--- a/src/IO.Ably.Tests.Shared/Rest/RequestSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RequestSandBoxSpecs.cs
@@ -121,7 +121,7 @@ namespace IO.Ably.Tests
         [Trait("spec", "RSC19b")]
         [Trait("spec", "RSC19c")]
         [Trait("spec", "RSC19d")]
-        [Theory]
+        [Theory(Skip = "Intermittently fails")]
         [ProtocolData]
         public async Task Request_Paginated(Protocol protocol)
         {

--- a/src/IO.Ably.Tests.Shared/Rest/StatsSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/StatsSandBoxSpecs.cs
@@ -21,7 +21,7 @@ namespace IO.Ably.Tests
             return result.Items;
         }
 
-        [Theory]
+        [Theory(Skip = "Intermittently fails")]
         [ProtocolData]
         [Trait("spec", "G3")]
         public async Task ShouldHaveCorrectStatsAsPerStatsSpec(Protocol protocol)

--- a/src/IO.Ably.Tests/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests/Realtime/PresenceSandboxSpecs.cs
@@ -85,7 +85,7 @@ namespace IO.Ably.Tests.Realtime
 	        * Test presence message map behaviour (RTP2 features)
 	        * Tests RTP2a, RTP2b1, RTP2b2, RTP2c, RTP2d, RTP2g, RTP18c, RTP6a features
 	        */
-            [Theory]
+            [Theory(Skip = "Intermittently fails")]
             [ProtocolData]
             [Trait("spec", "RTP2")]
             [Trait("spec", "RTP2a")]
@@ -262,7 +262,7 @@ namespace IO.Ably.Tests.Realtime
              * When the SYNC completes, any ABSENT members should be deleted from the presence map.
              * (This is because in a SYNC, we might receive a LEAVE before the corresponding ENTER)
              */
-            [Theory]
+            [Theory(Skip = "Intermittently fails")]
             [ProtocolData]
             [Trait("spec", "RTP2f")]
             [Trait("spec", "RTP18a")]


### PR DESCRIPTION
These disabled tests will have JIRA cards created for each instance
prior to creating a PR to `ably_dotnet`.