### PR TITLE
'AuthSandboxSpecs' use unused 'context' parameter

### DIFF
--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
@@ -414,8 +414,8 @@ namespace IO.Ably.Tests
 
                 _ = await Assert.ThrowsAsync<AblyException>(() => realtimeClient.Auth.AuthorizeAsync());
 
-                realtimeClient.Connection.State.Should().Be(ConnectionState.Connected);
-                stateChanged.Should().BeFalse();
+                realtimeClient.Connection.State.Should().Be(ConnectionState.Connected, because: context);
+                stateChanged.Should().BeFalse(because: context);
             }
 
             await TestConnectedStaysConnected("With invalid AuthUrl Connection remains Connected", AuthUrlOptions);


### PR DESCRIPTION
If our assertions fail having the `context` as part of the failure message use useful.