### PR TITLE
Push/preserve channel order

### DIFF
--- a/src/IO.Ably.Shared/Rest/RestChannels.cs
+++ b/src/IO.Ably.Shared/Rest/RestChannels.cs
@@ -13,6 +13,9 @@ namespace IO.Ably.Rest
         private readonly ConcurrentDictionary<string, RestChannel> _channels =
             new ConcurrentDictionary<string, RestChannel>();
 
+        private readonly List<IRestChannel> _orderedChannels = new List<IRestChannel>();
+        private object _orderedListLock = new object();
+
         private readonly AblyRest _ablyRest;
 
         internal RestChannels(AblyRest restClient)
@@ -41,6 +44,7 @@ namespace IO.Ably.Rest
 
                     return realtimeChannel;
                 });
+                AddToOrderedList(result);
             }
             else
             {
@@ -59,7 +63,9 @@ namespace IO.Ably.Rest
         /// <inheritdoc/>
         public bool Release(string name)
         {
-            return _channels.TryRemove(name, out _);
+            var result = _channels.TryRemove(name, out var channel);
+            RemoveFromOrderedList(channel);
+            return result;
         }
 
         /// <inheritdoc/>
@@ -81,13 +87,44 @@ namespace IO.Ably.Rest
         /// <inheritdoc/>
         IEnumerator<IRestChannel> IEnumerable<IRestChannel>.GetEnumerator()
         {
-            return _channels.ToArray().Select(x => x.Value).GetEnumerator();
+            lock (_orderedChannels)
+            {
+                return _orderedChannels.ToList().GetEnumerator();
+            }
         }
 
         /// <inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return _channels.ToArray().Select(x => x.Value).GetEnumerator();
+            lock (_orderedChannels)
+            {
+                return _orderedChannels.ToList().GetEnumerator();
+            }
+        }
+
+        private void AddToOrderedList(RestChannel channel)
+        {
+            if (_orderedChannels.Contains(channel) == false)
+            {
+                lock (_orderedListLock)
+                {
+                    if (_orderedChannels.Contains(channel) == false)
+                    {
+                        _orderedChannels.Add(channel);
+                    }
+                }
+            }
+        }
+
+        private void RemoveFromOrderedList(RestChannel channel)
+        {
+            lock (_orderedListLock)
+            {
+                if (_orderedChannels.Contains(channel))
+                {
+                    _orderedChannels.Remove(channel);
+                }
+            }
         }
     }
 }

--- a/src/IO.Ably.Shared/Rest/RestChannels.cs
+++ b/src/IO.Ably.Shared/Rest/RestChannels.cs
@@ -10,7 +10,8 @@ namespace IO.Ably.Rest
     /// </summary>
     public class RestChannels : IChannels<IRestChannel>
     {
-        private readonly ConcurrentDictionary<string, RestChannel> _channels = new ConcurrentDictionary<string, RestChannel>();
+        private readonly ConcurrentDictionary<string, RestChannel> _channels =
+            new ConcurrentDictionary<string, RestChannel>();
 
         private readonly AblyRest _ablyRest;
 
@@ -33,12 +34,9 @@ namespace IO.Ably.Rest
                 var channel = new RestChannel(_ablyRest, name, options);
                 result = _channels.AddOrUpdate(name, channel, (s, realtimeChannel) =>
                 {
-                    if (options != null)
+                    if (options != null && realtimeChannel != null)
                     {
-                        if (result != null)
-                        {
-                            result.Options = options;
-                        }
+                        realtimeChannel.Options = options;
                     }
 
                     return realtimeChannel;

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelsSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelsSpecs.cs
@@ -231,6 +231,23 @@ namespace IO.Ably.Tests.Realtime
         }
 
         [Fact]
+        public async Task AllowEnumerationAndReturnSameOrder()
+        {
+            // Arrange
+            var client = GetClientWithFakeTransport();
+
+            var channel1 = client.Channels.Get("test");
+            var channel2 = client.Channels.Get("test1");
+            var channel4 = client.Channels.Get("test3");
+            var channel5 = client.Channels.Get("test4");
+            var channel6 = client.Channels.Get("test5");
+            var channel7 = client.Channels.Get("test7");
+
+            client.Channels.Should().HaveCount(6);
+            client.Channels.Should().BeEquivalentTo(channel1, channel2, channel4, channel5, channel6, channel7);
+        }
+
+        [Fact]
         [Trait("spec", "RTS4a")]
         public async Task AllowsGenericEnumeration()
         {

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
@@ -15,36 +15,55 @@ namespace IO.Ably.Tests.Rest
 {
     public class ChannelSpecs : MockHttpRestSpecs
     {
-        [Fact]
-        [Trait("spec", "RSN1")]
-        public void ChannelsIsACollectionOfChannelObjects()
+        public class General : ChannelSpecs
         {
-            var client = GetRestClient();
-            client.Channels.Should().BeAssignableTo<IEnumerable<IRestChannel>>();
+            [Fact]
+            [Trait("spec", "RSN1")]
+            public void ChannelsIsACollectionOfChannelObjects()
+            {
+                var client = GetRestClient();
+                client.Channels.Should().BeAssignableTo<IEnumerable<IRestChannel>>();
+            }
+
+            [Fact]
+            [Trait("spec", "RSN2")]
+            public void ShouldBeAbleToIterateThroughExistingChannels()
+            {
+                var client = GetRestClient();
+                var channel1 = client.Channels.Get("test");
+                var channel2 = client.Channels.Get("test1");
+
+                client.Channels.Should().HaveCount(2);
+                client.Channels.Should().BeEquivalentTo(channel1, channel2);
+            }
+
+            [Fact]
+            [Trait("spec", "RSN2")]
+            public void ShouldBeAbleToCheckIsAChannelExists()
+            {
+                var client = GetRestClient();
+                var channel1 = client.Channels.Get("test");
+                var channel2 = client.Channels.Get("test1");
+
+                client.Channels.Any(x => x.Name == "test").Should().BeTrue();
+            }
+
+            [Fact]
+            [Trait("spec", "RSN4a")]
+            public void ShouldBeAbleToReleaseAChannelSoItIsRemovedFromTheChannelsCollection()
+            {
+                var client = GetRestClient();
+                var channel = client.Channels.Get("first");
+                client.Channels.Should().Contain(x => x.Name == "first");
+                client.Channels.Release("first");
+                client.Channels.Should().BeEmpty();
+            }
+
+            public General(ITestOutputHelper output) : base(output)
+            {
+            }
         }
 
-        [Fact]
-        [Trait("spec", "RSN2")]
-        public void ShouldBeAbleToIterateThroughExistingChannels()
-        {
-            var client = GetRestClient();
-            var channel1 = client.Channels.Get("test");
-            var channel2 = client.Channels.Get("test1");
-
-            client.Channels.Should().HaveCount(2);
-            client.Channels.Should().BeEquivalentTo(channel1, channel2);
-        }
-
-        [Fact]
-        [Trait("spec", "RSN2")]
-        public void ShouldBeAbleToCheckIsAChannelExists()
-        {
-            var client = GetRestClient();
-            var channel1 = client.Channels.Get("test");
-            var channel2 = client.Channels.Get("test1");
-
-            client.Channels.Any(x => x.Name == "test").Should().BeTrue();
-        }
 
         [Trait("spec", "RSN3")]
         public class GettingAChannel : ChannelSpecs
@@ -93,17 +112,6 @@ namespace IO.Ably.Tests.Rest
                 var secondTime = _client.Channels.Get("test", newOptions);
                 ((RestChannel)secondTime).Options.Should().BeEquivalentTo(newOptions);
             }
-        }
-
-        [Fact]
-        [Trait("spec", "RSN4a")]
-        public void ShouldBeAbleToReleaseAChannelSoItIsRemovedFromTheChannelsCollection()
-        {
-            var client = GetRestClient();
-            var channel = client.Channels.Get("first");
-            client.Channels.Should().Contain(x => x.Name == "first");
-            client.Channels.Release("first");
-            client.Channels.Should().BeEmpty();
         }
 
         public class ChannelPublish : ChannelSpecs

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
@@ -32,9 +32,14 @@ namespace IO.Ably.Tests.Rest
                 var client = GetRestClient();
                 var channel1 = client.Channels.Get("test");
                 var channel2 = client.Channels.Get("test1");
+                _ = client.Channels.Get("test2");
+                var channel4 = client.Channels.Get("test3");
+                var channel5 = client.Channels.Get("test4");
+                var channel6 = client.Channels.Get("test5");
+                client.Channels.Release("test2");
+                var channel7 = client.Channels.Get("test7");
 
-                client.Channels.Should().HaveCount(2);
-                client.Channels.Should().BeEquivalentTo(channel1, channel2);
+                client.Channels.Should().BeEquivalentTo(channel1, channel2, channel4, channel5, channel6, channel7);
             }
 
             [Fact]

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
@@ -43,6 +43,19 @@ namespace IO.Ably.Tests.Rest
             }
 
             [Fact]
+            public async Task ShouldUpdateOptionsWhenTwoThreadsTryToCreateTheSameChannelWithDifferentOptions()
+            {
+                var client = GetRestClient();
+                var options = new ChannelOptions(encrypted: true);
+                var task1 = Task.Run(() => client.Channels.Get("test"));
+                var task2 = Task.Run(() => client.Channels.Get("test", options));
+
+                await Task.WhenAll(task1, task2);
+                var channel2 = (RestChannel)client.Channels.Get("test");
+                channel2.Options.Should().BeSameAs(options);
+            }
+
+            [Fact]
             [Trait("spec", "RSN2")]
             public void ShouldBeAbleToCheckIsAChannelExists()
             {


### PR DESCRIPTION
This came into ligth because when I added the Push channel property to both Rest and Realtime channels the order of channels that came out was different than what we had before. 