### PR TITLE
'ConnectionFailureSpecs' replace lambda with local function

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
@@ -250,8 +250,7 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
         [Trait("spec", "RTN14e")]
         public async Task WhenInSuspendedState_ShouldTryAndReconnectAfterSuspendRetryTimeoutIsReached()
         {
-            Func<DateTimeOffset> nowFunc = () => DateTimeOffset.UtcNow;
-            DateTimeOffset NowWrapperFunc() => nowFunc();
+            DateTimeOffset Func() => DateTimeOffset.UtcNow;
 
             FakeTransportFactory.InitialiseFakeTransport =
                 transport => transport.OnConnectChangeStateToConnected = false;
@@ -262,7 +261,7 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
                 opts.AutoConnect = false;
                 opts.DisconnectedRetryTimeout = TimeSpan.FromMilliseconds(10);
                 opts.SuspendedRetryTimeout = TimeSpan.FromMilliseconds(1000);
-                opts.NowFunc = NowWrapperFunc;
+                opts.NowFunc = Func;
             });
 
             client.ExecuteCommand(SetSuspendedStateCommand.Create(ErrorInfo.ReasonSuspended));


### PR DESCRIPTION
Unlike lambdas or delegates, local functions do not cause additional overhead because they are essentially regular methods. For example, instantiating and invoking a delegate requires additional members being generated by compiler and causing some memory overhead. Another benefit of local functions is their support for all the syntax elements allowed in regular methods.