### PR TITLE
'ChannelSpecs' Fix warnings

### DIFF
--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
@@ -77,11 +77,11 @@ namespace IO.Ably.Tests.Rest
                 client.Channels.Should().BeEmpty();
             }
 
-            public General(ITestOutputHelper output) : base(output)
+            public General(ITestOutputHelper output)
+                : base(output)
             {
             }
         }
-
 
         [Trait("spec", "RSN3")]
         public class GettingAChannel : ChannelSpecs


### PR DESCRIPTION
Fixes:

- Put constructor initializers on their own line
- Code should not contain multiple blank lines in a row