### PR TITLE
'ActivationStateMachine' make member private

### DIFF
--- a/src/IO.Ably.Shared/Push/ActivationStateMachine.cs
+++ b/src/IO.Ably.Shared/Push/ActivationStateMachine.cs
@@ -258,7 +258,7 @@ namespace IO.Ably.Push
             _mobileDevice.RequestRegistrationToken(UpdateRegistrationToken);
         }
 
-        public void UpdateRegistrationToken(Result<RegistrationToken> tokenResult)
+        private void UpdateRegistrationToken(Result<RegistrationToken> tokenResult)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Check with Martin as the implementation is actually throwing a `NotImplementedException`.  Is this by design or does this indicate we've got unfinished business?