### PR TITLE
Migrate to 'Fluent Assertions'

### DIFF
--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
@@ -495,7 +495,7 @@ namespace IO.Ably.Tests
 
             var ex = await Assert.ThrowsAsync<AblyException>(() => realtimeClient.Auth.AuthorizeAsync(null, authOptionsWhichFail));
 
-            Assert.IsType<AblyException>(ex);
+            ex.Should().BeOfType<AblyException>();
 
             (await failedAwaiter.Task).Should().BeTrue("With 403 response connection should become Failed");
         }
@@ -517,7 +517,7 @@ namespace IO.Ably.Tests
             };
 
             var ex = await Assert.ThrowsAsync<AblyException>(() => realtimeClient.Auth.RequestTokenAsync(null, authOptions));
-            Assert.IsType<AblyException>(ex);
+            ex.Should().BeOfType<AblyException>();
             ex.ErrorInfo.Code.Should().Be(80019);
             ex.ErrorInfo.StatusCode.Should().Be(HttpStatusCode.Forbidden);
             await Task.Delay(1000);

--- a/src/IO.Ably.Tests.Shared/AuthTests/RequestTokenTests.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/RequestTokenTests.cs
@@ -91,7 +91,7 @@ namespace IO.Ably.Tests.AuthTests
         {
             await SendRequestTokenWithValidOptions();
 
-            Assert.IsType<TokenRequest>(LastRequest.PostData);
+            LastRequest.PostData.Should().BeOfType<TokenRequest>();
         }
 
         [Fact]

--- a/src/IO.Ably.Tests.Shared/AuthTests/RequestTokenTests.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/RequestTokenTests.cs
@@ -216,7 +216,7 @@ namespace IO.Ably.Tests.AuthTests
                               };
             var result = await rest.Auth.RequestTokenAsync(tokenRequest, options);
 
-            Assert.True(authCallbackCalled);
+            authCallbackCalled.Should().BeTrue();
             Assert.Same(token, result);
         }
 

--- a/src/IO.Ably.Tests.Shared/ClientOptionsTests.cs
+++ b/src/IO.Ably.Tests.Shared/ClientOptionsTests.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using FluentAssertions;
+using Xunit;
 
 namespace IO.Ably.Tests.Shared
 {
@@ -10,12 +11,12 @@ namespace IO.Ably.Tests.Shared
         public void DefaultOptions()
         {
             var options = new ClientOptions();
-            Assert.Equal("realtime.ably.io", options.FullRealtimeHost());
-            Assert.Equal("rest.ably.io", options.FullRestHost());
-            Assert.Equal(80, options.Port);
-            Assert.Equal(443, options.TlsPort);
+            options.FullRealtimeHost().Should().Be("realtime.ably.io");
+            options.FullRestHost().Should().Be("rest.ably.io");
+            options.Port.Should().Be(80);
+            options.TlsPort.Should().Be(443);
             Assert.Equal(Defaults.FallbackHosts, options.GetFallbackHosts());
-            Assert.True(options.Tls);
+            options.Tls.Should().BeTrue();
         }
 
         [Fact]
@@ -26,12 +27,12 @@ namespace IO.Ably.Tests.Shared
             {
                 Environment = "production"
             };
-            Assert.Equal("realtime.ably.io", options.FullRealtimeHost());
-            Assert.Equal("rest.ably.io", options.FullRestHost());
-            Assert.Equal(80, options.Port);
-            Assert.Equal(443, options.TlsPort);
+            options.FullRealtimeHost().Should().Be("realtime.ably.io");
+            options.FullRestHost().Should().Be("rest.ably.io");
+            options.Port.Should().Be(80);
+            options.TlsPort.Should().Be(443);
             Assert.Equal(Defaults.FallbackHosts, options.GetFallbackHosts());
-            Assert.True(options.Tls);
+            options.Tls.Should().BeTrue();
         }
 
         [Fact]
@@ -43,12 +44,12 @@ namespace IO.Ably.Tests.Shared
             {
                 Environment = "sandbox"
             };
-            Assert.Equal("sandbox-realtime.ably.io", options.FullRealtimeHost());
-            Assert.Equal("sandbox-rest.ably.io", options.FullRestHost());
-            Assert.Equal(80, options.Port);
-            Assert.Equal(443, options.TlsPort);
+            options.FullRealtimeHost().Should().Be("sandbox-realtime.ably.io");
+            options.FullRestHost().Should().Be("sandbox-rest.ably.io");
+            options.Port.Should().Be(80);
+            options.TlsPort.Should().Be(443);
             Assert.Equal(Defaults.GetEnvironmentFallbackHosts("sandbox"), options.GetFallbackHosts());
-            Assert.True(options.Tls);
+            options.Tls.Should().BeTrue();
         }
 
         [Fact]
@@ -64,12 +65,12 @@ namespace IO.Ably.Tests.Shared
                 TlsPort = 8081
             };
 
-            Assert.Equal("local-realtime.ably.io", options.FullRealtimeHost());
-            Assert.Equal("local-rest.ably.io", options.FullRestHost());
-            Assert.Equal(8080, options.Port);
-            Assert.Equal(8081, options.TlsPort);
+            options.FullRealtimeHost().Should().Be("local-realtime.ably.io");
+            options.FullRestHost().Should().Be("local-rest.ably.io");
+            options.Port.Should().Be(8080);
+            options.TlsPort.Should().Be(8081);
             Assert.Empty(options.GetFallbackHosts());
-            Assert.True(options.Tls);
+            options.Tls.Should().BeTrue();
         }
 
         [Fact]
@@ -81,12 +82,12 @@ namespace IO.Ably.Tests.Shared
                 RestHost = "test.org"
             };
 
-            Assert.Equal("test.org", options.FullRestHost());
-            Assert.Equal("test.org", options.FullRealtimeHost());
-            Assert.Equal(80, options.Port);
-            Assert.Equal(443, options.TlsPort);
+            options.FullRestHost().Should().Be("test.org");
+            options.FullRealtimeHost().Should().Be("test.org");
+            options.Port.Should().Be(80);
+            options.TlsPort.Should().Be(443);
             Assert.Empty(options.GetFallbackHosts());
-            Assert.True(options.Tls);
+            options.Tls.Should().BeTrue();
         }
 
         [Fact]
@@ -99,12 +100,12 @@ namespace IO.Ably.Tests.Shared
                 RealtimeHost = "ws.test.org"
             };
 
-            Assert.Equal("test.org", options.FullRestHost());
-            Assert.Equal("ws.test.org", options.FullRealtimeHost());
-            Assert.Equal(80, options.Port);
-            Assert.Equal(443, options.TlsPort);
+            options.FullRestHost().Should().Be("test.org");
+            options.FullRealtimeHost().Should().Be("ws.test.org");
+            options.Port.Should().Be(80);
+            options.TlsPort.Should().Be(443);
             Assert.Empty(options.GetFallbackHosts());
-            Assert.True(options.Tls);
+            options.Tls.Should().BeTrue();
         }
     }
 }

--- a/src/IO.Ably.Tests.Shared/Infrastructure/AblySpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/AblySpecs.cs
@@ -2,10 +2,12 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+
 using IO.Ably.Realtime;
 using IO.Ably.Tests.Realtime;
 using IO.Ably.Types;
-using Xunit;
+
+using FluentAssertions;
 using Xunit.Abstractions;
 
 namespace IO.Ably.Tests
@@ -17,7 +19,7 @@ namespace IO.Ably.Tests
         public void WaitOne()
         {
             var result = _signal.WaitOne(2000);
-            Assert.True(result, "Result was not returned within 2000ms");
+            result.Should().BeTrue("Result was not returned within 2000ms");
         }
 
         public void Done()

--- a/src/IO.Ably.Tests.Shared/MsgPackMessageSerializerTests.cs
+++ b/src/IO.Ably.Tests.Shared/MsgPackMessageSerializerTests.cs
@@ -91,7 +91,7 @@ namespace IO.Ably.Tests
             object result = MsgPackHelper.Serialise(message);
 
             // Assert
-            Assert.IsType<byte[]>(result);
+            result.Should().BeOfType<byte[]>();
             Assert.Equal(expectedMessage.ToArray(), result as byte[]);
         }
 
@@ -122,7 +122,7 @@ namespace IO.Ably.Tests
             object result = MsgPackHelper.Serialise(message);
 
             // Assert
-            Assert.IsType<byte[]>(result);
+            result.Should().BeOfType<byte[]>();
             Assert.Equal(expectedMessage.ToArray(), result as byte[]);
         }
 
@@ -154,7 +154,7 @@ namespace IO.Ably.Tests
             object result = MsgPackHelper.Serialise(message);
 
             // Assert
-            Assert.IsType<byte[]>(result);
+            result.Should().BeOfType<byte[]>();
             Assert.Equal<byte[]>(expectedMessage.ToArray(), result as byte[]);
         }
 
@@ -189,7 +189,7 @@ namespace IO.Ably.Tests
             object result = MsgPackHelper.Serialise(message);
 
             // Assert
-            Assert.IsType<byte[]>(result);
+            result.Should().BeOfType<byte[]>();
             Assert.Equal(expectedMessage.ToArray(), result as byte[]);
         }
 
@@ -228,7 +228,7 @@ namespace IO.Ably.Tests
             object result = MsgPackHelper.Serialise(message);
 
             // Assert
-            Assert.IsType<byte[]>(result);
+            result.Should().BeOfType<byte[]>();
             Assert.Equal(expectedMessage.ToArray(), result as byte[]);
         }
 

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -838,7 +838,7 @@ namespace IO.Ably.Tests.Realtime
 
                 WaitOne();
 
-                Assert.True(called);
+                called.Should().BeTrue();
             }
 
             [Fact]

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelsSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelsSpecs.cs
@@ -227,7 +227,7 @@ namespace IO.Ably.Tests.Realtime
 
             // Assert
             Assert.Same(channel, enumerator.Current);
-            Assert.False(enumerator.MoveNext());
+            enumerator.MoveNext().Should().BeFalse();
         }
 
         [Fact]
@@ -243,7 +243,7 @@ namespace IO.Ably.Tests.Realtime
 
             // Assert
             Assert.Same(channel, enumerator.Current);
-            Assert.False(enumerator.MoveNext());
+            enumerator.MoveNext().Should().BeFalse();
         }
 
         [Fact]
@@ -348,7 +348,7 @@ namespace IO.Ably.Tests.Realtime
             await client.ProcessCommands();
 
             Assert.Equal(options.ToJson(), channel2.Options.ToJson());
-            Assert.True(options.CipherParams.Equals(cipherParams));
+            options.CipherParams.Equals(cipherParams).Should().BeTrue();
         }
     }
 }

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/ClosingStateSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/ClosingStateSpecs.cs
@@ -92,7 +92,7 @@ namespace IO.Ably.Tests
             bool result = await _state.OnMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Disconnected), null);
 
             // Assert
-            Assert.True(result);
+            result.Should().BeTrue();
             _context.ShouldQueueCommand<SetDisconnectedStateCommand>();
         }
 

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/ConnectedStateSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/ConnectedStateSpecs.cs
@@ -48,7 +48,7 @@ namespace IO.Ably.Tests
             bool result = await _state.OnMessageReceived(new ProtocolMessage(action), null);
 
             // Assert
-            Assert.False(result);
+            result.Should().BeFalse();
             _context.ShouldHaveNotChangedState();
         }
 

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/ConnectingStateSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/ConnectingStateSpecs.cs
@@ -49,7 +49,7 @@ namespace IO.Ably.Tests
             bool result = await _state.OnMessageReceived(new ProtocolMessage(action), null);
 
             // Assert
-            Assert.False(result);
+            result.Should().BeFalse();
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace IO.Ably.Tests
             bool result = await _state.OnMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Connected), null);
 
             // Assert
-            Assert.True(result);
+            result.Should().BeTrue();
         }
 
         [Fact]

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/FailedStateSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/FailedStateSpecs.cs
@@ -69,7 +69,7 @@ namespace IO.Ably.Tests
             bool result = await _state.OnMessageReceived(new ProtocolMessage(action), null);
 
             // Assert
-            Assert.False(result);
+            result.Should().BeFalse();
         }
 
         private ConnectionFailedState GetState(ErrorInfo info = null)

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/InitializedStateSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/InitializedStateSpecs.cs
@@ -53,7 +53,7 @@ namespace IO.Ably.Tests
             bool result = await _state.OnMessageReceived(new ProtocolMessage(action), null);
 
             // Assert
-            Assert.False(result);
+            result.Should().BeFalse();
         }
 
         [Fact]

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/SuspendedStateSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionStateTests/SuspendedStateSpecs.cs
@@ -69,7 +69,7 @@ namespace IO.Ably.Tests
             var result = await _state.OnMessageReceived(new ProtocolMessage(action), null);
 
             // Assert
-            Assert.False(result);
+            result.Should().BeFalse();
         }
 
         [Fact]

--- a/src/IO.Ably.Tests.Shared/Realtime/RealtimeSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/RealtimeSpecs.cs
@@ -103,7 +103,7 @@ namespace IO.Ably.Tests
             if (Defaults.MsgPackEnabled)
 #pragma warning disable 162
             {
-                Assert.True(options.UseBinaryProtocol);
+                options.UseBinaryProtocol.Should().BeTrue();
             }
 #pragma warning restore 162
         }

--- a/src/IO.Ably.Tests.Shared/Realtime/RealtimeWorkflowSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/RealtimeWorkflowSpecs.cs
@@ -403,7 +403,7 @@ namespace IO.Ably.Tests.NETFramework.Realtime
                 bool result = await client.Workflow.HandleAckMessage(new ProtocolMessage(action));
 
                 // Assert
-                Assert.True(result);
+                result.Should().BeTrue();
             }
 
             [Theory]
@@ -431,7 +431,7 @@ namespace IO.Ably.Tests.NETFramework.Realtime
                 bool result = await client.Workflow.HandleAckMessage(new ProtocolMessage(action));
 
                 // Assert
-                Assert.False(result);
+                result.Should().BeFalse();
             }
 
             [Fact]

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
@@ -213,7 +213,7 @@ namespace IO.Ably.Tests.Rest
 
             var ex = await Record.ExceptionAsync(async () => await channel.PublishAsync(messages));
             ex.Should().NotBeNull();
-            Assert.IsType<AblyException>(ex);
+            ex.Should().BeOfType<AblyException>();
             ((AblyException)ex).ErrorInfo.Code.Should().Be(40031);  // Invalid publish request (invalid client-specified id), see https://github.com/ably/ably-common/pull/30
         }
 

--- a/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
@@ -863,7 +863,7 @@ namespace IO.Ably.Tests
 
             await rest.StatsAsync();
 
-            Assert.True(called, "Rest with Callback needs to request token using callback");
+            called.Should().BeTrue("Rest with Callback needs to request token using callback");
         }
 
         [Fact]


### PR DESCRIPTION
Migrate the our `Assert.` based assertions over to `Fluent
Assertions`.  This way we get better assertion messages and
move towards having a single API for assertion testing.