### PR TITLE
'PushChannelTests' Fix code layout

### DIFF
--- a/src/IO.Ably.Tests.Shared/Push/PushChannelTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/PushChannelTests.cs
@@ -342,7 +342,6 @@ namespace IO.Ably.Tests.Push
                 subscribeFunc.Should().ThrowAsync<AblyException>().WithMessage("Cannot Unsubscribe client from channel*");
             }
 
-
             [Fact]
             [Trait("spec", "RSH7d")]
             [Trait("spec", "RSH7d2")]


### PR DESCRIPTION
Fixes warning about code not containing multiple blank lines in a row.