### PR TITLE
Remove unused test dependencies

### DIFF
--- a/src/IO.Ably.Tests.DotNetCore20/IO.Ably.Tests.DotNetCore20.csproj
+++ b/src/IO.Ably.Tests.DotNetCore20/IO.Ably.Tests.DotNetCore20.csproj
@@ -23,11 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.4.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Microsoft.Build" Version="15.5.180" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="MsgPack.Cli" Version="0.9.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="5.0.0" />

--- a/src/IO.Ably.Tests.NETFramework/IO.Ably.Tests.NETFramework.csproj
+++ b/src/IO.Ably.Tests.NETFramework/IO.Ably.Tests.NETFramework.csproj
@@ -109,11 +109,17 @@
     </None>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Castle.Core">
+      <Version>4.4.0</Version>
+    </PackageReference>
     <PackageReference Include="FluentAssertions">
       <Version>5.10.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build">
       <Version>15.5.180</Version>
+    </PackageReference>
+    <PackageReference Include="Moq">
+      <Version>4.10.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>9.0.1</Version>

--- a/src/IO.Ably.Tests.NETFramework/IO.Ably.Tests.NETFramework.csproj
+++ b/src/IO.Ably.Tests.NETFramework/IO.Ably.Tests.NETFramework.csproj
@@ -109,17 +109,11 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Castle.Core">
-      <Version>4.4.0</Version>
-    </PackageReference>
     <PackageReference Include="FluentAssertions">
       <Version>5.10.3</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build">
       <Version>15.5.180</Version>
-    </PackageReference>
-    <PackageReference Include="Moq">
-      <Version>4.10.1</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>9.0.1</Version>


### PR DESCRIPTION
We are are not currently using `Moq` or `Castle`, removing these for
now as they can always be restored later if actual usage reappears.