### PR TITLE
Make 'MessageToSend' struct 'readonly'

### DIFF
--- a/src/IO.Ably.Shared/Transport/MsWebSocketConnection.cs
+++ b/src/IO.Ably.Shared/Transport/MsWebSocketConnection.cs
@@ -9,7 +9,7 @@ using IO.Ably.Realtime;
 
 namespace IO.Ably.Transport
 {
-    internal struct MessageToSend
+    internal readonly struct MessageToSend
     {
         public ArraySegment<byte> Message { get; }
 


### PR DESCRIPTION
Making the `MessageToSend` struct `readonly`.  Less is more.