### PR TITLE
Replace magic number with 'ChannelOperationFailedNoServerResponse' enum

### DIFF
--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -325,7 +325,7 @@ namespace IO.Ably.Realtime
             }
 
             // RTL4f
-            SetChannelState(ChannelState.Suspended, new ErrorInfo($"Channel didn't attach within  {ConnectionManager.Options.RealtimeRequestTimeout}", 90007, HttpStatusCode.RequestTimeout));
+            SetChannelState(ChannelState.Suspended, new ErrorInfo($"Channel didn't attach within  {ConnectionManager.Options.RealtimeRequestTimeout}", ErrorCodes.ChannelOperationFailedNoServerResponse, HttpStatusCode.RequestTimeout));
         }
 
         private void OnDetachTimeout()

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -384,7 +384,7 @@ namespace IO.Ably.Tests.Realtime
                     /* RTL2d */
                     s.Error.Should().NotBeNull();
                     s.Error.Message.Should().StartWith("Channel didn't attach within");
-                    s.Error.Code.Should().Be(90007);
+                    s.Error.Code.Should().Be(ErrorCodes.ChannelOperationFailedNoServerResponse);
                     tsc.SetCompleted();
                 });
 


### PR DESCRIPTION
Replace the magic number `90007` with the `ErrorCodes.ChannelOperationFailedNoServerResponse` enum.