### PR TITLE
Push/localdevice init

### DIFF
--- a/src/IO.Ably.Shared/AblyRealtime.cs
+++ b/src/IO.Ably.Shared/AblyRealtime.cs
@@ -54,7 +54,7 @@ namespace IO.Ably
             Logger = options.Logger;
             CaptureSynchronizationContext(options);
             RestClient = createRestFunc != null ? createRestFunc.Invoke(options, mobileDevice) : new AblyRest(options, mobileDevice);
-            Push = new PushRealtime(RestClient, mobileDevice, Logger);
+            Push = new PushRealtime(RestClient, Logger);
 
             Connection = new Connection(this, options.NowFunc, options.Logger);
             Connection.Initialise();

--- a/src/IO.Ably.Shared/Push/ActivationStateMachine.States.cs
+++ b/src/IO.Ably.Shared/Push/ActivationStateMachine.States.cs
@@ -71,19 +71,13 @@ namespace IO.Ably.Push
                             return (nextState, ToNextEventFunc(Machine.ValidateRegistration));
                         }
 
-                        if (localDevice.IsCreated == false)
+                        if (localDevice.RegistrationToken == null)
                         {
-                            var newLocalDevice = LocalDevice.Create(Machine.ClientId, Machine._mobileDevice);
-                            Machine.PersistLocalDevice(newLocalDevice);
-                            Machine.LocalDevice = newLocalDevice;
                             Machine.GetRegistrationToken();
-
                             return (new WaitingForPushDeviceDetails(Machine), EmptyNextEventFunc);
                         }
 
-                        var nextEvent = localDevice.RegistrationToken != null ? new GotPushDeviceDetails() : null;
-
-                        return (new WaitingForPushDeviceDetails(Machine), ToNextEventFunc(nextEvent));
+                        return (new WaitingForPushDeviceDetails(Machine), ToNextEventFunc(new GotPushDeviceDetails()));
                     case GotPushDeviceDetails _:
                         return (this, EmptyNextEventFunc);
                     default:
@@ -216,7 +210,7 @@ namespace IO.Ably.Push
                         var localDevice = Machine.LocalDevice;
                         return (new WaitingForDeregistration(Machine, this), ToNextEventFunc(() => Deregister(localDevice.Id)));
                     case GotPushDeviceDetails _:
-                        var device = Machine.EnsureLocalDeviceIsLoaded();
+                        var device = Machine.LocalDevice;
 
                         return (new WaitingForRegistrationSync(Machine, @event), ToNextEventFunc(() => UpdateRegistration(device)));
                     default:

--- a/src/IO.Ably.Shared/Push/PushRealtime.cs
+++ b/src/IO.Ably.Shared/Push/PushRealtime.cs
@@ -8,12 +8,12 @@
         private readonly AblyRest _restClient;
         private readonly ActivationStateMachine _stateMachine;
 
-        internal PushRealtime(AblyRest restClient, IMobileDevice mobileDevice, ILogger logger)
+        internal PushRealtime(AblyRest restClient, ILogger logger)
         {
             _restClient = restClient;
-            if (mobileDevice != null)
+            if (_restClient.MobileDevice != null)
             {
-                _stateMachine = new ActivationStateMachine(restClient, mobileDevice, logger);
+                _stateMachine = new ActivationStateMachine(restClient, logger);
             }
         }
 

--- a/src/IO.Ably.Tests.Shared/Push/ActivationStateMachineTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/ActivationStateMachineTests.cs
@@ -19,39 +19,6 @@ namespace IO.Ably.Tests.Push
         public class GeneralTests : MockHttpRestSpecs
         {
             [Fact]
-            public async Task LoadPersistedLocalDevice_ShouldLoadAllSavedProperties()
-            {
-                var mobileDevice = new FakeMobileDevice();
-                void SetSetting(string key, string value) => mobileDevice.SetPreference(key, value, PersistKeys.Device.SharedName);
-
-                var stateMachine = new ActivationStateMachine(GetRestClient(), mobileDevice);
-
-                const string deviceId = "deviceId";
-                SetSetting(PersistKeys.Device.DeviceId, deviceId);
-                const string clientId = "clientId";
-                SetSetting(PersistKeys.Device.ClientId, clientId);
-                const string deviceSecret = "secret";
-                SetSetting(PersistKeys.Device.DeviceSecret, deviceSecret);
-                const string identityToken = "token";
-                SetSetting(PersistKeys.Device.DeviceToken, identityToken);
-                const string tokenType = "fcm";
-                SetSetting(PersistKeys.Device.TokenType, tokenType);
-                const string token = "registration_token";
-                SetSetting(PersistKeys.Device.Token, token);
-
-                var localDevice = stateMachine.LoadPersistedLocalDevice();
-                localDevice.Platform.Should().Be(mobileDevice.DevicePlatform);
-                localDevice.FormFactor.Should().Be(mobileDevice.FormFactor);
-
-                localDevice.Id.Should().Be(deviceId);
-                localDevice.ClientId.Should().Be(clientId);
-                localDevice.DeviceSecret.Should().Be(deviceSecret);
-                localDevice.DeviceIdentityToken.Should().Be(identityToken);
-                localDevice.RegistrationToken.Type.Should().Be(tokenType);
-                localDevice.RegistrationToken.Token.Should().Be(token);
-            }
-
-            [Fact]
             [Trait("spec", "RSH4")]
             public async Task HandleEvent_WhenStateCannotHandleEvent_ShouldPutEventOnAQueue()
             {

--- a/src/IO.Ably.Tests.Shared/Push/ActivationStateMachineTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/ActivationStateMachineTests.cs
@@ -1232,7 +1232,7 @@ namespace IO.Ably.Tests.Push
         }
 
         [Trait("spec", "RSH3g")]
-        public class WaitingForDeregistrationTests : MockHttpRestSpecs
+        public class WaitingForDeregistrationTests : MockHttpRestSpecs, IDisposable
         {
             [Fact]
             [Trait("spec", "RSH3g1")]
@@ -1268,6 +1268,7 @@ namespace IO.Ably.Tests.Push
             {
                 var (state, machine) = GetStateAndStateMachine(stateMachine => new ActivationStateMachine.NotActivated(stateMachine));
                 var machineLocalDevice = machine.LocalDevice;
+
                 MobileDevice.Settings.Should().NotBeEmpty();
                 var (nextState, nextEventFunc) = await state.Transition(new ActivationStateMachine.Deregistered());
 
@@ -1344,9 +1345,17 @@ namespace IO.Ably.Tests.Push
                 return (new ActivationStateMachine.WaitingForDeregistration(stateMachine, getPreviousState(stateMachine)), stateMachine);
             }
 
+            private void ClearLocalDeviceStaticInstance() => LocalDevice.Instance = null;
+
             public FakeMobileDevice MobileDevice { get; set; }
 
-            public AblyRest RestClient { get; set; }
+            public AblyRest RestClient { get; }
+
+            public void Dispose()
+            {
+                MobileDevice = null;
+                ClearLocalDeviceStaticInstance();
+            }
         }
     }
 }

--- a/src/IO.Ably.Tests.Shared/Push/ActivationStateMachineTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/ActivationStateMachineTests.cs
@@ -234,7 +234,7 @@ namespace IO.Ably.Tests.Push
             }
         }
 
-        public class NotActivatedStateTests : MockHttpRestSpecs
+        public class NotActivatedStateTests : MockHttpRestSpecs, IDisposable
         {
             [Fact]
             [Trait("spec", "RSH3a1")]
@@ -465,7 +465,13 @@ namespace IO.Ably.Tests.Push
 
             public AblyRest RestClient { get; }
 
-            public FakeMobileDevice MobileDevice { get; }
+            public FakeMobileDevice MobileDevice { get; set; }
+
+            public void Dispose()
+            {
+                MobileDevice = null;
+                ClearLocalDeviceStaticInstance();
+            }
         }
 
         [Trait("spec", "RSH3b")]
@@ -1345,8 +1351,6 @@ namespace IO.Ably.Tests.Push
                 return (new ActivationStateMachine.WaitingForDeregistration(stateMachine, getPreviousState(stateMachine)), stateMachine);
             }
 
-            private void ClearLocalDeviceStaticInstance() => LocalDevice.Instance = null;
-
             public FakeMobileDevice MobileDevice { get; set; }
 
             public AblyRest RestClient { get; }
@@ -1357,5 +1361,7 @@ namespace IO.Ably.Tests.Push
                 ClearLocalDeviceStaticInstance();
             }
         }
+
+        private static void ClearLocalDeviceStaticInstance() => LocalDevice.Instance = null;
     }
 }

--- a/src/IO.Ably.Tests.Shared/Push/LocalDeviceTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/LocalDeviceTests.cs
@@ -39,6 +39,41 @@ namespace IO.Ably.Tests.Push
 
             device.IsCreated.Should().Be(result);
         }
+
+        [Fact]
+        public async Task LoadPersistedLocalDevice_ShouldLoadAllSavedProperties()
+        {
+            var mobileDevice = new FakeMobileDevice();
+            void SetSetting(string key, string value) => mobileDevice.SetPreference(key, value, PersistKeys.Device.SharedName);
+
+            var stateMachine = new ActivationStateMachine(GetRestClient(mobileDevice: mobileDevice));
+
+            const string deviceId = "deviceId";
+            SetSetting(PersistKeys.Device.DeviceId, deviceId);
+            const string clientId = "clientId";
+            SetSetting(PersistKeys.Device.ClientId, clientId);
+            const string deviceSecret = "secret";
+            SetSetting(PersistKeys.Device.DeviceSecret, deviceSecret);
+            const string identityToken = "token";
+            SetSetting(PersistKeys.Device.DeviceToken, identityToken);
+            const string tokenType = "fcm";
+            SetSetting(PersistKeys.Device.TokenType, tokenType);
+            const string token = "registration_token";
+            SetSetting(PersistKeys.Device.Token, token);
+
+            var loadResult = LocalDevice.LoadPersistedLocalDevice(mobileDevice, out var localDevice);
+            loadResult.Should().BeTrue();
+            localDevice.Platform.Should().Be(mobileDevice.DevicePlatform);
+            localDevice.FormFactor.Should().Be(mobileDevice.FormFactor);
+
+            localDevice.Id.Should().Be(deviceId);
+            localDevice.ClientId.Should().Be(clientId);
+            localDevice.DeviceSecret.Should().Be(deviceSecret);
+            localDevice.DeviceIdentityToken.Should().Be(identityToken);
+            localDevice.RegistrationToken.Type.Should().Be(tokenType);
+            localDevice.RegistrationToken.Token.Should().Be(token);
+        }
+
         [Fact]
         public async Task RestClient_LocalDevice_ShouldReturnSameInstanceForMultipleClients()
         {

--- a/src/IO.Ably.Tests.Shared/Push/LocalDeviceTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/LocalDeviceTests.cs
@@ -1,11 +1,13 @@
 ﻿using Xunit;
 using System.Linq;
+using System.Threading.Tasks;
 using FluentAssertions;
 using IO.Ably.Push;
+using Xunit.Abstractions;
 
 namespace IO.Ably.Tests.Push
 {
-    public class LocalDeviceTests
+    public class LocalDeviceTests : MockHttpRestSpecs
     {
         [Fact]
         [Trait("spec", "RSH3a2b")]
@@ -36,6 +38,20 @@ namespace IO.Ably.Tests.Push
             };
 
             device.IsCreated.Should().Be(result);
+        }
+        [Fact]
+        public async Task RestClient_LocalDevice_ShouldReturnSameInstanceForMultipleClients()
+        {
+            var mobileDevice = new FakeMobileDevice();
+            var client1 = GetRestClient(mobileDevice: mobileDevice);
+            var client2 = GetRestClient(mobileDevice: mobileDevice);
+
+            client1.Device.Should().BeSameAs(client2.Device);
+        }
+
+        public LocalDeviceTests(ITestOutputHelper output)
+            : base(output)
+        {
         }
     }
 }


### PR DESCRIPTION
The goal of this PR is to make sure we have 1 instance of LocalDevice no matter how many instances of the library we have. 
I had to refactor LocalDevice.cs and move some of the logic from ActivationStateMachine to there. 
I've also updated how we pass MobileDevice (interface that hides the actual physical device)