### PR TITLE
Update DeviceRegistartion get async and add tests

### DIFF
--- a/src/IO.Ably.Shared/Push/IDeviceRegistrations.cs
+++ b/src/IO.Ably.Shared/Push/IDeviceRegistrations.cs
@@ -21,7 +21,7 @@ namespace IO.Ably.Push
         /// </summary>
         /// <param name="deviceId">Id of the device.</param>
         /// <returns>Returns a DeviceDetails class if the device is found or `null` if not.</returns>
-        Task<DeviceDetails> GetAsync(string deviceId);
+        Task<Result<DeviceDetails>> GetAsync(string deviceId);
 
         /// <summary>
         /// Obtain the details for devices registered for receiving push registrations.


### PR DESCRIPTION
Updated the interface to return Result<DeviceRegistration> so we can return a meaningful error if the device is not found instead of null.

> (RSH1b1) get(deviceId) performs a request to /push/deviceRegistrations/:deviceId and returns a DeviceDetails object if the deviceId is found or results in a not found error if the device cannot be found. If the client has been activated as a push target device, and the specified deviceId is that of the present client, then this request must include push device authentication.

The push device authentication test will be in the next PR.