### PR TITLE
'TestAblyAuth' fix various warnings

### DIFF
--- a/src/IO.Ably.Tests.Shared/AuthTests/TestAblyAuth.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/TestAblyAuth.cs
@@ -5,21 +5,6 @@ namespace IO.Ably.Tests.AuthTests
 {
     internal class TestAblyAuth : AblyAuth
     {
-        public bool RequestTokenCalled { get; set; }
-
-        public TokenParams LastRequestTokenParams { get; set; }
-
-        public AuthOptions LastRequestAuthOptions { get; set; }
-
-        public override Task<TokenDetails> RequestTokenAsync(TokenParams tokenParams, AuthOptions options)
-        {
-            RequestTokenCalled = true;
-            LastRequestTokenParams = tokenParams;
-            LastRequestAuthOptions = options;
-
-            return base.RequestTokenAsync(tokenParams, options);
-        }
-
         public TestAblyAuth(ClientOptions options, AblyRest rest, Func<Task<DateTimeOffset>> serverTimeFunc = null)
             : base(options, rest)
         {
@@ -27,6 +12,21 @@ namespace IO.Ably.Tests.AuthTests
             {
                 ServerTime = serverTimeFunc;
             }
+        }
+
+        public bool RequestTokenCalled { get; private set; }
+
+        public TokenParams LastRequestTokenParams { get; private set; }
+
+        public AuthOptions LastRequestAuthOptions { get; private set; }
+
+        public override Task<TokenDetails> RequestTokenAsync(TokenParams tokenParams = null, AuthOptions options = null)
+        {
+            RequestTokenCalled = true;
+            LastRequestTokenParams = tokenParams;
+            LastRequestAuthOptions = options;
+
+            return base.RequestTokenAsync(tokenParams, options);
         }
 
         // Fetch and returns current Ably server time.


### PR DESCRIPTION
Fixes warnings around base member parameter default values and unnecessary access.

Tidied up the type layout too to confirm to the BCL FDG.