### PR TITLE
Add DeviceRegistration SaveAsync logic + tests RSH1b3

### DIFF
--- a/src/IO.Ably.Shared/Defaults.cs
+++ b/src/IO.Ably.Shared/Defaults.cs
@@ -64,6 +64,9 @@ namespace IO.Ably
         internal const int TokenErrorCodesRangeStart = 40140;
         internal const int TokenErrorCodesRangeEnd = 40149;
 
+        internal const string DeviceIdentityTokenHeader = "X-Ably-DeviceIdentityToken";
+        internal const string DeviceSecretHeader = "X-Ably-DeviceSecret";
+
         /// <summary>The default log level you'll see in the debug output.</summary>
         internal const LogLevel DefaultLogLevel = LogLevel.Warning;
 

--- a/src/IO.Ably.Shared/Http/AblyHttpClient.cs
+++ b/src/IO.Ably.Shared/Http/AblyHttpClient.cs
@@ -401,7 +401,7 @@ namespace IO.Ably
 
             // Always accept JSON
             message.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(GetHeaderValue(Protocol.Json)));
-            if (message.Method == HttpMethod.Post)
+            if (message.Method == HttpMethod.Post || message.Method == HttpMethod.Put)
             {
                 if (request.PostParameters.Any() && request.RequestBody.Length == 0)
                 {

--- a/src/IO.Ably.Shared/Push/DeviceDetails.cs
+++ b/src/IO.Ably.Shared/Push/DeviceDetails.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace IO.Ably.Push
 {
@@ -10,36 +11,43 @@ namespace IO.Ably.Push
         /// <summary>
         /// Device Id.
         /// </summary>
+        [JsonProperty("id")]
         public string Id { get; set; }
 
         /// <summary>
         /// Device platform (android|ios|web). TODO: Double check.
         /// </summary>
+        [JsonProperty("platform")]
         public string Platform { get; set; }
 
         /// <summary>
         /// Device form factor.
         /// </summary>
+        [JsonProperty("formFactor")]
         public string FormFactor { get; set; }
 
         /// <summary>
         /// Device ClientId. TODO: Explain how this can be used to send push notifications.
         /// </summary>
+        [JsonProperty("clientId")]
         public string ClientId { get; set; }
 
         /// <summary>
         /// Device Metadata. TODO: Give example how this can be used.
         /// </summary>
+        [JsonProperty("metadata")]
         public JObject Metadata { get; set; }
 
         /// <summary>
         /// Push registration data. TODO: Describe how it is relevant to each platform and how it differs.
         /// </summary>
+        [JsonProperty("push")]
         public PushData Push { get; set; } = new PushData();
 
         /// <summary>
         /// Device secret. TODO: Describe how this could be used to authenticate push messages.
         /// </summary>
+        [JsonProperty("deviceSecret")]
         public string DeviceSecret { get; set; }
 
         /// <summary>
@@ -50,16 +58,19 @@ namespace IO.Ably.Push
             /// <summary>
             /// Push Recipient. TODO: // describe the different options.
             /// </summary>
+            [JsonProperty("recipient")]
             public JObject Recipient { get; set; } // TODO: Once we know all the variations of the data, I'd like to make it strongly typed.
 
             /// <summary>
             /// State. TODO: Add examples.
             /// </summary>
+            [JsonProperty("state")]
             public string State { get; set; }
 
             /// <summary>
             /// Error registering device as a PushTarget.
             /// </summary>
+            [JsonProperty("errorReason")]
             public ErrorInfo ErrorReason { get; set; }
         }
     }

--- a/src/IO.Ably.Shared/Push/LocalDevice.cs
+++ b/src/IO.Ably.Shared/Push/LocalDevice.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using IO.Ably.Encryption;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace IO.Ably.Push
@@ -12,6 +13,7 @@ namespace IO.Ably.Push
         /// <summary>
         /// Devices that have completed registration have an identity token assigned to them by the push service. TODO: Check how accurate this is.
         /// </summary>
+        [JsonIgnore]
         public string DeviceIdentityToken { get; set; }
 
         internal bool IsRegistered => DeviceIdentityToken.IsNotEmpty();

--- a/src/IO.Ably.Tests.Shared/Push/PushAdminSandboxTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/PushAdminSandboxTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using FluentAssertions;
+using IO.Ably.Push;
 using IO.Ably.Tests.Infrastructure;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -54,6 +56,46 @@ namespace IO.Ably.Tests.DotNetCore20.Push
 
             public PublishTests(AblySandboxFixture fixture, ITestOutputHelper output)
                 : base(fixture, output)
+            {
+            }
+        }
+        public class DeviceRegistrationsTests : SandboxSpecs
+        {
+            [Theory]
+            [ProtocolData]
+            [Trait("spec", "RSH1b3")]
+            public async Task ShouldSuccessfullySaveDeviceRegistration(Protocol protocol)
+            {
+                using var _ = EnableDebugLogging();
+                // Arrange
+                var client = await GetRestClient(protocol, options => options.PushAdminFullWait = true);
+
+                var device = LocalDevice.Create("123");
+                device.FormFactor = "phone";
+                device.Platform = "android";
+                device.Push.Recipient = JObject.FromObject(new
+                {
+                    transportType = "ablyChannel",
+                    channel = "pushenabled:test",
+                    ablyKey = client.Options.Key,
+                    ablyUrl = "https://" + client.Options.FullRestHost(),
+                });
+
+                Func<Task> callSave = async () =>
+                {
+                    var savedDevice = await client.Push.Admin.DeviceRegistrations.SaveAsync(device);
+
+                    savedDevice.Metadata = JObject.FromObject(new { tag = "test-tag" });
+                    savedDevice.Push.State = null; // Clear state as we don't care about it.
+
+                    var updatedDevice = await client.Push.Admin.DeviceRegistrations.SaveAsync(savedDevice);
+                    updatedDevice.Metadata.Should().BeEquivalentTo(savedDevice.Metadata);
+                };
+
+                await callSave.Should().NotThrowAsync<AblyException>();
+            }
+
+            public DeviceRegistrationsTests(AblySandboxFixture fixture, ITestOutputHelper output) : base(fixture, output)
             {
             }
         }


### PR DESCRIPTION
> (RSH1b3) #save(device) issues a PUT request to /push/deviceRegistrations/:deviceId using the DeviceDetails object (and optionally a JSON-encodable object) argument. A test should exist for a successful save, a successful subsequent save with an update, and a failed save operation. If the client has been activated as a push target device, and the specified deviceId is that of the present client, then this request must include push device authentication.

I've also refactored the device security headers to constants