### PR TITLE
'PushRest' remove unused member state

### DIFF
--- a/src/IO.Ably.Shared/Push/PushRest.cs
+++ b/src/IO.Ably.Shared/Push/PushRest.cs
@@ -5,13 +5,8 @@
     /// </summary>
     public class PushRest
     {
-        private readonly AblyRest _rest;
-        private readonly ILogger _logger;
-
         internal PushRest(AblyRest rest, ILogger logger)
         {
-            _rest = rest;
-            _logger = logger;
             Admin = new PushAdmin(rest, logger);
         }
 


### PR DESCRIPTION
`PushRest` doesn't need to hang on to this member state since it's just delegated down to the `Admin` property which does the holding on.