### PR TITLE
Replace magic number with 'Unauthorized' enum

### DIFF
--- a/src/IO.Ably.Shared/AblyAuth.cs
+++ b/src/IO.Ably.Shared/AblyAuth.cs
@@ -177,7 +177,7 @@ namespace IO.Ably
                 var currentValidToken = await GetCurrentValidTokenAndRenewIfNecessaryAsync();
                 if (currentValidToken == null)
                 {
-                    throw new AblyException("Invalid token credentials: " + CurrentToken, 40100, HttpStatusCode.Unauthorized);
+                    throw new AblyException("Invalid token credentials: " + CurrentToken, ErrorCodes.Unauthorized, HttpStatusCode.Unauthorized);
                 }
 
                 request.Headers["Authorization"] = "Bearer " + CurrentToken.Token.ToBase64();

--- a/src/IO.Ably.Shared/Transport/TransportParams.cs
+++ b/src/IO.Ably.Shared/Transport/TransportParams.cs
@@ -99,7 +99,7 @@ namespace IO.Ably.Transport
                 var token = await auth.GetCurrentValidTokenAndRenewIfNecessaryAsync();
                 if (token == null)
                 {
-                    throw new AblyException("There is no valid token. Can't authenticate", 40100, HttpStatusCode.Unauthorized);
+                    throw new AblyException("There is no valid token. Can't authenticate", ErrorCodes.Unauthorized, HttpStatusCode.Unauthorized);
                 }
 
                 result.AuthValue = token.Token;

--- a/src/IO.Ably.Shared/Types/ErrorInfo.cs
+++ b/src/IO.Ably.Shared/Types/ErrorInfo.cs
@@ -16,7 +16,7 @@ namespace IO.Ably
         internal static readonly ErrorInfo ReasonDisconnected = new ErrorInfo("Connection temporarily unavailable", 80003);
         internal static readonly ErrorInfo ReasonSuspended = new ErrorInfo("Connection unavailable", 80002);
         internal static readonly ErrorInfo ReasonFailed = new ErrorInfo("Connection failed", 80000);
-        internal static readonly ErrorInfo ReasonRefused = new ErrorInfo("Access refused", 40100);
+        internal static readonly ErrorInfo ReasonRefused = new ErrorInfo("Access refused", ErrorCodes.Unauthorized);
         internal static readonly ErrorInfo ReasonTooBig = new ErrorInfo("Connection closed; message too large", 40000);
         internal static readonly ErrorInfo ReasonNeverConnected = new ErrorInfo("Unable to establish connection", 80002);
         internal static readonly ErrorInfo ReasonTimeout = new ErrorInfo("Unable to establish connection", 80014);

--- a/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
@@ -207,7 +207,7 @@ namespace IO.Ably.Tests
             [Fact]
             public async Task WhenErrorCodeIsNotTokenSpecific_ShouldThrow()
             {
-                var client = GetConfiguredRestClient(40100, null);
+                var client = GetConfiguredRestClient(ErrorCodes.Unauthorized, null);
 
                 await Assert.ThrowsAsync<AblyException>(() => client.StatsAsync());
             }


### PR DESCRIPTION
Replace the magic number `40100` with the `ErrorCodes.Unauthorized` enum.