### PR TITLE
Move 'ChannelModeExtensions' out to its own file

### DIFF
--- a/src/IO.Ably.Shared/Extensions/ChannelModeExtensions.cs
+++ b/src/IO.Ably.Shared/Extensions/ChannelModeExtensions.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+
+using IO.Ably.Types;
+
+namespace IO.Ably
+{
+    /// <summary>
+    /// Helper methods when dealing with Channel Models.
+    /// </summary>
+    internal static class ChannelModeExtensions
+    {
+        public static ProtocolMessage.Flag? ToFlag(this ChannelMode mode)
+        {
+            switch (mode)
+            {
+                case ChannelMode.Presence:
+                    return ProtocolMessage.Flag.Presence;
+                case ChannelMode.Publish:
+                    return ProtocolMessage.Flag.Publish;
+                case ChannelMode.Subscribe:
+                    return ProtocolMessage.Flag.Subscribe;
+                case ChannelMode.PresenceSubscribe:
+                    return ProtocolMessage.Flag.PresenceSubscribe;
+                default:
+                    return null;
+            }
+        }
+
+        public static IEnumerable<ChannelMode> FromFlag(this ProtocolMessage.Flag flag)
+        {
+            if (flag.HasFlag(ProtocolMessage.Flag.Presence))
+            {
+                yield return ChannelMode.Presence;
+            }
+
+            if (flag.HasFlag(ProtocolMessage.Flag.Publish))
+            {
+                yield return ChannelMode.Publish;
+            }
+
+            if (flag.HasFlag(ProtocolMessage.Flag.Subscribe))
+            {
+                yield return ChannelMode.Subscribe;
+            }
+
+            if (flag.HasFlag(ProtocolMessage.Flag.PresenceSubscribe))
+            {
+                yield return ChannelMode.PresenceSubscribe;
+            }
+        }
+    }
+}

--- a/src/IO.Ably.Shared/IO.Ably.Shared.projitems
+++ b/src/IO.Ably.Shared/IO.Ably.Shared.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AblyRest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ApiKey.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CustomSerialisers\MessageExtrasConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\ChannelModeExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MessageEncoders\PayloadCache.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MessageEncoders\ProcessedPayload.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MessageEncoders\VCDiffEncoder.cs" />

--- a/src/IO.Ably.Shared/Types/ChannelModes.cs
+++ b/src/IO.Ably.Shared/Types/ChannelModes.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using IO.Ably.Types;
 
 namespace IO.Ably
 {
@@ -28,52 +27,6 @@ namespace IO.Ably
         /// PresenceSubscribe. Allows the attached channel to subscribe to Presence updates.
         /// </summary>
         PresenceSubscribe,
-    }
-
-    /// <summary>
-    /// Helper methods when dealing with Channel Models.
-    /// </summary>
-    internal static class ChannelModeExtensions
-    {
-        public static ProtocolMessage.Flag? ToFlag(this ChannelMode mode)
-        {
-            switch (mode)
-            {
-                case ChannelMode.Presence:
-                    return ProtocolMessage.Flag.Presence;
-                case ChannelMode.Publish:
-                    return ProtocolMessage.Flag.Publish;
-                case ChannelMode.Subscribe:
-                    return ProtocolMessage.Flag.Subscribe;
-                case ChannelMode.PresenceSubscribe:
-                    return ProtocolMessage.Flag.PresenceSubscribe;
-                default:
-                    return null;
-            }
-        }
-
-        public static IEnumerable<ChannelMode> FromFlag(this ProtocolMessage.Flag flag)
-        {
-            if (flag.HasFlag(ProtocolMessage.Flag.Presence))
-            {
-                yield return ChannelMode.Presence;
-            }
-
-            if (flag.HasFlag(ProtocolMessage.Flag.Publish))
-            {
-                yield return ChannelMode.Publish;
-            }
-
-            if (flag.HasFlag(ProtocolMessage.Flag.Subscribe))
-            {
-                yield return ChannelMode.Subscribe;
-            }
-
-            if (flag.HasFlag(ProtocolMessage.Flag.PresenceSubscribe))
-            {
-                yield return ChannelMode.PresenceSubscribe;
-            }
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
Move `ChannelModeExtensions` out to its own file, located along with the other 'Extensions classes.