### PR TITLE
Rework 'switch' statements to be explicit about non-handled 'enum' st…

### DIFF
--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -656,14 +656,23 @@ namespace IO.Ably.Realtime
                             // SetChannelState(ChannelState.Detached, error, protocolMessage);
                             Reattach(error, protocolMessage);
                             break;
+
                         case ChannelState.Attaching:
                             /* RTL13b says we need to become suspended, but continue to retry */
                             Logger.Debug($"Server initiated detach for channel {Name} whilst attaching; moving to suspended");
                             SetChannelState(ChannelState.Suspended, error, protocolMessage);
                             ReattachAfterTimeout(error, protocolMessage);
                             break;
-                        default:
+
+                        case ChannelState.Initialized:
+                        case ChannelState.Detaching:
+                        case ChannelState.Detached:
+                        case ChannelState.Failed:
+                            // Nothing to do here.
                             break;
+
+                        default:
+                            throw new ArgumentOutOfRangeException();
                     }
 
                     Presence.ChannelDetachedOrFailed(error);

--- a/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
+++ b/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
@@ -476,6 +476,7 @@ namespace IO.Ably.Realtime.Workflow
                         {
                             case ConnectionState.Closing:
                                 return SetClosedStateCommand.Create(exception: cmd.Exception).TriggeredBy(cmd);
+
                             case ConnectionState.Connecting:
                                 AblyException ablyException = null;
                                 if (cmd.Exception != null)
@@ -484,6 +485,7 @@ namespace IO.Ably.Realtime.Workflow
                                 }
 
                                 return HandleConnectingErrorCommand.Create(null, ablyException, false).TriggeredBy(cmd);
+
                             case ConnectionState.Connected:
                                 var errorInfo =
                                     GetErrorInfoFromTransportException(cmd.Exception, ErrorInfo.ReasonDisconnected);
@@ -491,8 +493,17 @@ namespace IO.Ably.Realtime.Workflow
                                     errorInfo,
                                     retryInstantly: Connection.ConnectionResumable,
                                     exception: cmd.Exception).TriggeredBy(cmd);
-                            default:
+
+                            case ConnectionState.Initialized:
+                            case ConnectionState.Disconnected:
+                            case ConnectionState.Suspended:
+                            case ConnectionState.Closed:
+                            case ConnectionState.Failed:
+                                // Nothing to do here.
                                 break;
+
+                            default:
+                                throw new ArgumentOutOfRangeException();
                         }
                     }
 


### PR DESCRIPTION
…ates

Generally speaking I think its better to be explicit about non-handled `enum` states in `switch` statements. This better communicates that something hasn't been omitted by mistake.