### PR TITLE
Replace magic number with 'NoError' enum

### DIFF
--- a/src/IO.Ably.Shared/Types/ErrorInfo.cs
+++ b/src/IO.Ably.Shared/Types/ErrorInfo.cs
@@ -12,7 +12,7 @@ namespace IO.Ably
     /// </summary>
     public class ErrorInfo
     {
-        internal static readonly ErrorInfo ReasonClosed = new ErrorInfo("Connection closed by client", 10000);
+        internal static readonly ErrorInfo ReasonClosed = new ErrorInfo("Connection closed by client", ErrorCodes.NoError);
         internal static readonly ErrorInfo ReasonDisconnected = new ErrorInfo("Connection temporarily unavailable", 80003);
         internal static readonly ErrorInfo ReasonSuspended = new ErrorInfo("Connection unavailable", 80002);
         internal static readonly ErrorInfo ReasonFailed = new ErrorInfo("Connection failed", 80000);


### PR DESCRIPTION
Replace the magic number `10000` with `ErrorCodes.NoError` enum.