### PR TITLE
Added 'ErrorPolicy' type with 'HandleUnexpected'

### DIFF
--- a/src/IO.Ably.Shared/IO.Ably.Shared.projitems
+++ b/src/IO.Ably.Shared/IO.Ably.Shared.projitems
@@ -169,6 +169,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utils\ActionOnDispose.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\ActionUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\ConnectionChangeAwaiter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utils\ErrorPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\StringUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils\TaskUtils.cs" />
   </ItemGroup>

--- a/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
+++ b/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
@@ -1065,9 +1065,9 @@ namespace IO.Ably.Realtime.Workflow
                     return true;
                 }
             }
-            catch
+            catch (Exception e)
             {
-                // ignored
+                ErrorPolicy.HandleUnexpected(e, Logger);
             }
 
             count = default(int);

--- a/src/IO.Ably.Shared/Transport/MsWebSocketConnection.cs
+++ b/src/IO.Ably.Shared/Transport/MsWebSocketConnection.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
 using IO.Ably.Realtime;
+using IO.Ably.Utils;
 
 namespace IO.Ably.Transport
 {
@@ -386,9 +387,9 @@ namespace IO.Ably.Transport
                     return true;
                 }
             }
-            catch
+            catch (Exception e)
             {
-                // ignored
+                ErrorPolicy.HandleUnexpected(e, Logger);
             }
 
             count = default(int);

--- a/src/IO.Ably.Shared/Utils/ErrorPolicy.cs
+++ b/src/IO.Ably.Shared/Utils/ErrorPolicy.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace IO.Ably.Utils
+{
+    /// <summary>
+    /// Utility type to defining various error policies.
+    /// </summary>
+    internal static class ErrorPolicy
+    {
+        /// <summary>
+        /// Upon receiving an *unexpected* exception where no course of action should be taken defer to this method.
+        /// </summary>
+        /// <param name="e">The unexpected exception.</param>
+        /// <param name="logger">Logger to report to.</param>
+        public static void HandleUnexpected(Exception e, ILogger logger)
+        {
+            string type = e.GetType().Name;
+            string message = $"Caught unexpected '{type}': '{e.Message}'";
+            logger.Debug(message);
+        }
+    }
+}

--- a/src/IO.Ably.Shared/Utils/ErrorPolicy.cs
+++ b/src/IO.Ably.Shared/Utils/ErrorPolicy.cs
@@ -8,7 +8,7 @@ namespace IO.Ably.Utils
     internal static class ErrorPolicy
     {
         /// <summary>
-        /// Upon receiving an *unexpected* exception where no course of action should be taken defer to this method.
+        /// Upon receiving an *unexpected* exception and local policy is unclear, defer to this method.
         /// </summary>
         /// <param name="e">The unexpected exception.</param>
         /// <param name="logger">Logger to report to.</param>

--- a/src/IO.Ably.Shared/Utils/TaskUtils.cs
+++ b/src/IO.Ably.Shared/Utils/TaskUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using IO.Ably.Utils;
 
 namespace IO.Ably
 {
@@ -38,9 +39,9 @@ namespace IO.Ably
                 {
                     t.Wait();
                 }
-                catch
+                catch (Exception e)
                 {
-                    // ignored
+                    ErrorPolicy.HandleUnexpected(e, DefaultLogger.LoggerInstance);
                 }
             };
 

--- a/src/IO.Ably.Tests.Shared/IO.Ably.Tests.Shared.projitems
+++ b/src/IO.Ably.Tests.Shared/IO.Ably.Tests.Shared.projitems
@@ -143,5 +143,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Transport\ConnectionAttemptTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Transport\AttemptFailedStateTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Types\SemanticVersionTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Utils\ErrorPolicyTests.cs" />
   </ItemGroup>
 </Project>

--- a/src/IO.Ably.Tests.Shared/Utils/ErrorPolicyTests.cs
+++ b/src/IO.Ably.Tests.Shared/Utils/ErrorPolicyTests.cs
@@ -1,0 +1,30 @@
+using System;
+using FluentAssertions;
+using IO.Ably.Utils;
+using Xunit;
+
+namespace IO.Ably.Tests.Utils
+{
+    public class ErrorPolicyTests
+    {
+        [Fact]
+        public void HandleUnexpectedLogsCorrectly()
+        {
+            try
+            {
+                throw new ApplicationException("Troll in the Dungeon");
+            }
+            catch (Exception e)
+            {
+                const string expectedMessage = "Caught unexpected 'ApplicationException': 'Troll in the Dungeon'";
+
+                var testLogger = new TestLogger(expectedMessage);
+                ErrorPolicy.HandleUnexpected(e, testLogger);
+
+                testLogger.MessageSeen.Should().BeTrue();
+                testLogger.SeenCount.Should().Be(1);
+                testLogger.FullMessage.Should().Be(expectedMessage);
+            }
+        }
+    }
+}


### PR DESCRIPTION
We need to do something more than just sending unexpected exceptions to /dev/nul so at the very least the current implementation now logs that they occured before carrying on.