### PR TITLE
'FakeConnectionContext' missing call to 'Initialise'

### DIFF
--- a/src/IO.Ably.Tests.Shared/Infrastructure/FakeConnectionContext.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/FakeConnectionContext.cs
@@ -14,6 +14,7 @@ namespace IO.Ably.Tests
         public FakeConnectionContext()
         {
             Connection = new Connection(null, TestHelpers.NowFunc());
+            Connection.Initialise();
         }
 
         public ConnectionStateBase LastSetState { get; set; }


### PR DESCRIPTION
The missing call to `Connection.Initialise` was causing `NullReferenceExceptions` to be thrown during test execution.

This corresponds to [Issue 951](https://github.com/ably/ably-dotnet/issues/951) .