### PR TITLE
Push/make pushrest public

### DIFF
--- a/src/IO.Ably.Shared/AblyRest.cs
+++ b/src/IO.Ably.Shared/AblyRest.cs
@@ -75,7 +75,11 @@ namespace IO.Ably
         /// </summary>
         public IAblyAuth Auth => AblyAuth;
 
-        internal PushRest Push { get; private set; }
+        /// <summary>
+        /// Expose Push Admin Rest APIs.
+        /// Rest API documentation: https://ably.com/documentation/rest-api#push.
+        /// </summary>
+        public PushRest Push { get; private set; }
 
         // TODO: Think about how the local device will be shared among Rest instances and
         // what will happen whet it gets updated.

--- a/src/IO.Ably.Shared/Push/DeviceDetails.cs
+++ b/src/IO.Ably.Shared/Push/DeviceDetails.cs
@@ -15,37 +15,37 @@ namespace IO.Ably.Push
         public string Id { get; set; }
 
         /// <summary>
-        /// Device platform (android|ios|web). TODO: Double check.
+        /// Device platform. One of 'android', 'ios' or 'browser').
         /// </summary>
         [JsonProperty("platform")]
         public string Platform { get; set; }
 
         /// <summary>
-        /// Device form factor.
+        /// Device form factor. One of 'phone', 'tablet', 'desktop', 'tv', 'watch', 'car' or 'embedded'.
         /// </summary>
         [JsonProperty("formFactor")]
         public string FormFactor { get; set; }
 
         /// <summary>
-        /// Device ClientId. TODO: Explain how this can be used to send push notifications.
+        /// Device ClientId which is associated with the push registration.
         /// </summary>
         [JsonProperty("clientId")]
         public string ClientId { get; set; }
 
         /// <summary>
-        /// Device Metadata. TODO: Give example how this can be used.
+        /// Device Metadata. It's a flexible key value pair. Usually used to tag devices.
         /// </summary>
         [JsonProperty("metadata")]
         public JObject Metadata { get; set; }
 
         /// <summary>
-        /// Push registration data. TODO: Describe how it is relevant to each platform and how it differs.
+        /// Push registration data.
         /// </summary>
         [JsonProperty("push")]
         public PushData Push { get; set; } = new PushData();
 
         /// <summary>
-        /// Device secret. TODO: Describe how this could be used to authenticate push messages.
+        /// Random string which is automatically generated when a new LocalDevice is created and can be used to authenticate PushAdmin Rest requests.
         /// </summary>
         [JsonProperty("deviceSecret")]
         public string DeviceSecret { get; set; }
@@ -56,13 +56,14 @@ namespace IO.Ably.Push
         public class PushData
         {
             /// <summary>
-            /// Push Recipient. TODO: // describe the different options.
+            /// Push Recipient. Currently supporter recipients are Apple (apns), Google (fcm) and Browser (web).
+            /// For more information - https://ably.com/documentation/rest-api#post-device-registration.
             /// </summary>
             [JsonProperty("recipient")]
-            public JObject Recipient { get; set; } // TODO: Once we know all the variations of the data, I'd like to make it strongly typed.
+            public JObject Recipient { get; set; }
 
             /// <summary>
-            /// State. TODO: Add examples.
+            /// State of the push integration.
             /// </summary>
             [JsonProperty("state")]
             public string State { get; set; }

--- a/src/IO.Ably.Shared/Push/IPushChannelSubscriptions.cs
+++ b/src/IO.Ably.Shared/Push/IPushChannelSubscriptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace IO.Ably.Push
 {
@@ -24,20 +25,30 @@ namespace IO.Ably.Push
         Task<PaginatedResult<PushChannelSubscription>> ListAsync(ListSubscriptionsRequest requestFilter);
 
         /// <summary>
+        /// List all channels with at least one subscribed device.
+        /// RestApi: https://ably.com/documentation/rest-api#list-channels.
+        /// </summary>
+        /// <param name="requestParams">Allows adding a limit to the number of results and supports paginated requests handling.</param>
+        /// <returns>Paginated list of channel names.</returns>
+        Task<PaginatedResult<string>> ListChannelsAsync(PaginatedRequestParams requestParams);
+
+        /// <summary>
         /// Stop receiving push notifications when push messages are published on the specified channels.
         /// Please note that this operation is done asynchronously so immediate requests subsequent to this delete request may briefly still return the subscription.
         /// RestApi: https://ably.com/documentation/rest-api#delete-channel-subscription.
         /// </summary>
         /// <param name="subscription">Channel Subscription object to unsubscribe.</param>
         /// <returns>Task.</returns>
-        Task RemoveAsync(PushChannelSubscription subscription); // TODO: Add request object and allow other params
+        Task RemoveAsync(PushChannelSubscription subscription);
 
         /// <summary>
-        /// List all channels with at least one subscribed device.
-        /// RestApi: https://ably.com/documentation/rest-api#list-channels.
+        /// Stop receiving push notifications when push messages are published on the specified channels.
+        /// Please note that this operation is done asynchronously so immediate requests subsequent to this delete request may briefly still return the subscription.
+        /// Allows custom parameters to be passed in the filter.
+        /// RestApi: https://ably.com/documentation/rest-api#delete-channel-subscription.
         /// </summary>
-        /// <param name="requestParams">Allows adding a limit to the number of results and supports paginated requests handling.</param>
-        /// <returns>Paginated list of channel names.</returns>
-        Task<PaginatedResult<string>> ListChannelsAsync(PaginatedRequestParams requestParams); // TODO: Create a return type that is not string. Note: Java implementation has possible deviceId parameter but the REST documentation doesn't include it.
+        /// <param name="removeParams">Dictionary with query parameters passed to the server. Possible values are `clientId`, `deviceId` and `channel`.</param>
+        /// <returns>Task.</returns>
+        Task RemoveWhereAsync(IDictionary<string, string> removeParams);
     }
 }

--- a/src/IO.Ably.Shared/Push/LocalDevice.cs
+++ b/src/IO.Ably.Shared/Push/LocalDevice.cs
@@ -11,7 +11,8 @@ namespace IO.Ably.Push
     public class LocalDevice : DeviceDetails
     {
         /// <summary>
-        /// Devices that have completed registration have an identity token assigned to them by the push service. TODO: Check how accurate this is.
+        /// Devices that have completed registration have an identity token assigned to them by the push service.
+        /// It can be used to authenticate Push Admin requests.
         /// </summary>
         [JsonIgnore]
         public string DeviceIdentityToken { get; set; }
@@ -50,9 +51,9 @@ namespace IO.Ably.Push
         /// <summary>
         /// Create a new instance of localDevice with a random Id and secret.
         /// </summary>
-        /// <param name="clientId">The clientId which is set on the device. Can be null.</param>
+        /// <param name="clientId">Optional clientId which is set on the device.</param>
         /// <returns>Instance of LocalDevice.</returns>
-        public static LocalDevice Create(string clientId)
+        public static LocalDevice Create(string clientId = null)
         {
             return new LocalDevice
             {

--- a/src/IO.Ably.Shared/Push/PushAdmin.cs
+++ b/src/IO.Ably.Shared/Push/PushAdmin.cs
@@ -153,7 +153,7 @@ namespace IO.Ably.Push
         /// <summary>
         /// Publish a push notification message.
         /// </summary>
-        /// <param name="recipient">Recipient. TODO: When format is know, update to strongly typed object.</param>
+        /// <param name="recipient">Recipient. Best description of what is allowed can be found in the RestApi documentation: https://ably.com/documentation/rest-api#post-device-registration.</param>
         /// <param name="payload">Message payload.</param>
         /// <returns>Task.</returns>
         public async Task PublishAsync(JObject recipient, JObject payload)
@@ -218,7 +218,7 @@ namespace IO.Ably.Push
         }
 
         /// <inheritdoc />
-        async Task<PaginatedResult<PushChannelSubscription>> IPushChannelSubscriptions.ListAsync(ListSubscriptionsRequest requestFilter) // TODO: Update parametrs to PaginatedQuery
+        async Task<PaginatedResult<PushChannelSubscription>> IPushChannelSubscriptions.ListAsync(ListSubscriptionsRequest requestFilter)
         {
             var url = "/push/channelSubscriptions";
 
@@ -236,7 +236,7 @@ namespace IO.Ably.Push
         }
 
         /// <inheritdoc />
-        async Task IPushChannelSubscriptions.RemoveAsync(PushChannelSubscription subscription) // TODO: Do we allow to specify the channel as well.
+        async Task IPushChannelSubscriptions.RemoveAsync(PushChannelSubscription subscription)
         {
             Validate();
 

--- a/src/IO.Ably.Shared/Push/PushAdmin.cs
+++ b/src/IO.Ably.Shared/Push/PushAdmin.cs
@@ -284,6 +284,28 @@ namespace IO.Ably.Push
         }
 
         /// <inheritdoc />
+        async Task IPushChannelSubscriptions.RemoveWhereAsync(IDictionary<string, string> removeParams)
+        {
+            Validate();
+
+            var url = "/push/channelSubscriptions";
+
+            var request = _restClient.CreateRequest(url, HttpMethod.Delete);
+            AddFullWaitIfNecessary(request);
+            request.AddQueryParameters(removeParams);
+
+            _ = await _restClient.ExecuteRequest(request);
+
+            void Validate()
+            {
+                if (removeParams is null)
+                {
+                    throw new AblyException("RemoveParams should not be null", ErrorCodes.BadRequest);
+                }
+            }
+        }
+
+        /// <inheritdoc />
         async Task<PaginatedResult<string>> IPushChannelSubscriptions.ListChannelsAsync(PaginatedRequestParams requestParams)
         {
             var request = _restClient.CreateGetRequest("/push/channels");

--- a/src/IO.Ably.Tests.Shared/Push/PushAdminTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/PushAdminTests.cs
@@ -582,6 +582,38 @@ namespace IO.Ably.Tests.DotNetCore20.Push
                 requestWithClientId.QueryParameters.Should().ContainKey("clientId").WhichValue.Should().Be("123");
             }
 
+            [Fact]
+            [Trait("spec", "RSH1c5")]
+            public async Task RemoveWhere_ShouldCallTheCorrectUrl()
+            {
+                Func<IDictionary<string, string>, Task<AblyRequest>> callRemoveWhere = async whereParams =>
+                {
+                    AblyRequest request = null;
+                    var rest = GetRestClient(r =>
+                    {
+                        request = r;
+                        return Task.FromResult(new AblyResponse() { TextResponse = string.Empty });
+                    });
+
+                    await rest.Push.Admin.ChannelSubscriptions.RemoveWhereAsync(whereParams);
+                    return request;
+                };
+
+                var request = await callRemoveWhere(new Dictionary<string, string>());
+                request.Url.Should().Be("/push/channelSubscriptions");
+                request.Method.Should().Be(HttpMethod.Delete);
+                request.QueryParameters.Should().BeEmpty();
+
+                var requestWithChannelAndDeviceId = await callRemoveWhere(new Dictionary<string, string>() { { "channel", "test" }, { "deviceId", "best" } });
+
+                requestWithChannelAndDeviceId.QueryParameters.Should().ContainKey("channel").WhichValue.Should().Be("test");
+                requestWithChannelAndDeviceId.QueryParameters.Should().ContainKey("deviceId").WhichValue.Should().Be("best");
+
+                var requestWithRandomParameter = await callRemoveWhere(new Dictionary<string, string>() { { "random", "value" } });
+
+                requestWithRandomParameter.QueryParameters.Should().ContainKey("random").WhichValue.Should().Be("value");
+            }
+
             public ChannelSubscriptionsTests(ITestOutputHelper output)
                 : base(output)
             {


### PR DESCRIPTION
Now we have unit and integration tests for the Push Admin APIs, we can make the Push property in AblyRest public.