### PR TITLE
Replace magic number with 'InvalidCredentials' enum

### DIFF
--- a/src/IO.Ably.Shared/AblyAuth.cs
+++ b/src/IO.Ably.Shared/AblyAuth.cs
@@ -537,7 +537,7 @@ namespace IO.Ably
 
             if (string.IsNullOrEmpty(authOptions.Key))
             {
-                throw new AblyException("No key specified", 40101, HttpStatusCode.Unauthorized);
+                throw new AblyException("No key specified", ErrorCodes.InvalidCredentials, HttpStatusCode.Unauthorized);
             }
 
             await SetTokenParamsTimestamp(authOptions, tokenParams);

--- a/src/IO.Ably.Shared/ApiKey.cs
+++ b/src/IO.Ably.Shared/ApiKey.cs
@@ -44,7 +44,7 @@ namespace IO.Ably
         {
             if (string.IsNullOrWhiteSpace(key))
             {
-                throw new AblyException("Ably key was empty. Ably key must be in the following format [AppId].[keyId]:[keyValue]", 40101, HttpStatusCode.Unauthorized);
+                throw new AblyException("Ably key was empty. Ably key must be in the following format [AppId].[keyId]:[keyValue]", ErrorCodes.InvalidCredentials, HttpStatusCode.Unauthorized);
             }
 
             var trimmedKey = key.Trim();
@@ -65,7 +65,7 @@ namespace IO.Ably
                 }
             }
 
-            throw new AblyException("Invalid Ably key. Ably key must be in the following format [AppId].[keyId]:[keyValue]", 40101, HttpStatusCode.Unauthorized);
+            throw new AblyException("Invalid Ably key. Ably key must be in the following format [AppId].[keyId]:[keyValue]", ErrorCodes.InvalidCredentials, HttpStatusCode.Unauthorized);
         }
 
         internal static bool IsValidFormat(string key)

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -349,7 +349,7 @@ namespace IO.Ably.Tests.Realtime
 
             // this assertion shows that we are picking up a client side validation error
             // if this key is passed to the server we would get an error with a 40005 code
-            client.Connection.ErrorReason.Code.Should().Be(40101);
+            client.Connection.ErrorReason.Code.Should().Be(ErrorCodes.InvalidCredentials);
         }
 
         [Theory]


### PR DESCRIPTION
Replace the `40101` magic number with `ErrorCodes.InvalidCredentials` enum.