### PR TITLE
Remove interface methods that hide those in the base

### DIFF
--- a/src/IO.Ably.Shared/IO.Ably.Shared.projitems
+++ b/src/IO.Ably.Shared/IO.Ably.Shared.projitems
@@ -160,7 +160,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Types\ErrorCodes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Types\ErrorInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpPaginatedResponse.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Types\IEncodedMessage.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Types\IMessage.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Types\Message.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Types\MessageExtras.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Types\PresenceMessage.cs" />

--- a/src/IO.Ably.Shared/Types/IMessage.cs
+++ b/src/IO.Ably.Shared/Types/IMessage.cs
@@ -4,7 +4,6 @@ namespace IO.Ably
 {
     // No need to document an internal interface.
 #pragma warning disable SA1600 // Elements should be documented
-#pragma warning disable SA1649 // File name should match first type name
 
     internal interface IPayload
     {
@@ -21,15 +20,10 @@ namespace IO.Ably
 
         string ConnectionKey { get; set; }
 
-        object Data { get; set; }
-
         string ClientId { get; set; }
-
-        string Encoding { get; set; }
 
         DateTimeOffset? Timestamp { get; set; }
     }
-#pragma warning restore SA1649 // File name should match first type name
-#pragma warning restore SA1600 // Elements should be documented
 
+#pragma warning restore SA1600 // Elements should be documented
 }


### PR DESCRIPTION
Methods in the `IMessage` interface hide those in the `IPayload` base interface.

Perhaps due to a previously interupted refactoring?