### PR TITLE
Remove redundant and inconsistent member initialization

### DIFF
--- a/src/IO.Ably.Shared/AblyRealtime.cs
+++ b/src/IO.Ably.Shared/AblyRealtime.cs
@@ -23,7 +23,7 @@ namespace IO.Ably
 
         internal RealtimeWorkflow Workflow { get; private set; }
 
-        internal volatile bool Disposed = false;
+        internal volatile bool Disposed;
         private static readonly Func<ClientOptions, IMobileDevice, AblyRest> CreateRestFunc = (clientOptions, mobileDevice) => new AblyRest(clientOptions, mobileDevice);
 
         /// <summary>

--- a/src/IO.Ably.Shared/ClientOptions.cs
+++ b/src/IO.Ably.Shared/ClientOptions.cs
@@ -16,7 +16,7 @@ namespace IO.Ably
         private string _restHost;
         private Func<DateTimeOffset> _nowFunc;
 #if !MSGPACK
-        private bool _useBinaryProtocol = false;
+        private bool _useBinaryProtocol;
 #endif
         private string[] _fallbackHosts;
 
@@ -411,7 +411,7 @@ namespace IO.Ably
         /// If enabled, every REST request to Ably includes a `request_id` query string parameter.
         /// This request ID remains the same if a request is retried to a fallback host.
         /// </summary>
-        public bool AddRequestIds { get; set; } = false;
+        public bool AddRequestIds { get; set; }
 
         /// <summary>
         /// It tells Ably push REST requests to fully wait for all their effects before responding.
@@ -429,7 +429,7 @@ namespace IO.Ably
         [JsonIgnore]
         internal ILogger Logger { get; set; } = DefaultLogger.LoggerInstance;
 
-        internal bool SkipInternetCheck { get; set; } = false;
+        internal bool SkipInternetCheck { get; set; }
 
         internal TimeSpan RealtimeRequestTimeout { get; set; } = Defaults.DefaultRealtimeTimeout;
 

--- a/src/IO.Ably.Shared/Http/AblyHttpOptions.cs
+++ b/src/IO.Ably.Shared/Http/AblyHttpOptions.cs
@@ -34,7 +34,7 @@ namespace IO.Ably
 
         public ILogger Logger { get; set; }
 
-        public bool AddRequestIds { get; set; } = false;
+        public bool AddRequestIds { get; set; }
 
         public AblyHttpOptions()
         {

--- a/src/IO.Ably.Shared/Http/AblyRequest.cs
+++ b/src/IO.Ably.Shared/Http/AblyRequest.cs
@@ -54,7 +54,7 @@ namespace IO.Ably
         /// Set to 'true' when 4XX or 5XX HTTP status codes should not cause an exception.
         /// Add to support AblyRest.Request(...).
         /// </summary>
-        public bool NoExceptionOnHttpError { get; set; } = false;
+        public bool NoExceptionOnHttpError { get; set; }
 
         public void AddHeaders(IEnumerable<KeyValuePair<string, string>> parameters)
         {

--- a/src/IO.Ably.Shared/Realtime/ChannelProperties.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelProperties.cs
@@ -8,6 +8,6 @@
         /// <summary>
         /// contains the last channelSerial received in an ATTACHED ProtocolMessage for the channel, see RTL15a.
         /// </summary>
-        public string AttachSerial { get; internal set; } = null;
+        public string AttachSerial { get; internal set; }
     }
 }

--- a/src/IO.Ably.Shared/Realtime/ChannelStateChangedEventArgs.cs
+++ b/src/IO.Ably.Shared/Realtime/ChannelStateChangedEventArgs.cs
@@ -66,7 +66,7 @@ namespace IO.Ably.Realtime
         /// </summary>
         public ChannelEvent Event { get; }
 
-        internal ProtocolMessage ProtocolMessage { get; set; } = null;
+        internal ProtocolMessage ProtocolMessage { get; set; }
 
         /// <inheritdoc/>
         public override string ToString()

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -21,7 +21,7 @@ namespace IO.Ably.Realtime
         private readonly Handlers<PresenceMessage> _handlers = new Handlers<PresenceMessage>();
         private readonly IConnectionManager _connection;
         private string _currentSyncChannelSerial;
-        private bool _initialSyncCompleted = false;
+        private bool _initialSyncCompleted;
 
         internal Presence(IConnectionManager connection, RealtimeChannel channel, string clientId, ILogger logger)
         {

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -27,9 +27,9 @@ namespace IO.Ably.Realtime
         /// True when the channel moves to the @ATTACHED@ state, and False
         /// when the channel moves to the @DETACHING@ or @FAILED@ states.
         /// </summary>
-        internal bool AttachResume { get; set; } = false;
+        internal bool AttachResume { get; set; }
 
-        private int _decodeRecoveryInProgress = 0;
+        private int _decodeRecoveryInProgress;
 
         // We use interlocked exchange because it is a thread safe way to read a variable
         // without the need of locking. Generally DecodeRecovery is set from a method triggered by

--- a/src/IO.Ably.Shared/Realtime/Workflows/RealtimeCommands.cs
+++ b/src/IO.Ably.Shared/Realtime/Workflows/RealtimeCommands.cs
@@ -160,9 +160,9 @@ namespace IO.Ably.Realtime.Workflow
             RetryAuth = retryAuth;
         }
 
-        public bool ClearConnectionKey { get; } = false;
+        public bool ClearConnectionKey { get; }
 
-        public bool RetryAuth { get; } = false;
+        public bool RetryAuth { get; }
 
         public static SetConnectingStateCommand Create(bool clearConnectionKey = false, bool retryAuth = false) => new SetConnectingStateCommand(clearConnectionKey, retryAuth);
 

--- a/src/IO.Ably.Shared/Realtime/Workflows/RealtimeState.cs
+++ b/src/IO.Ably.Shared/Realtime/Workflows/RealtimeState.cs
@@ -36,7 +36,7 @@ namespace IO.Ably.Realtime.Workflow
 
             public bool IsFallbackHost => FallbackHosts.Contains(Host);
 
-            internal long MessageSerial { get; set; } = 0;
+            internal long MessageSerial { get; set; }
 
             /// <summary>
             /// The current connection key.

--- a/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
+++ b/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
@@ -32,8 +32,8 @@ namespace IO.Ably.Realtime.Workflow
 
         // This is used for the tests so we can have a good
         // way of figuring out when processing has finished
-        private volatile bool _processingCommand = false;
-        private bool _heartbeatMonitorDisconnectRequested = false;
+        private volatile bool _processingCommand;
+        private bool _heartbeatMonitorDisconnectRequested;
 
         private AblyRealtime Client { get; }
 

--- a/src/IO.Ably.Shared/Transport/MsWebSocketConnection.cs
+++ b/src/IO.Ably.Shared/Transport/MsWebSocketConnection.cs
@@ -48,7 +48,7 @@ namespace IO.Ably.Transport
             Closed
         }
 
-        private bool _disposed = false;
+        private bool _disposed;
 
         internal ILogger Logger { get; set; } = DefaultLogger.LoggerInstance;
 

--- a/src/IO.Ably.Shared/Transport/MsWebSocketTransport.cs
+++ b/src/IO.Ably.Shared/Transport/MsWebSocketTransport.cs
@@ -31,7 +31,7 @@ namespace IO.Ably.Transport
     public class MsWebSocketTransport : ITransport
     {
         private readonly MsWebSocketOptions _socketOptions;
-        private bool _disposed = false;
+        private bool _disposed;
         private readonly CancellationTokenSource _readerThreadSource = new CancellationTokenSource();
         private MsWebSocketConnection _socket;
 

--- a/src/IO.Ably.Tests.Shared/Infrastructure/TestTransportWrapper.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/TestTransportWrapper.cs
@@ -91,7 +91,7 @@ namespace IO.Ably.Tests.Infrastructure
             _handler = new MessageHandler(DefaultLogger.LoggerInstance, protocol);
         }
 
-        public bool ThrowOnConnect { get; set; } = false;
+        public bool ThrowOnConnect { get; set; }
 
         public Guid Id => WrappedTransport.Id;
 


### PR DESCRIPTION
C# rigourously defines the [default values](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/default-values) for built in types.

We don't need to inconsistently, explicitly, set these in some places but not others.