### PR TITLE
Update 'readme.md' for message extras support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ This client library is currently *not compatible* with some of the Ably features
 | [Push Notification target](https://www.ably.io/documentation/general/push/activate-subscribe#subscribing) |
 | [Push Notification admin](https://www.ably.io/documentation/general/push/admin) |
 | [Custom transportParams](https://www.ably.io/documentation/realtime/usage#client-options) |
-| [Message extras](https://www.ably.io/documentation/realtime/types#message) |
 
 ## Documentation
 


### PR DESCRIPTION
Sachin Shinde confirms that Message Extras is supported and as such should not be listed under `Known Limitations`.