### PR TITLE
Remove redundant explicit array creation bound to 'params'

### DIFF
--- a/src/IO.Ably.Shared/MessageEncoders/MessageEncoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/MessageEncoder.cs
@@ -35,7 +35,7 @@ namespace IO.Ably.MessageEncoders
                 return string.Empty;
             }
 
-            var encodings = payload.Encoding.Split(new[] { '/' });
+            var encodings = payload.Encoding.Split('/');
             return string.Join("/", encodings.Take(encodings.Length - 1));
         }
 

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -1336,7 +1336,9 @@ namespace IO.Ably.Tests.Realtime
 
                 receivedMessages.Should().HaveCount(3);
                 receivedMessages.Select(x => x.Id).Should().BeEquivalentTo(
-                    new[] { $"{protocolMessage.Id}:0", $"{protocolMessage.Id}:1", $"{protocolMessage.Id}:2" });
+                    $"{protocolMessage.Id}:0",
+                    $"{protocolMessage.Id}:1",
+                    $"{protocolMessage.Id}:2");
             }
 
             [Fact]

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -1047,10 +1047,7 @@ namespace IO.Ably.Tests.Realtime
                 Error = dummyError
             });
 
-            states.Should().Equal(new[]
-            {
-                ConnectionState.Failed
-            });
+            states.Should().Equal(ConnectionState.Failed);
 
             errors.Should().HaveCount(1);
             errors[0].Should().Be(dummyError);

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/EventEmitterSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/EventEmitterSpecs.cs
@@ -20,8 +20,7 @@ namespace IO.Ably.Tests.Realtime
         public void EmittedEventTypesShouldBe()
         {
             var states = Enum.GetNames(typeof(ConnectionEvent));
-            states.Should().BeEquivalentTo(new[]
-            {
+            states.Should().BeEquivalentTo(
                 "Initialized",
                 "Connecting",
                 "Connected",
@@ -30,8 +29,7 @@ namespace IO.Ably.Tests.Realtime
                 "Closing",
                 "Closed",
                 "Failed",
-                "Update"
-            });
+                "Update");
         }
 
         [Fact]

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
@@ -32,7 +32,7 @@ namespace IO.Ably.Tests.Rest
             var channel2 = client.Channels.Get("test1");
 
             client.Channels.Should().HaveCount(2);
-            client.Channels.Should().BeEquivalentTo(new[] { channel1, channel2 });
+            client.Channels.Should().BeEquivalentTo(channel1, channel2);
         }
 
         [Fact]
@@ -144,7 +144,7 @@ namespace IO.Ably.Tests.Rest
                 LastRequest.Url.Should().Be($"/channels/{channel.Name}/messages");
                 var postedMessages = LastRequest.PostData as List<Message>;
                 postedMessages.Should().HaveCount(3);
-                postedMessages.Should().BeEquivalentTo(new[] { message, message1, message2 });
+                postedMessages.Should().BeEquivalentTo(message, message1, message2);
             }
 
             [Fact]


### PR DESCRIPTION
When calling a method that uses the 'params' keyword you don't need to explicitly create an array, the compiler takes care of this for you. It's all part of the 'params' value proposition.