### PR TITLE
Replace magic number with 'UnableToEnterPresenceChannelInvalidState' …

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -472,7 +472,7 @@ namespace IO.Ably.Realtime
                 default:
                     var error = new ErrorInfo(
                         $"Unable to enter presence channel when connection is in a ${_connection.Connection.State} state.",
-                        91001,
+                        ErrorCodes.UnableToEnterPresenceChannelInvalidState,
                         HttpStatusCode.BadRequest);
                     Logger.Warning(error.ToString());
                     ActionUtils.SafeExecute(() => callback?.Invoke(false, error), Logger, nameof(UpdatePresence));
@@ -498,7 +498,7 @@ namespace IO.Ably.Realtime
                     _connection.Send(message, callback);
                     break;
                 default:
-                    var error = new ErrorInfo($"Unable to enter presence channel in {_channel.State} state", 91001);
+                    var error = new ErrorInfo($"Unable to enter presence channel in {_channel.State} state", ErrorCodes.UnableToEnterPresenceChannelInvalidState);
                     Logger.Warning(error.ToString());
                     ActionUtils.SafeExecute(() => callback?.Invoke(false, error), Logger, nameof(UpdatePresence));
                     return;

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -1743,7 +1743,7 @@ namespace IO.Ably.Tests.Realtime
                         if (result.IsFailure)
                         {
                             didError = true;
-                            result.Error.Code.Should().Be(91001);
+                            result.Error.Code.Should().Be(ErrorCodes.UnableToEnterPresenceChannelInvalidState);
                             errCount++;
                         }
 
@@ -1800,7 +1800,7 @@ namespace IO.Ably.Tests.Realtime
                         if (result.IsFailure)
                         {
                             didError = true;
-                            result.Error.Code.Should().Be(91001);
+                            result.Error.Code.Should().Be(ErrorCodes.UnableToEnterPresenceChannelInvalidState);
                             errCount++;
                         }
 


### PR DESCRIPTION
…enum

Replace the magic number `91001` with the `ErrorCodes.UnableToEnterPresenceChannelInvalidState` enum.