### PR TITLE
Fix unused variable

### DIFF
--- a/src/IO.Ably.Shared/IoC.cs
+++ b/src/IO.Ably.Shared/IoC.cs
@@ -18,7 +18,7 @@ namespace IO.Ably
             {
                 var name = new AssemblyName("IO.Ably");
                 var asm = Assembly.Load(name);
-                var type = Assembly.Load(name).GetType("IO.Ably.Platform");
+                var type = asm.GetType("IO.Ably.Platform");
                 if (type != null)
                 {
                     var obj = Activator.CreateInstance(type);


### PR DESCRIPTION
Simple unused variable fix, presumably this was meant to be used
rather than 'reference chasing'.