### PR TITLE
'MsWebSocketTransport' explicitly check for null socket.

### DIFF
--- a/src/IO.Ably.Shared/Transport/MsWebSocketTransport.cs
+++ b/src/IO.Ably.Shared/Transport/MsWebSocketTransport.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -136,16 +137,28 @@ namespace IO.Ably.Transport
                     Logger.Debug("Socket connected");
                 }
 
-                await _socket.Receive(HandleMessageReceived);
+                if (_socket == null)
+                {
+                    HandleError(new NullReferenceException($"'{nameof(_socket)}' is null"));
+                }
+                else
+                {
+                    await _socket.Receive(HandleMessageReceived);
+                }
             }
             catch (Exception ex)
             {
+                HandleError(ex);
+            }
+
+            void HandleError(Exception e)
+            {
                 if (Logger.IsDebug)
                 {
-                    Logger.Debug("Socket couldn't connect. Error: " + ex.Message);
+                    Logger.Debug($"Socket couldn't connect. Error: {e.Message}");
                 }
 
-                Listener?.OnTransportEvent(Id, TransportState.Closed, ex);
+                Listener?.OnTransportEvent(Id, TransportState.Closed, e);
             }
         }
 


### PR DESCRIPTION
Rather than let the runtime throw a `NullReferenceException` I am explicitly checking and delegating to the error handler.

This is an interim step. We have many such `NullReferenceExceptions` being thrown by the runtime during execution. The source of each needs to be investigated to see if it is a latent bug or has somehow become part of our Happy Path through the logic.