### PR TITLE
'ConnectionFailureSpecs' check 'stateChanges' accumulator

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
@@ -110,6 +110,7 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
 
             await taskAwaiter.Task;
 
+            stateChanges.Count().Should().BeGreaterThan(0);
             client.Connection.ErrorReason.Should().NotBeNull();
             client.Connection.ErrorReason.Code.Should().Be(ErrorCodes.TokenError);
         }


### PR DESCRIPTION
We go to the trouble of creating and populating the `stateChanges` accumulator so we can at least check it's not empty at the end of a test run.