### PR TITLE
Fix 'local variable is never used' warnings

### DIFF
--- a/src/IO.Ably.Tests.Shared/AuthTests/RequestTokenSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/RequestTokenSpecs.cs
@@ -488,7 +488,7 @@ namespace IO.Ably.Tests.AuthTests
 
             var tokenParams = new TokenParams { Capability = new Capability() };
 
-            var ex = await Assert.ThrowsAsync<AblyException>(() => rest.Auth.RequestTokenAsync(tokenParams, options));
+            _ = await Assert.ThrowsAsync<AblyException>(() => rest.Auth.RequestTokenAsync(tokenParams, options));
         }
 
         [Fact]

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -1618,7 +1618,7 @@ namespace IO.Ably.Tests.Realtime
                 var channel = client.Channels.Get("history");
 
 #pragma warning disable 618
-                var ex = await Assert.ThrowsAsync<AblyException>(() => channel.HistoryAsync(true));
+                _ = await Assert.ThrowsAsync<AblyException>(() => channel.HistoryAsync(true));
 #pragma warning restore 618
             }
 

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionParameterSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionParameterSpecs.cs
@@ -15,7 +15,7 @@ namespace IO.Ably.Tests.Realtime
         [Trait("spec", "RTN2")]
         public async Task ShouldUseDefaultRealtimeHost()
         {
-            var client = await GetConnectedClient();
+            _ = await GetConnectedClient();
             LastCreatedTransport.Parameters.Host.Should().Be(Defaults.RealtimeHost);
         }
 
@@ -31,7 +31,7 @@ namespace IO.Ably.Tests.Realtime
             }
 
 #pragma warning disable 162
-            var client = GetClientWithFakeTransport(opts => opts.UseBinaryProtocol = useBinary);
+            _ = GetClientWithFakeTransport(opts => opts.UseBinaryProtocol = useBinary);
             LastCreatedTransport.Parameters.UseBinaryProtocol.Should().Be(useBinary);
             LastCreatedTransport.Parameters.GetParams().Should().ContainKey("format").WhichValue.Should().Be(format);
 #pragma warning restore 162
@@ -43,7 +43,7 @@ namespace IO.Ably.Tests.Realtime
         [Trait("spec", "RTN2b")]
         public async Task WithEchoInClientOptions_ShouldSetTransportEchoCorrectly(bool echo)
         {
-            var client = await GetConnectedClient(opts => opts.EchoMessages = echo);
+            _ = await GetConnectedClient(opts => opts.EchoMessages = echo);
 
             LastCreatedTransport.Parameters.EchoMessages.Should().Be(echo);
             LastCreatedTransport.Parameters.GetParams()
@@ -55,8 +55,8 @@ namespace IO.Ably.Tests.Realtime
         [Trait("spec", "RTN2d")]
         public async Task WithClientId_ShouldSetTransportClientIdCorrectly()
         {
-            var clientId = "12345";
-            var client = await GetConnectedClient(opts =>
+            const string clientId = "12345";
+            _ = await GetConnectedClient(opts =>
             {
                 opts.ClientId = clientId;
                 opts.Token = "123";
@@ -72,7 +72,7 @@ namespace IO.Ably.Tests.Realtime
         [Trait("spec", "RTN2d")]
         public async Task WithoutClientId_ShouldNotSetClientIdParameterOnTransport()
         {
-            var client = await GetConnectedClient();
+            _ = await GetConnectedClient();
 
             LastCreatedTransport.Parameters.ClientId.Should().BeNullOrEmpty();
             LastCreatedTransport.Parameters.GetParams().Should().NotContainKey("clientId");
@@ -92,9 +92,9 @@ namespace IO.Ably.Tests.Realtime
         [Trait("spec", "RSA3c")]
         public async Task WithTokenAuth_ShouldSetTransportAccessTokeParameter()
         {
-            var clientId = "123";
-            var tokenString = "token";
-            var client = await GetConnectedClient(opts =>
+            const string clientId = "123";
+            const string tokenString = "token";
+            _ = await GetConnectedClient(opts =>
             {
                 opts.Key = string.Empty;
                 opts.ClientId = clientId;
@@ -111,7 +111,7 @@ namespace IO.Ably.Tests.Realtime
         [Trait("spec", "RTN2f")]
         public async Task ShouldSetTransportVersionParameterToProtocolVersion()
         {
-            var client = await GetConnectedClient();
+            _ = await GetConnectedClient();
 
             LastCreatedTransport.Parameters.GetParams()
                 .Should().ContainKey("v")
@@ -131,7 +131,7 @@ namespace IO.Ably.Tests.Realtime
             Regex.Match($"xdotnet-{Defaults.ProtocolVersion}.321", pattern).Success.Should().BeFalse();
             Regex.Match($"csharp.netstandard20-{Defaults.ProtocolVersion}.0", pattern).Success.Should().BeFalse();
 
-            var client = await GetConnectedClient();
+            _ = await GetConnectedClient();
             LastCreatedTransport.Parameters.GetParams().Should().ContainKey("lib");
             var transportParams = LastCreatedTransport.Parameters.GetParams();
 
@@ -143,7 +143,7 @@ namespace IO.Ably.Tests.Realtime
         [Trait("spec", "RTC1f")]
         public async Task WithNullTransportParamsInOptions_ShouldNotThrow()
         {
-            var client = await GetConnectedClient(options => options.TransportParams = null);
+            _ = await GetConnectedClient(options => options.TransportParams = null);
 
             var ex = Record.Exception(() => LastCreatedTransport.Parameters.GetUri().ToString());
 
@@ -154,7 +154,7 @@ namespace IO.Ably.Tests.Realtime
         [Trait("spec", "RTC1f")]
         public async Task WithCustomTransportParamsInOptions_ShouldPassThemInQueryStringWhenCreatingTransport()
         {
-            var client = await GetConnectedClient(options => options.TransportParams = new Dictionary<string, object>
+            _ = await GetConnectedClient(options => options.TransportParams = new Dictionary<string, object>
             {
                 { "test", "best" },
                 { "best", "test" },

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
@@ -42,12 +42,14 @@ namespace IO.Ably.Tests.Rest
         [Trait("spec", "RSL1d")]
         public async Task SendingAVeryLargeMessage_ShouldThrowErrorToIndicateSendingFailed(Protocol protocol)
         {
-            var message = new Message();
-            message.Name = "large";
-            message.Data = new string('a', 50 * 1024 * 8); // 100KB
+            var message = new Message
+            {
+                Name = "large",
+                Data = new string('a', 50 * 1024 * 8), // 100KB
+            };
             var client = await GetRestClient(protocol);
-            var ex = await Assert.ThrowsAsync<AblyException>(()
-                => client.Channels.Get("large").PublishAsync(message));
+            var channel = client.Channels.Get("large");
+            _ = await Assert.ThrowsAsync<AblyException>(() => channel.PublishAsync(message));
         }
 
         [Theory]
@@ -105,7 +107,7 @@ namespace IO.Ably.Tests.Rest
             var message = new Message("test", "test") { ClientId = "999" };
             var client = await GetRestClient(protocol, opts => opts.ClientId = "111");
             var channel = client.Channels.Get("test");
-            var ex = await Assert.ThrowsAsync<AblyException>(() => channel.PublishAsync(message));
+            _ = await Assert.ThrowsAsync<AblyException>(() => channel.PublishAsync(message));
 
             // Can publish further messages in the same channel
             await channel.PublishAsync("test", "test");
@@ -488,7 +490,7 @@ namespace IO.Ably.Tests.Rest
             var client = await GetRestClient(protocol);
             var channel = client.Channels.Get("persisted:test_" + protocol);
 
-            var ex = await Assert.ThrowsAsync<AblyException>(() => channel.PublishAsync("int", 1));
+            _ = await Assert.ThrowsAsync<AblyException>(() => channel.PublishAsync("int", 1));
         }
 
         private class TestLoggerSink : ILoggerSink

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
@@ -346,7 +346,7 @@ namespace IO.Ably.Tests.Rest
             [Trait("spec", "RSL2b")]
             public async Task WithStartBeforeEnd_Throws()
             {
-                var ex = await Assert.ThrowsAsync<AblyException>(() =>
+                _ = await Assert.ThrowsAsync<AblyException>(() =>
                         _channel.HistoryAsync(new PaginatedRequestParams { Start = Now, End = Now.AddHours(-1) }));
             }
 
@@ -375,7 +375,7 @@ namespace IO.Ably.Tests.Rest
             [Trait("spec", "RSP3a1")]
             public async Task WithLimitLessThan0andMoreThan1000_ShouldThrow(int limit)
             {
-                var ex = await
+                _ = await
                     Assert.ThrowsAsync<AblyException>(() => _channel.HistoryAsync(new PaginatedRequestParams { Limit = limit }));
             }
 
@@ -388,7 +388,7 @@ namespace IO.Ably.Tests.Rest
                 {
                     var query = new PaginatedRequestParams { Start = (DateTimeOffset?)dates.First(), End = (DateTimeOffset)dates.Last() };
 
-                    var ex = await Assert.ThrowsAsync<AblyException>(async () => await channel.HistoryAsync(query));
+                    _ = await Assert.ThrowsAsync<AblyException>(async () => await channel.HistoryAsync(query));
                 }
             }
 

--- a/src/IO.Ably.Tests.Shared/Rest/PresenceSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/PresenceSpecs.cs
@@ -46,11 +46,11 @@ namespace IO.Ably.Tests
             {
                 if (throws)
                 {
-                    var ex = await Assert.ThrowsAsync<ArgumentException>(() => _channel.Presence.GetAsync(limit));
+                    _ = await Assert.ThrowsAsync<ArgumentException>(() => _channel.Presence.GetAsync(limit));
                 }
                 else
                 {
-                    var result = await _channel.Presence.GetAsync(limit);
+                    _ = await _channel.Presence.GetAsync(limit);
 
                     LastRequest.AssertContainsParameter("limit", expectedLimitHeader);
                 }
@@ -141,7 +141,7 @@ namespace IO.Ably.Tests
             [Trait("spec", "RSP4b3")]
             public async Task History_WithLimitLessThan0andMoreThan1000_ShouldThrow(int limit)
             {
-                var ex = await
+                _ = await
                     Assert.ThrowsAsync<AblyException>(() => _channel.Presence.HistoryAsync(new PaginatedRequestParams { Limit = limit }));
             }
 

--- a/src/IO.Ably.Tests.Shared/Rest/RestInitSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestInitSpecs.cs
@@ -43,7 +43,7 @@ namespace IO.Ably.Tests
             public void WithTokenButNoWayToRenew_ShouldLogErrorMessageWithError()
             {
                 var testLogger = new TestLogger(NoMeansProvidedToRenewAuthToken);
-                var client = new AblyRest(new ClientOptions { Token = "Test", Logger = testLogger });
+                _ = new AblyRest(new ClientOptions { Token = "Test", Logger = testLogger });
                 testLogger.MessageSeen.Should().BeTrue();
             }
 
@@ -52,7 +52,7 @@ namespace IO.Ably.Tests
             public void WithTokenDetailsButNoWayToRenew_ShouldLogErrorMessageWithError()
             {
                 var testLogger = new TestLogger(NoMeansProvidedToRenewAuthToken);
-                var client = new AblyRest(new ClientOptions { TokenDetails = new TokenDetails("test"), Logger = testLogger });
+                _ = new AblyRest(new ClientOptions { TokenDetails = new TokenDetails("test"), Logger = testLogger });
                 testLogger.MessageSeen.Should().BeTrue();
             }
 

--- a/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
@@ -516,9 +516,8 @@ namespace IO.Ably.Tests
                 _response.StatusCode = HttpStatusCode.BadGateway;
                 var client = CreateClient(null);
 
-                var ex = await Assert.ThrowsAsync<AblyException>(() => MakeAnyRequest(client));
+                _ = await Assert.ThrowsAsync<AblyException>(() => MakeAnyRequest(client));
 
-                // ex.ErrorInfo.statusCode.Should().Be(_response.StatusCode);
                 _handler.NumberOfRequests.Should().Be(client.Options.HttpMaxRetryCount);
             }
 
@@ -663,7 +662,7 @@ namespace IO.Ably.Tests
 
                 client.HttpClient.CreateInternalHttpClient(TimeSpan.FromSeconds(6), handler);
 
-                var ex = await Assert.ThrowsAsync<AblyException>(() => MakeAnyRequest(client));
+                _ = await Assert.ThrowsAsync<AblyException>(() => MakeAnyRequest(client));
 
                 handler.Requests.Count.Should().Be(3); // First attempt is with rest.ably.io
             }


### PR DESCRIPTION
Using the C# 7.0 support for discards, which communicates intent to the compiler.