### PR TITLE
'ConnectionFailuresOnceConnectedSpecs' replace lambda with local function

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
@@ -217,13 +217,11 @@ namespace IO.Ably.Tests.Realtime
             var client = await SetupConnectedClient();
 
             List<bool> callbackResults = new List<bool>();
-            Action<bool, ErrorInfo> callback = (b, info) =>
-            {
-                callbackResults.Add(b);
-            };
 
-            client.ConnectionManager.Send(new ProtocolMessage(ProtocolMessage.MessageAction.Message), callback);
-            client.ConnectionManager.Send(new ProtocolMessage(ProtocolMessage.MessageAction.Message), callback);
+            void Callback(bool b, ErrorInfo info) => callbackResults.Add(b);
+
+            client.ConnectionManager.Send(new ProtocolMessage(ProtocolMessage.MessageAction.Message), Callback);
+            client.ConnectionManager.Send(new ProtocolMessage(ProtocolMessage.MessageAction.Message), Callback);
 
             await client.ProcessCommands();
 


### PR DESCRIPTION
Unlike lambdas or delegates, local functions do not cause additional overhead because they are essentially regular methods. For example, instantiating and invoking a delegate requires additional members being generated by compiler and causing some memory overhead. Another benefit of local functions is their support for all the syntax elements allowed in regular methods.