### PR TITLE
Remove unused 'RealtimeClients' property

### DIFF
--- a/src/IO.Ably.Tests.Shared/Infrastructure/AblySpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/AblySpecs.cs
@@ -140,22 +140,8 @@ namespace IO.Ably.Tests
 
         public void Dispose()
         {
-            foreach (var client in RealtimeClients)
-            {
-                try
-                {
-                    client.Dispose();
-                }
-                catch (Exception ex)
-                {
-                    Output?.WriteLine("Error disposing Client: " + ex.Message);
-                }
-            }
-
             _signal?.Dispose();
         }
-
-        public List<AblyRealtime> RealtimeClients { get; set; } = new List<AblyRealtime>();
     }
 
     public abstract class AblySpecs


### PR DESCRIPTION
I think the 'RealtimeClients' property may be unused. It's appears to always be an empty collection and I can't find any unit test that exercises it.  Check with Martin...