### PR TITLE
'ChannelAwaiter' replace lambda with local function

### DIFF
--- a/src/IO.Ably.Shared/Realtime/ChannelAwaiter.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelAwaiter.cs
@@ -81,9 +81,9 @@ namespace IO.Ably.Realtime
 
         public async Task<Result<bool>> WaitAsync(TimeSpan? timeout = null)
         {
-            Func<Action<bool, ErrorInfo>, bool> func = action => StartWait(action, timeout ?? TimeSpan.FromSeconds(2));
+            bool Func(Action<bool, ErrorInfo> action) => StartWait(action, timeout ?? TimeSpan.FromSeconds(2));
 
-            return await TaskWrapper.Wrap(func);
+            return await TaskWrapper.Wrap((Func<Action<bool, ErrorInfo>, bool>)Func);
         }
 
         public bool StartWait(Action<bool, ErrorInfo> callback, TimeSpan timeout, bool restart = false)


### PR DESCRIPTION
Unlike lambdas or delegates, local functions do not cause additional overhead because they are essentially regular methods. For example, instantiating and invoking a delegate requires additional members being generated by compiler and causing some memory overhead. Another benefit of local functions is their support for all the syntax elements allowed in regular methods.