### PR TITLE
Replace magic number with 'TokenError' enum

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -992,7 +992,7 @@ namespace IO.Ably.Tests.Realtime
 
                 client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Disconnected)
                 {
-                    Error = new ErrorInfo("test", 40140)
+                    Error = new ErrorInfo("test", ErrorCodes.TokenError)
                 });
             });
 

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandboxOperatingSystemEventsForNetworkSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandboxOperatingSystemEventsForNetworkSpecs.cs
@@ -136,7 +136,7 @@ namespace IO.Ably.Tests.Realtime
                 });
             });
 
-            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Disconnected) { Error = new ErrorInfo("testing RTN22a", 40140) });
+            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Disconnected) { Error = new ErrorInfo("testing RTN22a", ErrorCodes.TokenError) });
             var didReconnect = await reconnectAwaiter.Task;
             didReconnect.Should().BeTrue();
             client.RestClient.AblyAuth.CurrentToken.Should().NotBe(initialToken);
@@ -173,7 +173,7 @@ namespace IO.Ably.Tests.Realtime
                 });
             });
 
-            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Disconnected) { Error = new ErrorInfo("testing RTN22a", 40140) });
+            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Disconnected) { Error = new ErrorInfo("testing RTN22a", ErrorCodes.TokenError) });
             var didReconnect = await reconnectAwaiter.Task;
             didReconnect.Should().BeTrue();
             client.RestClient.AblyAuth.CurrentToken.Should().NotBe(initialToken);

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
@@ -16,8 +16,6 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
 {
     public class ConnectionFailureSpecs : AblyRealtimeSpecs
     {
-        private const int TokenErrorCode = 40140;
-
         private readonly TokenDetails _returnedDummyTokenDetails = new TokenDetails("123") { Expires = TestHelpers.Now().AddDays(1), ClientId = "123" };
 
         public ConnectionFailureSpecs(ITestOutputHelper output)
@@ -63,7 +61,7 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
 
             await client.WaitForState(ConnectionState.Connecting);
 
-            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Error) { Error = new ErrorInfo("Unauthorised", TokenErrorCode, HttpStatusCode.Unauthorized) });
+            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Error) { Error = new ErrorInfo("Unauthorised", ErrorCodes.TokenError, HttpStatusCode.Unauthorized) });
 
             await client.ProcessCommands();
             renewTokenCalled.Should().BeTrue();
@@ -89,7 +87,7 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
             {
                 if (request.Url.Contains("/keys"))
                 {
-                    throw new AblyException(new ErrorInfo { Code = TokenErrorCode });
+                    throw new AblyException(new ErrorInfo { Code = ErrorCodes.TokenError });
                 }
 
                 return AblyResponse.EmptyResponse.ToTask();
@@ -108,12 +106,12 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
 
             await client.WaitForState(ConnectionState.Connecting);
 
-            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Error) { Error = new ErrorInfo("Unauthorised", TokenErrorCode, HttpStatusCode.Unauthorized) });
+            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Error) { Error = new ErrorInfo("Unauthorised", ErrorCodes.TokenError, HttpStatusCode.Unauthorized) });
 
             await taskAwaiter.Task;
 
             client.Connection.ErrorReason.Should().NotBeNull();
-            client.Connection.ErrorReason.Code.Should().Be(TokenErrorCode);
+            client.Connection.ErrorReason.Code.Should().Be(ErrorCodes.TokenError);
         }
 
         [Fact]
@@ -148,11 +146,11 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
 
             await client.WaitForState(ConnectionState.Connecting);
 
-            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Error) { Error = new ErrorInfo("Unauthorised", TokenErrorCode, HttpStatusCode.Unauthorized) });
+            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Error) { Error = new ErrorInfo("Unauthorised", ErrorCodes.TokenError, HttpStatusCode.Unauthorized) });
 
             await client.ProcessCommands();
 
-            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Error) { Error = new ErrorInfo("Unauthorised", TokenErrorCode, HttpStatusCode.Unauthorized) });
+            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Error) { Error = new ErrorInfo("Unauthorised", ErrorCodes.TokenError, HttpStatusCode.Unauthorized) });
 
             await client.ProcessCommands();
 

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
@@ -18,7 +18,6 @@ namespace IO.Ably.Tests.Realtime
     [Trait("spec", "RTN15")]
     public class ConnectionFailuresOnceConnectedSpecs : AblyRealtimeSpecs
     {
-        private const int TokenErrorCode = 40140;
         private const int FailedRenewalErrorCode = 1234;
 
         private readonly TokenDetails _returnedDummyTokenDetails = new TokenDetails("123") { Expires = TestHelpers.Now().AddDays(1), ClientId = "123" };
@@ -33,7 +32,7 @@ namespace IO.Ably.Tests.Realtime
             SetNowFunc(() => DateTimeOffset.UtcNow);
             _validToken = new TokenDetails("id") { Expires = Now.AddHours(1) };
             _renewTokenCalled = false;
-            _tokenErrorInfo = new ErrorInfo { Code = TokenErrorCode, StatusCode = HttpStatusCode.Unauthorized };
+            _tokenErrorInfo = new ErrorInfo { Code = ErrorCodes.TokenError, StatusCode = HttpStatusCode.Unauthorized };
         }
 
         [Fact]
@@ -141,7 +140,7 @@ namespace IO.Ably.Tests.Realtime
 
             errors.Should().NotBeEmpty();
             errors.Should().HaveCount(2);
-            errors[0].Code.Should().Be(40140);
+            errors[0].Code.Should().Be(ErrorCodes.TokenError);
             errors[1].Code.Should().Be(FailedRenewalErrorCode);
         }
 

--- a/src/IO.Ably.Tests.Shared/Realtime/RealtimeSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/RealtimeSandboxSpecs.cs
@@ -168,7 +168,7 @@ namespace IO.Ably.Tests.Realtime
             catch (AblyException e)
             {
                 e.Should().BeOfType<AblyException>();
-                e.ErrorInfo.Code.Should().Be(40140);
+                e.ErrorInfo.Code.Should().Be(ErrorCodes.TokenError);
             }
         }
 


### PR DESCRIPTION
Replace the magic number `40140` with the `ErrorCodes.TokenError` enum.