### PR TITLE
'RealtimeChannels' replace lambda with local function

### DIFF
--- a/src/IO.Ably.Shared/Realtime/RealtimeChannels.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannels.cs
@@ -108,8 +108,7 @@ namespace IO.Ably.Realtime
                 return false;
             }
 
-            EventHandler<ChannelStateChange> eventHandler = null;
-            eventHandler = (s, args) =>
+            void EventHandler(object s, ChannelStateChange args)
             {
                 if (args.Current == ChannelState.Detached || args.Current == ChannelState.Failed)
                 {
@@ -119,7 +118,7 @@ namespace IO.Ably.Realtime
                     }
 
                     var detachedChannel = (RealtimeChannel)s;
-                    detachedChannel.InternalStateChanged -= eventHandler;
+                    detachedChannel.InternalStateChanged -= EventHandler;
 
                     if (Channels.TryRemove(name, out RealtimeChannel removedChannel))
                     {
@@ -134,9 +133,9 @@ namespace IO.Ably.Realtime
                         Logger.Debug($"Waiting to remove Channel #{name}. State {args.Current}");
                     }
                 }
-            };
+            }
 
-            channel.InternalStateChanged += eventHandler;
+            channel.InternalStateChanged += EventHandler;
             channel.Detach();
             return true;
         }


### PR DESCRIPTION
Unlike lambdas or delegates, local functions do not cause additional overhead because they are essentially regular methods. For example, instantiating and invoking a delegate requires additional members being generated by compiler and causing some memory overhead. Another benefit of local functions is their support for all the syntax elements allowed in regular methods.