### PR TITLE
Replace magic number with 'OperationNotPermittedWithCapability' enum

### DIFF
--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
@@ -603,7 +603,7 @@ namespace IO.Ably.Tests
             var error =
                 await
                     Assert.ThrowsAsync<AblyException>(() => tokenAbly.Channels.Get("boo").PublishAsync("test", "true"));
-            error.ErrorInfo.Code.Should().Be(40160);
+            error.ErrorInfo.Code.Should().Be(ErrorCodes.OperationNotPermittedWithCapability);
             error.ErrorInfo.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         }
 

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -111,7 +111,7 @@ namespace IO.Ably.Tests.Realtime
             var result = await channel.AttachAsync();
 
             result.IsFailure.Should().BeTrue();
-            result.Error.Code.Should().Be(40160);
+            result.Error.Code.Should().Be(ErrorCodes.OperationNotPermittedWithCapability);
             result.Error.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
         }
 

--- a/src/IO.Ably.Tests.Shared/Realtime/RealtimeSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/RealtimeSandboxSpecs.cs
@@ -216,7 +216,7 @@ namespace IO.Ably.Tests.Realtime
             {
                 // bar should fail
                 b.Should().BeFalse();
-                info.Code.Should().Be(40160);
+                info.Code.Should().Be(ErrorCodes.OperationNotPermittedWithCapability);
                 barFailAwaiter.SetCompleted();
             });
             barChannel.Attach();
@@ -277,7 +277,7 @@ namespace IO.Ably.Tests.Realtime
             await failedAwaiter.Task;
 
             stateChange.Should().NotBeNull("channel should have failed");
-            stateChange.Error.Code.Should().Be(40160);
+            stateChange.Error.Code.Should().Be(ErrorCodes.OperationNotPermittedWithCapability);
             stateChange.Error.Message.Should().Contain("Channel denied access");
 
             async Task DowngradeCapability(AblyRealtime rt)


### PR DESCRIPTION
Replace the magic number `40160` with the `ErrorCodes.OperationNotPermittedWithCapability` enum.