### PR TITLE
Ensure device auth headers are included for getting a push device info

### DIFF
--- a/src/IO.Ably.Shared/AblyRest.cs
+++ b/src/IO.Ably.Shared/AblyRest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using IO.Ably.MessageEncoders;
 using IO.Ably.Push;
@@ -75,6 +76,10 @@ namespace IO.Ably
         public IAblyAuth Auth => AblyAuth;
 
         internal PushRest Push { get; private set; }
+
+        // TODO: Think about how the local device will be shared among Rest instances and
+        // what will happen whet it gets updated.
+        internal LocalDevice Device { get; set; }
 
         internal Protocol Protocol => Options.UseBinaryProtocol == false ? Protocol.Json : Defaults.Protocol;
 

--- a/src/IO.Ably.Shared/Push/PushAdmin.cs
+++ b/src/IO.Ably.Shared/Push/PushAdmin.cs
@@ -288,7 +288,7 @@ namespace IO.Ably.Push
 
             var request = _restClient.CreateGetRequest($"/push/deviceRegistrations/{deviceId}");
             AddFullWaitIfNecessary(request);
-
+            AddDeviceAuthenticationToRequest(request, _restClient.Device);
             var response = await _restClient.ExecuteRequest(request);
 
             if (response.StatusCode == HttpStatusCode.NotFound)

--- a/src/IO.Ably.Tests.Shared/Push/PushAdminTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/PushAdminTests.cs
@@ -170,7 +170,7 @@ namespace IO.Ably.Tests.DotNetCore20.Push
 
             [Fact]
             [Trait("spec", "RSH1b1")]
-            public async Task Get_ShouldThrowIfDeviceNotFound()
+            public async Task Get_ShouldFailDeviceNotFound()
             {
                 var rest = GetRestClient(request => Task.FromResult(new AblyResponse
                 {
@@ -183,6 +183,27 @@ namespace IO.Ably.Tests.DotNetCore20.Push
 
                 result.IsFailure.Should().BeTrue();
                 result.Error.Code.Should().Be(ErrorCodes.NotFound);
+            }
+
+            [Fact]
+            [Trait("spec", "RSH1b1")]
+            public async Task Get_ShouldAddDeviceAuthHeadersWhenAvailable()
+            {
+                var rest = GetRestClient(request =>
+                {
+                    request.Headers.Should().ContainKey("X-Ably-DeviceSecret");
+
+                    return Task.FromResult(new AblyResponse
+                    {
+                        StatusCode = HttpStatusCode.OK,
+                        TextResponse = new LocalDevice().ToJson(),
+                    });
+                });
+
+                rest.Device = new LocalDevice() { DeviceSecret = "secret" };
+
+                var id = Guid.NewGuid().ToString("D");
+                await rest.Push.Admin.DeviceRegistrations.GetAsync(id);
             }
 
             public DeviceRegistrationTests(ITestOutputHelper output)


### PR DESCRIPTION


I've started adding a way to load the persisted device and share that device among multiple rest clients but it got complicated so I deviced to leave that to a future PR. This is why there is a todo on the Device Property.