### PR TITLE
Be explicit about ignored return values

### DIFF
--- a/src/IO.Ably.Shared/MessageEncoders/MessageHandler.cs
+++ b/src/IO.Ably.Shared/MessageEncoders/MessageHandler.cs
@@ -79,7 +79,7 @@ namespace IO.Ably.MessageEncoders
         private static void ProcessMessages<T>(IEnumerable<T> payloads, DecodingContext context) where T : IMessage
         {
             // TODO: What happens with rest request where we can't decode messages
-            DecodePayloads(context, payloads as IEnumerable<IMessage>);
+            _ = DecodePayloads(context, payloads as IEnumerable<IMessage>);
         }
 
         public void SetRequestBody(AblyRequest request)
@@ -212,7 +212,7 @@ namespace IO.Ably.MessageEncoders
             if (pp == context.PreviousPayload)
             {
                 var originalPayloadResult = GetOriginalMessagePayload();
-                originalPayloadResult.IfSuccess(x =>
+                _ = originalPayloadResult.IfSuccess(x =>
                 {
                     context.PreviousPayload = x;
                 });

--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -117,7 +117,7 @@ namespace IO.Ably.Realtime
                     throw new AblyException(new ErrorInfo($"Channel {_channel.Name}: presence state is out of sync due to the channel being in a SUSPENDED state", 91005));
                 }
 
-                await WaitForSyncAsync();
+                _ = await WaitForSyncAsync();
             }
 
             var result = Map.Values.Where(x => (getOptions.ClientId.IsEmpty() || x.ClientId == getOptions.ClientId)

--- a/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
+++ b/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
@@ -675,7 +675,7 @@ namespace IO.Ably.Realtime.Workflow
             if (Connection.State != ConnectionState.Connected)
             {
                 // We don't want to wait for the execution to finish
-                NotifyExternalClient(
+                _ = NotifyExternalClient(
                     () => { cmd.Request.Callback?.Invoke(null, PingRequest.DefaultError); },
                     "Notifying Ping callback because connection state is not Connected");
             }

--- a/src/IO.Ably.Shared/Rest/RestChannels.cs
+++ b/src/IO.Ably.Shared/Rest/RestChannels.cs
@@ -77,7 +77,7 @@ namespace IO.Ably.Rest
             var channelList = _channels.Keys.ToArray();
             foreach (var channelName in channelList)
             {
-                Release(channelName);
+                _ = Release(channelName);
             }
         }
 

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
@@ -283,7 +283,7 @@ namespace IO.Ably.Tests
             });
             await Task.Delay(2000);
             // This makes sure we get server time
-            ((AblyAuth)mainClient.Auth).CreateTokenRequest();
+            _ = ((AblyAuth)mainClient.Auth).CreateTokenRequest();
 
             await mainClient.StatsAsync();
             ((AblyAuth)mainClient.Auth).CurrentToken.Should().NotBeSameAs(token);

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthorizeTests.cs
@@ -73,7 +73,7 @@ namespace IO.Ably.Tests.AuthTests
             var client = GetRestClient();
             var testAblyAuth = new TestAblyAuth(client.Options, client);
             var customTokenParams = TokenParams.WithDefaultsApplied();
-            customTokenParams.Merge(new TokenParams { Ttl = TimeSpan.FromHours(2), Timestamp = Now.AddHours(1) });
+            _ = customTokenParams.Merge(new TokenParams { Ttl = TimeSpan.FromHours(2), Timestamp = Now.AddHours(1) });
             var customAuthOptions = AuthOptions.FromExisting(testAblyAuth.Options);
             customAuthOptions.UseTokenAuth = true;
 
@@ -160,13 +160,13 @@ namespace IO.Ably.Tests.AuthTests
             var testLogger1 = new TestLogger("AuthoriseAsync is deprecated and will be removed in the future, please replace with a call to AuthorizeAsync");
             var client = GetRestClient(setOptionsAction: options => { options.Logger = testLogger1; });
             var testAblyAuth = new TestAblyAuth(client.Options, client);
-            await testAblyAuth.AuthoriseAsync();
+            _ = await testAblyAuth.AuthoriseAsync();
             testLogger1.MessageSeen.Should().BeTrue();
 
             var testLogger2 = new TestLogger("Authorise is deprecated and will be removed in the future, please replace with a call to Authorize");
             client = GetRestClient(setOptionsAction: options => { options.Logger = testLogger2; });
             testAblyAuth = new TestAblyAuth(client.Options, client);
-            testAblyAuth.Authorise();
+            _ = testAblyAuth.Authorise();
             testLogger2.MessageSeen.Should().BeTrue();
 #pragma warning restore CS0618 // Type or member is obsolete
         }

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -327,7 +327,7 @@ namespace IO.Ably.Tests.Realtime
 
                     await rtChannel.Presence.EnterAsync();
                     await rtChannel.WaitForState(ChannelState.Attached);
-                    await rtChannel.Presence.WaitSync();
+                    _ = await rtChannel.Presence.WaitSync();
 
                     return (rtChannel, rChannel);
                 }
@@ -387,7 +387,7 @@ namespace IO.Ably.Tests.Realtime
                     await realtimeClient.WaitForState(ConnectionState.Disconnected);
                     await realtimeClient.WaitForState(ConnectionState.Connected);
                     await realtimeChannel.WaitForState(ChannelState.Attached);
-                    await realtimeChannel.Presence.WaitSync();
+                    _ = await realtimeChannel.Presence.WaitSync();
 
                     // Wait for a second because the Rest call returns [] if done straight away
                     await Sleep(1);
@@ -870,7 +870,7 @@ namespace IO.Ably.Tests.Realtime
                 await channel2.Presence.EnterClientAsync("3", null);
 
                 // wait for the above to raise a subscribe event
-                await ch2Awaiter.WaitFor(1);
+                _ = await ch2Awaiter.WaitFor(1);
 
                 // filter by clientId
                 var presenceMessages3 = await channel2.Presence.GetAsync("1");


### PR DESCRIPTION
By being explicit we communicate to future developers that we actually intended to ignore the return value, we also inform the compiler which then won't raise a warning. An added advantage is that the ignored return value is more obvious at the point of call, rather than possibly being a call to a method that returns `void`. Lastly the `_ =` is very grep-able.