### PR TITLE
Rename the 'VCDiff*' types to fix various warnings

### DIFF
--- a/src/IO.Ably.Shared/MessageEncoders/MessageHandler.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/MessageHandler.cs
@@ -16,7 +16,7 @@ namespace IO.Ably.MessageEncoders
 
         public static List<MessageEncoder> DefaultEncoders { get; } = new List<MessageEncoder>
         {
-            new JsonEncoder(), new Utf8Encoder(), new CipherEncoder(), new VCDiffEncoder(), Base64Encoder,
+            new JsonEncoder(), new Utf8Encoder(), new CipherEncoder(), new VcDiffEncoder(), Base64Encoder,
         };
 
         private static readonly Type[] UnsupportedTypes =

--- a/src/IO.Ably.Shared/MessageEncoders/VCDiffEncoder.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/VCDiffEncoder.cs
@@ -3,7 +3,7 @@ using IO.Ably.DeltaCodec;
 
 namespace IO.Ably.MessageEncoders
 {
-    internal class VCDiffEncoder : MessageEncoder
+    internal class VcDiffEncoder : MessageEncoder
     {
         private const string EncodingNameStr = "vcdiff";
 

--- a/src/IO.Ably.Shared/MessageEncoders/VcdiffErrorInfo.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/VcdiffErrorInfo.cs
@@ -11,12 +11,12 @@ namespace IO.Ably.MessageEncoders
     internal class VcdiffErrorInfo : ErrorInfo
     {
         public VcdiffErrorInfo(string reason)
-            : base(reason, ErrorCodes.VCDiffDecodeError)
+            : base(reason, ErrorCodes.VcDiffDecodeError)
         {
         }
 
         public VcdiffErrorInfo(string reason, Exception innerException)
-            : base(reason, ErrorCodes.VCDiffDecodeError, HttpStatusCode.BadRequest, innerException)
+            : base(reason, ErrorCodes.VcDiffDecodeError, HttpStatusCode.BadRequest, innerException)
         {
         }
     }

--- a/src/IO.Ably.Shared/Realtime/ChannelMessageProcessor.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelMessageProcessor.cs
@@ -94,7 +94,7 @@ namespace IO.Ably.Realtime
                     {
                         var message =
                             "Delta message decode failure. Previous message id does not equal expected message id.";
-                        var reason = new ErrorInfo(message, ErrorCodes.VCDiffDecodeError);
+                        var reason = new ErrorInfo(message, ErrorCodes.VcDiffDecodeError);
                         channel.StartDecodeFailureRecovery(reason);
                         return TaskConstants.BooleanTrue;
                     }

--- a/src/IO.Ably.Shared/Types/ErrorCodes.cs
+++ b/src/IO.Ably.Shared/Types/ErrorCodes.cs
@@ -21,7 +21,7 @@ namespace IO.Ably
         public const int InvalidClientId = 40012;
         public const int InvalidMessageDataOrEncoding = 40013;
         public const int ResourceDisposed = 40014;
-        public const int VCDiffDecodeError = 40018;
+        public const int VcDiffDecodeError = 40018;
         public const int BatchError = 40020;
 
         /* 401 codes */

--- a/src/IO.Ably.Tests.Shared/Realtime/DeltaSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/DeltaSandboxSpecs.cs
@@ -283,7 +283,7 @@ namespace IO.Ably.Tests.Realtime
                 received.Should().NotContain(x => x.Id == "badMessage");
 
                 bool hasVcdiffErrorMessage = testSink.Messages.Any(x => x.StartsWith(LogLevel.Error.ToString())
-                                                                        && x.Contains(ErrorCodes.VCDiffDecodeError
+                                                                        && x.Contains(ErrorCodes.VcDiffDecodeError
                                                                             .ToString()));
 
                 hasVcdiffErrorMessage.Should().BeTrue();

--- a/src/IO.Ably.Tests.Shared/Realtime/DeltaSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/DeltaSpecs.cs
@@ -86,7 +86,7 @@ namespace IO.Ably.Tests.Realtime
             await awaiter.Task;
 
             stateChange.Current.Should().Be(ChannelState.Attaching);
-            stateChange.Error.Code.Should().Be(ErrorCodes.VCDiffDecodeError);
+            stateChange.Error.Code.Should().Be(ErrorCodes.VcDiffDecodeError);
         }
 
         [Fact]


### PR DESCRIPTION
Part of our slow and steady quest to zero warnings...