### PR TITLE
'ActivationStateMachine' fix 'NullReferenceException'

### DIFF
--- a/src/IO.Ably.Shared/Push/ActivationStateMachine.cs
+++ b/src/IO.Ably.Shared/Push/ActivationStateMachine.cs
@@ -43,6 +43,7 @@ namespace IO.Ably.Push
             _restClient = restClient;
             ClientId = _restClient.Auth.ClientId;
             _logger = logger ?? restClient.Logger;
+            _currentState = new NotActivated(this);
         }
 
         public LocalDevice LocalDevice


### PR DESCRIPTION
When executing the tests under the debugger it was observed that `ActivationStateMachine.HandleEvent` was throwing a `NullReferenceException` when trying to access its `CurrentState` property.