### PR TITLE
'RealtimeChannel' replace lambda with local function

### DIFF
--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -430,8 +430,9 @@ namespace IO.Ably.Realtime
 
         public async Task<Result> SetOptionsAsync(ChannelOptions options)
         {
-            Action<Action<bool, ErrorInfo>> setOptions = callback => SetOptions(options, callback);
-            return await TaskWrapper.Wrap(setOptions);
+            void Action(Action<bool, ErrorInfo> callback) => SetOptions(options, callback);
+
+            return await TaskWrapper.Wrap(Action);
         }
 
         public void Subscribe(Action<Message> handler)


### PR DESCRIPTION
Unlike lambdas or delegates, local functions do not cause additional overhead because they are essentially regular methods. For example, instantiating and invoking a delegate requires additional members being generated by compiler and causing some memory overhead. Another benefit of local functions is their support for all the syntax elements allowed in regular methods.