### PR TITLE
Push/device registrations remove where

### DIFF
--- a/src/IO.Ably.Shared/Defaults.cs
+++ b/src/IO.Ably.Shared/Defaults.cs
@@ -64,6 +64,9 @@ namespace IO.Ably
         internal const int TokenErrorCodesRangeStart = 40140;
         internal const int TokenErrorCodesRangeEnd = 40149;
 
+        internal const string DeviceIdentityTokenHeader = "X-Ably-DeviceIdentityToken";
+        internal const string DeviceSecretHeader = "X-Ably-DeviceSecret";
+
         /// <summary>The default log level you'll see in the debug output.</summary>
         internal const LogLevel DefaultLogLevel = LogLevel.Warning;
 

--- a/src/IO.Ably.Shared/Http/AblyHttpClient.cs
+++ b/src/IO.Ably.Shared/Http/AblyHttpClient.cs
@@ -401,7 +401,7 @@ namespace IO.Ably
 
             // Always accept JSON
             message.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(GetHeaderValue(Protocol.Json)));
-            if (message.Method == HttpMethod.Post)
+            if (message.Method == HttpMethod.Post || message.Method == HttpMethod.Put)
             {
                 if (request.PostParameters.Any() && request.RequestBody.Length == 0)
                 {

--- a/src/IO.Ably.Shared/Push/DeviceDetails.cs
+++ b/src/IO.Ably.Shared/Push/DeviceDetails.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace IO.Ably.Push
 {
@@ -10,36 +11,43 @@ namespace IO.Ably.Push
         /// <summary>
         /// Device Id.
         /// </summary>
+        [JsonProperty("id")]
         public string Id { get; set; }
 
         /// <summary>
         /// Device platform (android|ios|web). TODO: Double check.
         /// </summary>
+        [JsonProperty("platform")]
         public string Platform { get; set; }
 
         /// <summary>
         /// Device form factor.
         /// </summary>
+        [JsonProperty("formFactor")]
         public string FormFactor { get; set; }
 
         /// <summary>
         /// Device ClientId. TODO: Explain how this can be used to send push notifications.
         /// </summary>
+        [JsonProperty("clientId")]
         public string ClientId { get; set; }
 
         /// <summary>
         /// Device Metadata. TODO: Give example how this can be used.
         /// </summary>
+        [JsonProperty("metadata")]
         public JObject Metadata { get; set; }
 
         /// <summary>
         /// Push registration data. TODO: Describe how it is relevant to each platform and how it differs.
         /// </summary>
+        [JsonProperty("push")]
         public PushData Push { get; set; } = new PushData();
 
         /// <summary>
         /// Device secret. TODO: Describe how this could be used to authenticate push messages.
         /// </summary>
+        [JsonProperty("deviceSecret")]
         public string DeviceSecret { get; set; }
 
         /// <summary>
@@ -50,16 +58,19 @@ namespace IO.Ably.Push
             /// <summary>
             /// Push Recipient. TODO: // describe the different options.
             /// </summary>
+            [JsonProperty("recipient")]
             public JObject Recipient { get; set; } // TODO: Once we know all the variations of the data, I'd like to make it strongly typed.
 
             /// <summary>
             /// State. TODO: Add examples.
             /// </summary>
+            [JsonProperty("state")]
             public string State { get; set; }
 
             /// <summary>
             /// Error registering device as a PushTarget.
             /// </summary>
+            [JsonProperty("errorReason")]
             public ErrorInfo ErrorReason { get; set; }
         }
     }

--- a/src/IO.Ably.Shared/Push/IDeviceRegistrations.cs
+++ b/src/IO.Ably.Shared/Push/IDeviceRegistrations.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace IO.Ably.Push
 {
@@ -46,5 +47,13 @@ namespace IO.Ably.Push
         /// <param name="deviceId">The deviceId of the device to be removed.</param>
         /// <returns>Task.</returns>
         Task RemoveAsync(string deviceId);
+
+        /// <summary>
+        /// Removes a registered devices based on a filter of parameters.
+        /// RestAPI: https://ably.com/documentation/rest-api#delete-device-registration.
+        /// </summary>
+        /// <param name="deleteFilter">Filter devices by deviceId or clientId.</param>
+        /// <returns>Task.</returns>
+        Task RemoveWhereAsync(Dictionary<string, string> deleteFilter);
     }
 }

--- a/src/IO.Ably.Shared/Push/LocalDevice.cs
+++ b/src/IO.Ably.Shared/Push/LocalDevice.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using IO.Ably.Encryption;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace IO.Ably.Push
@@ -12,6 +13,7 @@ namespace IO.Ably.Push
         /// <summary>
         /// Devices that have completed registration have an identity token assigned to them by the push service. TODO: Check how accurate this is.
         /// </summary>
+        [JsonIgnore]
         public string DeviceIdentityToken { get; set; }
 
         internal bool IsRegistered => DeviceIdentityToken.IsNotEmpty();

--- a/src/IO.Ably.Shared/Push/PushAdmin.cs
+++ b/src/IO.Ably.Shared/Push/PushAdmin.cs
@@ -48,7 +48,7 @@ namespace IO.Ably.Push
         internal async Task<LocalDevice> RegisterDevice(DeviceDetails details)
         {
             ValidateDeviceDetails();
-            var request = _restClient.CreateRequest("/push/deviceRegistrations/", HttpMethod.Post);
+            var request = _restClient.CreateRequest("/push/deviceRegistrations", HttpMethod.Post);
             AddFullWaitIfNecessary(request);
             request.PostData = details;
 

--- a/src/IO.Ably.Shared/Push/PushAdmin.cs
+++ b/src/IO.Ably.Shared/Push/PushAdmin.cs
@@ -367,18 +367,25 @@ namespace IO.Ably.Push
         /// <inheritdoc />
         async Task IDeviceRegistrations.RemoveAsync(DeviceDetails details)
         {
-            await ((IDeviceRegistrations)this).RemoveAsync(details.Id);
+            await ((IDeviceRegistrations)this).RemoveAsync(details?.Id);
         }
 
         /// <inheritdoc />
         async Task IDeviceRegistrations.RemoveAsync(string deviceId)
         {
-            // TODO: Validate the deviceId is not empty
+            Validate();
+
             var request = _restClient.CreateRequest($"/push/deviceRegistrations/{deviceId}", HttpMethod.Delete);
             AddFullWaitIfNecessary(request);
-            var result = await _restClient.ExecuteRequest(request);
+            await _restClient.ExecuteRequest(request);
 
-            // Question: what happens if the request errors
+            void Validate()
+            {
+                if (deviceId.IsEmpty())
+                {
+                    throw new AblyException("Please pass a non-empty deviceId to Remove", ErrorCodes.BadRequest);
+                }
+            }
         }
 
         private void AddFullWaitIfNecessary(AblyRequest request)

--- a/src/IO.Ably.Shared/Push/PushAdmin.cs
+++ b/src/IO.Ably.Shared/Push/PushAdmin.cs
@@ -388,6 +388,31 @@ namespace IO.Ably.Push
             }
         }
 
+        /// <inheritdoc />
+        async Task IDeviceRegistrations.RemoveWhereAsync(Dictionary<string, string> deleteFilter)
+        {
+            Validate();
+
+            var request = _restClient.CreateRequest($"/push/deviceRegistrations", HttpMethod.Delete);
+            AddFullWaitIfNecessary(request);
+            request.AddQueryParameters(deleteFilter);
+
+            if (deleteFilter.ContainsKey("deviceId") && deleteFilter["deviceId"] == _restClient.Device?.Id)
+            {
+                AddDeviceAuthenticationToRequest(request, _restClient.Device);
+            }
+
+            await _restClient.ExecuteRequest(request);
+
+            void Validate()
+            {
+                if (deleteFilter is null)
+                {
+                    throw new AblyException("DeleteFilter cannot be null.", ErrorCodes.BadRequest);
+                }
+            }
+        }
+
         private void AddFullWaitIfNecessary(AblyRequest request)
         {
             if (Options.PushAdminFullWait)

--- a/src/IO.Ably.Tests.Shared/Push/PushAdminSandboxTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/PushAdminSandboxTests.cs
@@ -59,8 +59,37 @@ namespace IO.Ably.Tests.DotNetCore20.Push
             {
             }
         }
+
         public class DeviceRegistrationsTests : SandboxSpecs
         {
+            [Theory]
+            [ProtocolData]
+            [Trait("spec", "RSH1")]
+            public async Task ShouldSuccessfullyRegisterDevice(Protocol protocol)
+            {
+                using var _ = EnableDebugLogging();
+                // Arrange
+                var client = await GetRestClient(protocol, options => options.PushAdminFullWait = true);
+
+                var device = LocalDevice.Create("123");
+                device.FormFactor = "phone";
+                device.Platform = "android";
+                device.Push.Recipient = JObject.FromObject(new
+                {
+                    transportType = "ablyChannel",
+                    channel = "pushenabled:test",
+                    ablyKey = client.Options.Key,
+                    ablyUrl = "https://" + client.Options.FullRestHost(),
+                });
+
+                Func<Task> callRegister = async () =>
+                {
+                    await client.Push.Admin.RegisterDevice(device);
+                };
+
+                await callRegister.Should().NotThrowAsync<AblyException>();
+            }
+
             [Theory]
             [ProtocolData]
             [Trait("spec", "RSH1b3")]

--- a/src/IO.Ably.Tests.Shared/Push/PushAdminSandboxTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/PushAdminSandboxTests.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using FluentAssertions;
+using IO.Ably.Push;
 using IO.Ably.Tests.Infrastructure;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -54,6 +56,46 @@ namespace IO.Ably.Tests.DotNetCore20.Push
 
             public PublishTests(AblySandboxFixture fixture, ITestOutputHelper output)
                 : base(fixture, output)
+            {
+            }
+        }
+        public class DeviceRegistrationsTests : SandboxSpecs
+        {
+            [Theory]
+            [ProtocolData]
+            [Trait("spec", "RSH1b3")]
+            public async Task ShouldSuccessfullySaveDeviceRegistration(Protocol protocol)
+            {
+                using var _ = EnableDebugLogging();
+                // Arrange
+                var client = await GetRestClient(protocol, options => options.PushAdminFullWait = true);
+
+                var device = LocalDevice.Create("123");
+                device.FormFactor = "phone";
+                device.Platform = "android";
+                device.Push.Recipient = JObject.FromObject(new
+                {
+                    transportType = "ablyChannel",
+                    channel = "pushenabled:test",
+                    ablyKey = client.Options.Key,
+                    ablyUrl = "https://" + client.Options.FullRestHost(),
+                });
+
+                Func<Task> callSave = async () =>
+                {
+                    var savedDevice = await client.Push.Admin.DeviceRegistrations.SaveAsync(device);
+
+                    savedDevice.Metadata = JObject.FromObject(new { tag = "test-tag" });
+                    savedDevice.Push.State = null; // Clear state as we don't care about it.
+
+                    var updatedDevice = await client.Push.Admin.DeviceRegistrations.SaveAsync(savedDevice);
+                    updatedDevice.Metadata.Should().BeEquivalentTo(savedDevice.Metadata);
+                };
+
+                await callSave.Should().NotThrowAsync<AblyException>();
+            }
+
+            public DeviceRegistrationsTests(AblySandboxFixture fixture, ITestOutputHelper output) : base(fixture, output)
             {
             }
         }

--- a/src/IO.Ably.Tests.Shared/Push/PushAdminSandboxTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/PushAdminSandboxTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using FluentAssertions;
 using IO.Ably.Push;
@@ -139,6 +140,60 @@ namespace IO.Ably.Tests.DotNetCore20.Push
                 };
 
                 await callSaveAndDelete.Should().NotThrowAsync<AblyException>();
+            }
+
+            [Theory]
+            [ProtocolData]
+            [Trait("spec", "RSH1b5")]
+            public async Task ShouldSuccessfullyDeleteDeviceRegistrationWithFilterByClientId(Protocol protocol)
+            {
+                // Arrange
+                var client = await GetRestClient(protocol, options => options.PushAdminFullWait = true);
+
+                var device = GetTestLocalDevice(client);
+
+                Func<Task> callSaveAndDelete = async () =>
+                {
+                    await client.Push.Admin.DeviceRegistrations.SaveAsync(device);
+                    await client.Push.Admin.DeviceRegistrations.RemoveWhereAsync(new Dictionary<string, string> { { "clientId", device.ClientId } });
+                };
+
+                await callSaveAndDelete.Should().NotThrowAsync<AblyException>();
+            }
+
+            [Theory]
+            [ProtocolData]
+            [Trait("spec", "RSH1b5")]
+            public async Task ShouldSuccessfullyDeleteDeviceRegistrationWithFilterByDeviceId(Protocol protocol)
+            {
+                // Arrange
+                var client = await GetRestClient(protocol, options => options.PushAdminFullWait = true);
+
+                var device = GetTestLocalDevice(client);
+
+                Func<Task> callSaveAndDelete = async () =>
+                {
+                    await client.Push.Admin.DeviceRegistrations.SaveAsync(device);
+                    await client.Push.Admin.DeviceRegistrations.RemoveWhereAsync(new Dictionary<string, string> { { "deviceId", device.Id } });
+                };
+
+                await callSaveAndDelete.Should().NotThrowAsync<AblyException>();
+            }
+
+            [Theory]
+            [ProtocolData]
+            [Trait("spec", "RSH1b5")]
+            public async Task ShouldSuccessfullyDeleteDeviceRegistrationWithOutMatchingFilter(Protocol protocol)
+            {
+                // Arrange
+                var client = await GetRestClient(protocol, options => options.PushAdminFullWait = true);
+
+                Func<Task> callRemoveWithNoFilter = async () =>
+                {
+                    await client.Push.Admin.DeviceRegistrations.RemoveWhereAsync(new Dictionary<string, string>() { { "deviceId", "test" } });
+                };
+
+                await callRemoveWithNoFilter.Should().NotThrowAsync<AblyException>();
             }
 
             private static LocalDevice GetTestLocalDevice(AblyRest client)

--- a/src/IO.Ably.Tests.Shared/Push/PushAdminTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/PushAdminTests.cs
@@ -316,6 +316,42 @@ namespace IO.Ably.Tests.DotNetCore20.Push
                     .Be(ErrorCodes.BadRequest);
             }
 
+            [Fact]
+            [Trait("spec", "RSH1b4")]
+            public async Task Delete_ShouldUseTheCorrectUrl()
+            {
+                AblyRequest currentRequest = null;
+                var client = GetRestClient(request =>
+                {
+                    currentRequest = request;
+                    return Task.FromResult(new AblyResponse() {StatusCode = HttpStatusCode.OK});
+                });
+
+                var deviceId = "123";
+                await client.Push.Admin.DeviceRegistrations.RemoveAsync(deviceId);
+
+                currentRequest.Url.Should().Be($"/push/deviceRegistrations/{deviceId}");
+                currentRequest.Method.Should().Be(HttpMethod.Delete);
+            }
+
+            [Fact]
+            [Trait("spec", "RSH1b4")]
+            public async Task Delete_ThrowWhenThereIsNoDeviceIdPassed()
+            {
+                var client = GetRestClient();
+
+                Func<string, Task> callDelete = (deviceId) => client.Push.Admin.DeviceRegistrations.RemoveAsync(deviceId);
+
+                Func<Task> withNullDeviceId = () => callDelete(null);
+                Func<Task> withEmptyDeviceId = () => callDelete(string.Empty);
+
+                (await withEmptyDeviceId.Should().ThrowAsync<AblyException>()).Which.ErrorInfo.Code.Should()
+                    .Be(ErrorCodes.BadRequest);
+
+                (await withNullDeviceId.Should().ThrowAsync<AblyException>()).Which.ErrorInfo.Code.Should()
+                    .Be(ErrorCodes.BadRequest);
+            }
+
             public DeviceRegistrationTests(ITestOutputHelper output)
                 : base(output)
             {


### PR DESCRIPTION
I don't like the spec for `removeWhere`
> (RSH1b5) #removeWhere(params) issues a DELETE request to /push/deviceRegistrations and deletes the registered devices matching the provided params. A test should exist that deletes devices by clientId and by deviceId separately, then additionally issues a delete for devices with no matching params and checks the operation still succeeds. If the client has been activated as a push target device, and the specified deviceId is that of the present client, then this request must include push device authentication.

The method should accept a dictionary<string, string> but at the same time the server only cares about `deviceId` or `clientId`. I wonder if I make it more specific. What do you think?