### PR TITLE
'ConnectionSpecs' name opaque boolean parameter

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
@@ -110,7 +110,7 @@ namespace IO.Ably.Tests.Realtime
         [Trait("spec", "RTN15h2")]
         public async Task WithTokenErrorWhenTokenRenewalFails_ShouldGoToDisconnectedAndEmitError()
         {
-            var client = await SetupConnectedClient(true);
+            var client = await SetupConnectedClient(failRenewal: true);
 
             List<ConnectionState> states = new List<ConnectionState>();
             var errors = new List<ErrorInfo>();


### PR DESCRIPTION
I'm not a fan of boolean parameters, they're almost entirely opaque when subsequently being read, an `enum` would be better...