### PR TITLE
Elide 'MSGPACK' only state

### DIFF
--- a/src/IO.Ably.Shared/ClientOptions.cs
+++ b/src/IO.Ably.Shared/ClientOptions.cs
@@ -15,7 +15,9 @@ namespace IO.Ably
         private string _realtimeHost;
         private string _restHost;
         private Func<DateTimeOffset> _nowFunc;
+#if !MSGPACK
         private bool _useBinaryProtocol = false;
+#endif
         private string[] _fallbackHosts;
 
         /// <summary>


### PR DESCRIPTION
We don't need this state at the moment, as and when we re-enable `MSGPACK` we'll bring this back.