### PR TITLE
'Connection' fix possible 'NullReferenceException' when invoking external handlers

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Connection.cs
+++ b/src/IO.Ably.Shared/Realtime/Connection.cs
@@ -288,7 +288,7 @@ namespace IO.Ably.Realtime
                         Emit(stateChange.Event, stateChange);
                         try
                         {
-                            externalHandlers(this, stateChange);
+                            externalHandlers?.Invoke(this, stateChange);
                         }
                         catch (Exception ex)
                         {


### PR DESCRIPTION
It is possible for the `Connection` to be in a state where it attempts to invoke an empty (`null`) chain of external handlers.

This corresponds to [Issue 950](https://github.com/ably/ably-dotnet/issues/950)
