### PR TITLE
'SetInitStateCommand' refactor to remove unused property

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Workflows/RealtimeCommands.cs
+++ b/src/IO.Ably.Shared/Realtime/Workflows/RealtimeCommands.cs
@@ -99,16 +99,13 @@ namespace IO.Ably.Realtime.Workflow
         protected override string ExplainData() => string.Empty;
     }
 
-    internal class SetInitStateCommand : RealtimeCommand
+    internal class ForceStateInitializationCommand : RealtimeCommand
     {
-        public string Recover { get; }
-
-        private SetInitStateCommand(string recover)
+        private ForceStateInitializationCommand()
         {
-            Recover = recover;
         }
 
-        public static SetInitStateCommand Create(string recover) => new SetInitStateCommand(recover);
+        public static ForceStateInitializationCommand Create() => new ForceStateInitializationCommand();
 
         protected override string ExplainData()
         {

--- a/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
+++ b/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
@@ -315,7 +315,7 @@ namespace IO.Ably.Realtime.Workflow
                         return EmptyCommand.Instance;
                     }
 
-                case SetInitStateCommand _:
+                case ForceStateInitializationCommand _:
                 case SetConnectedStateCommand _:
                 case SetConnectingStateCommand _:
                 case SetFailedStateCommand _:
@@ -716,7 +716,7 @@ namespace IO.Ably.Realtime.Workflow
             {
                 switch (command)
                 {
-                    case SetInitStateCommand _:
+                    case ForceStateInitializationCommand _:
                         var initState = new ConnectionInitializedState(ConnectionManager, Logger);
                         SetState(initState);
                         break;

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -1657,7 +1657,7 @@ namespace IO.Ably.Tests.Realtime
                 [Trait("spec", "RTP16b")]
                 public async Task ConnectionStateCondition_WhenConnectionIsInitialized_MessageArePublishedWhenConnectionBecomesConnected(Protocol protocol)
                 {
-                    /* tests initialized and connecting states */
+                    // Tests initialized and connecting states
 
                     var client = await GetRealtimeClient(protocol, (options, settings) => { options.ClientId = "RTP16b"; });
                     var channel = GetRandomChannel(client, "RTP16a");
@@ -1665,8 +1665,7 @@ namespace IO.Ably.Tests.Realtime
                     List<int> queueCounts = new List<int>();
                     Presence.QueuedPresenceMessage[] presenceMessages = null;
 
-                    // force Initialized state
-                    client.Workflow.QueueCommand(SetInitStateCommand.Create(null));
+                    client.Workflow.QueueCommand(ForceStateInitializationCommand.Create());
                     await client.WaitForState(ConnectionState.Initialized);
 
                     await WaitForMultiple(2, partialDone =>


### PR DESCRIPTION
Rename the `SetInitStateCommand` to be `ForceStateInitializationCommand` and remove the unused property.