### PR TITLE
'ConnectionFailedSpecs' use 'Count' property rather than extension me…

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
@@ -110,7 +110,7 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
 
             await taskAwaiter.Task;
 
-            stateChanges.Count().Should().BeGreaterThan(0);
+            stateChanges.Count.Should().BeGreaterThan(0);
             client.Connection.ErrorReason.Should().NotBeNull();
             client.Connection.ErrorReason.Code.Should().Be(ErrorCodes.TokenError);
         }


### PR DESCRIPTION
We don't need to use `LINQ` here, the collection maintains its own `Count` property.