### PR TITLE
Replace magic number with 'KeyError' enum

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -1037,7 +1037,7 @@ namespace IO.Ably.Tests.Realtime
 
             var dummyError = new ErrorInfo
             {
-                Code = 40130,
+                Code = ErrorCodes.KeyError,
                 StatusCode = HttpStatusCode.Unauthorized,
                 Message = "fake error"
             };


### PR DESCRIPTION
Replace the magic number `40130` with the `ErrorCodes.KeyError` enum.