### PR TITLE
Use 'static' where possible

### DIFF
--- a/src/IO.Ably.Shared/Capability.cs
+++ b/src/IO.Ably.Shared/Capability.cs
@@ -146,7 +146,7 @@ namespace IO.Ably
             return new JArray(resource.AllowedOperations.ToArray());
         }
 
-        private string CleanUpWhiteSpace(string jsonString)
+        private static string CleanUpWhiteSpace(string jsonString)
         {
             return Regex.Replace(jsonString, @"\s+", string.Empty, RegexOptions.Singleline);
         }

--- a/src/IO.Ably.Shared/DefaultLogger.cs
+++ b/src/IO.Ably.Shared/DefaultLogger.cs
@@ -224,7 +224,7 @@ namespace IO.Ably
             }
 
             /// <summary>Produce long multiline string with the details about the exception, including inner exceptions, if any.</summary>
-            private string GetExceptionDetails(Exception ex)
+            private static string GetExceptionDetails(Exception ex)
             {
                 try
                 {

--- a/src/IO.Ably.Shared/Http/AblyHttpClient.cs
+++ b/src/IO.Ably.Shared/Http/AblyHttpClient.cs
@@ -402,12 +402,12 @@ namespace IO.Ably
             return Options.FallbackHosts.Contains(host);
         }
 
-        internal bool IsRetryableResponse(HttpResponseMessage response)
+        internal static bool IsRetryableResponse(HttpResponseMessage response)
         {
             return ErrorInfo.IsRetryableStatusCode(response.StatusCode);
         }
 
-        internal bool IsRetryableError(Exception ex)
+        internal static bool IsRetryableError(Exception ex)
         {
             if (ex is TaskCanceledException)
             {
@@ -509,7 +509,7 @@ namespace IO.Ably
             return new Uri($"{protocol}{host}{(Options.Port.HasValue ? ":" + Options.Port.Value : string.Empty)}{request.Url}{GetQuery(request)}");
         }
 
-        private string GetQuery(AblyRequest request)
+        private static string GetQuery(AblyRequest request)
         {
             var query = request.QueryParameters.ToQueryString();
             if (query.IsNotEmpty())

--- a/src/IO.Ably.Shared/HttpPaginatedResponse.cs
+++ b/src/IO.Ably.Shared/HttpPaginatedResponse.cs
@@ -96,7 +96,7 @@ namespace IO.Ably
             InitializeQuery(NextQueryParams, requestParams);
         }
 
-        private void InitializeQuery(PaginatedRequestParams queryParams, PaginatedRequestParams requestParams)
+        private static void InitializeQuery(PaginatedRequestParams queryParams, PaginatedRequestParams requestParams)
         {
             queryParams.Path = requestParams.Path;
             queryParams.HttpMethod = requestParams.HttpMethod;
@@ -105,7 +105,7 @@ namespace IO.Ably
         }
 
         /// <summary>
-        /// If there is a next result it will make a call to retrieve it. Othewise it will return an empty response.
+        /// If there is a next result it will make a call to retrieve it. Otherwise it will return an empty response.
         /// </summary>
         /// <returns>returns the next response.</returns>
         public new Task<HttpPaginatedResponse> NextAsync()

--- a/src/IO.Ably.Shared/MessageEncoders/CipherEncoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/CipherEncoder.cs
@@ -52,7 +52,7 @@ namespace IO.Ably.MessageEncoders
             }
         }
 
-        private string GetCipherType(string currentEncoding)
+        private static string GetCipherType(string currentEncoding)
         {
             var parts = currentEncoding.Split('+');
             if (parts.Length == 2)

--- a/src/IO.Ably.Shared/MessageEncoders/JsonEncoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/JsonEncoder.cs
@@ -53,7 +53,7 @@ namespace IO.Ably.MessageEncoders
             return Result.Ok(new ProcessedPayload(payload));
         }
 
-        public bool NeedsJsonEncoding(IPayload payload)
+        public static bool NeedsJsonEncoding(IPayload payload)
         {
             return payload.Data is string == false && payload.Data is byte[] == false;
         }

--- a/src/IO.Ably.Shared/MessageEncoders/MessageEncoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/MessageEncoder.cs
@@ -13,7 +13,7 @@ namespace IO.Ably.MessageEncoders
 
         public abstract Result<ProcessedPayload> Decode(IPayload payload, DecodingContext context);
 
-        public bool IsEmpty(object data)
+        public static bool IsEmpty(object data)
         {
             return data == null || (data is string s && s.IsEmpty());
         }

--- a/src/IO.Ably.Shared/MessageEncoders/MessageHandler.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/MessageHandler.cs
@@ -78,7 +78,7 @@ namespace IO.Ably.MessageEncoders
 #endif
         }
 
-        private void ProcessMessages<T>(IEnumerable<T> payloads, DecodingContext context) where T : IMessage
+        private static void ProcessMessages<T>(IEnumerable<T> payloads, DecodingContext context) where T : IMessage
         {
             // TODO: What happens with rest request where we can't decode messages
             DecodePayloads(context, payloads as IEnumerable<IMessage>);
@@ -141,7 +141,7 @@ namespace IO.Ably.MessageEncoders
             return JsonHelper.Serialize(payloads).GetBytes();
         }
 
-        internal Result EncodePayloads(DecodingContext context, IEnumerable<IMessage> payloads)
+        internal static Result EncodePayloads(DecodingContext context, IEnumerable<IMessage> payloads)
         {
             var result = Result.Ok();
             foreach (var payload in payloads)
@@ -383,7 +383,7 @@ namespace IO.Ably.MessageEncoders
             }
         }
 
-        private IEnumerable<Stats> ParseStatsResponse(AblyResponse response)
+        private static IEnumerable<Stats> ParseStatsResponse(AblyResponse response)
         {
             var body = response.TextResponse;
 #if MSGPACK

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -1280,7 +1280,7 @@ namespace IO.Ably.Tests.Realtime
                 };
 
                 var message = new Message("name", "encrypted with otherChannelOptions");
-                new MessageHandler(Logger, Protocol.Json).EncodePayloads(otherChannelOptions.ToDecodingContext(), new[] { message });
+                MessageHandler.EncodePayloads(otherChannelOptions.ToDecodingContext(), new[] { message });
 
                 client.FakeMessageReceived(message, encryptedChannel.Name);
 
@@ -1303,7 +1303,7 @@ namespace IO.Ably.Tests.Realtime
                 channel.Subscribe(msg => { receivedMessage = msg; });
 
                 var message = new Message("name", "encrypted with otherChannelOptions") { Encoding = "json" };
-                new MessageHandler(Logger, Protocol.Json).EncodePayloads(otherChannelOptions.ToDecodingContext(), new[] { message });
+                MessageHandler.EncodePayloads(otherChannelOptions.ToDecodingContext(), new[] { message });
 
                 var testSink = new TestLoggerSink();
                 using (DefaultLogger.SetTempDestination(testSink))

--- a/src/IO.Ably.Tests.Shared/Rest/AblyHttpClientSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/AblyHttpClientSpecs.cs
@@ -108,7 +108,7 @@ namespace IO.Ably.Tests
             [Fact]
             public void IsRetryableError_WithTaskCancellationException_ShouldBeTrue()
             {
-                _client.IsRetryableError(new TaskCanceledException()).Should().BeTrue();
+                AblyHttpClient.IsRetryableError(new TaskCanceledException()).Should().BeTrue();
             }
 
             [Theory]
@@ -119,7 +119,7 @@ namespace IO.Ably.Tests
             public void IsRetyableError_WithHttpMessageExecption_ShouldBeTrue(WebExceptionStatus status)
             {
                 var exception = new HttpRequestException("Error", new WebException("boo", status));
-                _client.IsRetryableError(exception).Should().BeTrue();
+                AblyHttpClient.IsRetryableError(exception).Should().BeTrue();
             }
 
             [Theory]
@@ -137,7 +137,7 @@ namespace IO.Ably.Tests
                 bool expected)
             {
                 var response = new HttpResponseMessage(statusCode);
-                _client.IsRetryableResponse(response).Should().Be(expected);
+                AblyHttpClient.IsRetryableResponse(response).Should().Be(expected);
             }
         }
     }


### PR DESCRIPTION
`static` methods get us one tiny step closer to pseudo pure
functions in C#.  Like `readonly` and `records` its one of those
things that in the absence of strong `const` we should leverage
as much as possible.