### PR TITLE
Delete project reference to deleted 'nuspec' file.

### DIFF
--- a/src/IO.Ably.NetFramework.sln
+++ b/src/IO.Ably.NetFramework.sln
@@ -16,7 +16,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Solution Items", ".Solutio
 		..\nuget\io.ably.nuspec = ..\nuget\io.ably.nuspec
 		IO.Ably.ruleset = IO.Ably.ruleset
 		IO.Ably.Tests.ruleset = IO.Ably.Tests.ruleset
-		..\nuget\io.ably_msgpack.nuspec = ..\nuget\io.ably_msgpack.nuspec
 		..\README.md = ..\README.md
 		stylecop.json = stylecop.json
 	EndProjectSection

--- a/src/IO.Ably.NetStandard.sln
+++ b/src/IO.Ably.NetStandard.sln
@@ -15,7 +15,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Solution Items", ".Solutio
 		CommonAssemblyInfo.cs = CommonAssemblyInfo.cs
 		..\nuget\io.ably.nuspec = ..\nuget\io.ably.nuspec
 		IO.Ably.ruleset = IO.Ably.ruleset
-		..\nuget\io.ably_msgpack.nuspec = ..\nuget\io.ably_msgpack.nuspec
 		..\README.md = ..\README.md
 		stylecop.json = stylecop.json
 		IO.Ably.Tests.ruleset = IO.Ably.Tests.ruleset

--- a/src/IO.Ably.Package.sln
+++ b/src/IO.Ably.Package.sln
@@ -15,7 +15,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Solution Items", ".Solutio
 		CommonAssemblyInfo.cs = CommonAssemblyInfo.cs
 		..\nuget\io.ably.nuspec = ..\nuget\io.ably.nuspec
 		IO.Ably.ruleset = IO.Ably.ruleset
-		..\nuget\io.ably_msgpack.nuspec = ..\nuget\io.ably_msgpack.nuspec
 		..\README.md = ..\README.md
 		stylecop.json = stylecop.json
 	EndProjectSection

--- a/src/IO.Ably.UWP.sln
+++ b/src/IO.Ably.UWP.sln
@@ -15,7 +15,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Solution Items", ".Solutio
 		CommonAssemblyInfo.cs = CommonAssemblyInfo.cs
 		..\nuget\io.ably.nuspec = ..\nuget\io.ably.nuspec
 		IO.Ably.ruleset = IO.Ably.ruleset
-		..\nuget\io.ably_msgpack.nuspec = ..\nuget\io.ably_msgpack.nuspec
 		..\README.md = ..\README.md
 		stylecop.json = stylecop.json
 	EndProjectSection

--- a/src/IO.Ably.Xamarin.sln
+++ b/src/IO.Ably.Xamarin.sln
@@ -15,7 +15,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Solution Items", ".Solutio
 		CommonAssemblyInfo.cs = CommonAssemblyInfo.cs
 		..\nuget\io.ably.nuspec = ..\nuget\io.ably.nuspec
 		IO.Ably.ruleset = IO.Ably.ruleset
-		..\nuget\io.ably_msgpack.nuspec = ..\nuget\io.ably_msgpack.nuspec
 		..\README.md = ..\README.md
 		stylecop.json = stylecop.json
 	EndProjectSection

--- a/src/IO.Ably.sln
+++ b/src/IO.Ably.sln
@@ -15,7 +15,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Solution Items", ".Solutio
 		CommonAssemblyInfo.cs = CommonAssemblyInfo.cs
 		..\nuget\io.ably.nuspec = ..\nuget\io.ably.nuspec
 		IO.Ably.ruleset = IO.Ably.ruleset
-		..\nuget\io.ably_msgpack.nuspec = ..\nuget\io.ably_msgpack.nuspec
 		..\README.md = ..\README.md
 		stylecop.json = stylecop.json
 	EndProjectSection


### PR DESCRIPTION
We removed the `io.ably_msgpack.nuspec`, but also need to remove
the various project references to it.