### PR TITLE
'RealtimeWorkflow' fix possible 'NullReferenceException' warning

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
+++ b/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
@@ -639,7 +639,7 @@ namespace IO.Ably.Realtime.Workflow
                 {
                     if (channel.State == ChannelState.Attached || channel.State == ChannelState.Attaching)
                     {
-                        (channel as RealtimeChannel).SetChannelState(ChannelState.Detached, cmd.Message.Error);
+                        ((RealtimeChannel)channel).SetChannelState(ChannelState.Detached, cmd.Message.Error);
                     }
                 }
             }


### PR DESCRIPTION
We should use a cast here rather than `as` since by construction our expectation is for this to succeed.  If it doesn't then we have deeper problems.