### PR TITLE
Replace magic number with new 'NoMeansProvidedToRenewAuthToken' constant

### DIFF
--- a/src/IO.Ably.Shared/Types/ErrorCodes.cs
+++ b/src/IO.Ably.Shared/Types/ErrorCodes.cs
@@ -45,6 +45,7 @@ namespace IO.Ably
         public const int ConnectionBlockedLimitsExceeded = 40150;
         public const int OperationNotPermittedWithCapability = 40160;
         public const int ClientCallbackError = 40170;
+        public const int NoMeansProvidedToRenewAuthToken = 40171;
 
         /* 403 codes */
         public const int Forbidden = 40300;

--- a/src/IO.Ably.Shared/Types/ErrorInfo.cs
+++ b/src/IO.Ably.Shared/Types/ErrorInfo.cs
@@ -20,7 +20,7 @@ namespace IO.Ably
         internal static readonly ErrorInfo ReasonTooBig = new ErrorInfo("Connection closed; message too large", 40000);
         internal static readonly ErrorInfo ReasonNeverConnected = new ErrorInfo("Unable to establish connection", ErrorCodes.ConnectionSuspended);
         internal static readonly ErrorInfo ReasonTimeout = new ErrorInfo("Unable to establish connection", 80014);
-        internal static readonly ErrorInfo ReasonUnknown = new ErrorInfo("Unknown error", 50000, HttpStatusCode.InternalServerError);
+        internal static readonly ErrorInfo ReasonUnknown = new ErrorInfo("Unknown error", ErrorCodes.InternalError, HttpStatusCode.InternalServerError);
         internal static readonly ErrorInfo NonRenewableToken = new ErrorInfo("The library was initialized with a token without any way to renew the token when it expires (no authUrl, authCallback, or key). See https://help.ably.io/error/40171 for help", ErrorCodes.NoMeansProvidedToRenewAuthToken, HttpStatusCode.Unauthorized);
 
         internal const string CodePropertyName = "code";

--- a/src/IO.Ably.Shared/Types/ErrorInfo.cs
+++ b/src/IO.Ably.Shared/Types/ErrorInfo.cs
@@ -21,7 +21,7 @@ namespace IO.Ably
         internal static readonly ErrorInfo ReasonNeverConnected = new ErrorInfo("Unable to establish connection", ErrorCodes.ConnectionSuspended);
         internal static readonly ErrorInfo ReasonTimeout = new ErrorInfo("Unable to establish connection", 80014);
         internal static readonly ErrorInfo ReasonUnknown = new ErrorInfo("Unknown error", 50000, HttpStatusCode.InternalServerError);
-        internal static readonly ErrorInfo NonRenewableToken = new ErrorInfo("The library was initialized with a token without any way to renew the token when it expires (no authUrl, authCallback, or key). See https://help.ably.io/error/40171 for help", 40171, HttpStatusCode.Unauthorized);
+        internal static readonly ErrorInfo NonRenewableToken = new ErrorInfo("The library was initialized with a token without any way to renew the token when it expires (no authUrl, authCallback, or key). See https://help.ably.io/error/40171 for help", ErrorCodes.NoMeansProvidedToRenewAuthToken, HttpStatusCode.Unauthorized);
 
         internal const string CodePropertyName = "code";
         internal const string StatusCodePropertyName = "statusCode";

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
@@ -89,7 +89,7 @@ namespace IO.Ably.Tests
                 // (401 HTTP status code and an Ably error value 40140 <= code < 40150)
                 // As the token is expired we can expect a specific code "40142": "token expired"
                 e.ErrorInfo.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
-                e.ErrorInfo.Code.Should().Be(40171);
+                e.ErrorInfo.Code.Should().Be(ErrorCodes.NoMeansProvidedToRenewAuthToken);
             }
 
             // did not retry the request
@@ -123,7 +123,7 @@ namespace IO.Ably.Tests
             realtimeClient.Connection.State.Should().Be(ConnectionState.Failed);
             connected.Should().BeFalse();
 
-            realtimeClient.Connection.ErrorReason.Code.Should().Be(40171);
+            realtimeClient.Connection.ErrorReason.Code.Should().Be(ErrorCodes.NoMeansProvidedToRenewAuthToken);
             helper.Requests.Count.Should().Be(0);
         }
 
@@ -149,7 +149,7 @@ namespace IO.Ably.Tests
             await realtimeClient.WaitForState(ConnectionState.Failed);
             realtimeClient.Connection.State.Should().Be(ConnectionState.Failed);
 
-            realtimeClient.Connection.ErrorReason.Code.Should().Be(40171);
+            realtimeClient.Connection.ErrorReason.Code.Should().Be(ErrorCodes.NoMeansProvidedToRenewAuthToken);
             helper.Requests.Count.Should().Be(0);
         }
 
@@ -584,7 +584,7 @@ namespace IO.Ably.Tests
             });
 
             var ex = await Assert.ThrowsAsync<AblyException>(() => ably.StatsAsync());
-            ex.ErrorInfo.Code.Should().Be(40171);
+            ex.ErrorInfo.Code.Should().Be(ErrorCodes.NoMeansProvidedToRenewAuthToken);
         }
 
         [Theory]

--- a/src/IO.Ably.Tests.Shared/Rest/RestInitSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestInitSpecs.cs
@@ -8,6 +8,8 @@ namespace IO.Ably.Tests
 {
     public class RestInitSpecs : AblySpecs
     {
+        private const string NoMeansProvidedToRenewAuthToken = "Warning: library initialized with a token literal without any way to renew the token when it expires (no authUrl, authCallback, or key). See https://help.ably.io/error/40171 for help";
+
         [Fact]
         [Trait("spec", "RSA2")]
         public void Init_WithKeyAndNoClientId_SetsAuthMethodToBasic()
@@ -40,9 +42,7 @@ namespace IO.Ably.Tests
             [Trait("spec", "RSA4a1")]
             public void WithTokenButNoWayToRenew_ShouldLogErrorMessageWithError()
             {
-                var testLogger =
-                    new TestLogger(
-                        "Warning: library initialized with a token literal without any way to renew the token when it expires (no authUrl, authCallback, or key). See https://help.ably.io/error/40171 for help");
+                var testLogger = new TestLogger(NoMeansProvidedToRenewAuthToken);
                 var client = new AblyRest(new ClientOptions { Token = "Test", Logger = testLogger });
                 testLogger.MessageSeen.Should().BeTrue();
             }
@@ -51,9 +51,7 @@ namespace IO.Ably.Tests
             [Trait("spec", "RSA4a1")]
             public void WithTokenDetailsButNoWayToRenew_ShouldLogErrorMessageWithError()
             {
-                var testLogger =
-                    new TestLogger(
-                        "Warning: library initialized with a token literal without any way to renew the token when it expires (no authUrl, authCallback, or key). See https://help.ably.io/error/40171 for help");
+                var testLogger = new TestLogger(NoMeansProvidedToRenewAuthToken);
                 var client = new AblyRest(new ClientOptions { TokenDetails = new TokenDetails("test"), Logger = testLogger });
                 testLogger.MessageSeen.Should().BeTrue();
             }


### PR DESCRIPTION
Create the new `ErrorCodes.NoMeansProvidedToRenewAuthToken` to banish magic numbers.