### PR TITLE
Prefer local functions to delegates

### DIFF
--- a/src/IO.Ably.Tests.Shared/Push/PushAdminTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/PushAdminTests.cs
@@ -12,7 +12,7 @@ using Xunit.Abstractions;
 namespace IO.Ably.Tests.Push
 {
     [Trait("spec", "RSH1")]
-    public class PushAdminTests
+    public static class PushAdminTests
     {
         public class GeneralTests : MockHttpRestSpecs
         {

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFallbackSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFallbackSpecs.cs
@@ -150,7 +150,8 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
         public async Task WithRealtimeHostConnectedToFallback_WhenMakingRestRequestThatFails_ShouldRetryUsingAFallback()
         {
             var requestCount = 0;
-            Func<HttpRequestMessage, HttpResponseMessage> getResponse = request =>
+
+            HttpResponseMessage GetResponse(HttpRequestMessage request)
             {
                 try
                 {
@@ -175,9 +176,9 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
                 {
                     requestCount++;
                 }
-            };
+            }
 
-            var handler = new FakeHttpMessageHandler(getResponse);
+            var handler = new FakeHttpMessageHandler(GetResponse);
 
             var client = GetClientWithFakeTransportAndMessageHandler(messageHandler: handler);
 
@@ -305,7 +306,6 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
         public async Task WhenItMovesFromDisconnectedToSuspended_ShouldTryDefaultHostAgain()
         {
             var now = DateTimeOffset.UtcNow;
-
             Func<DateTimeOffset> testNow = () => now;
 
             var client = await GetConnectedClient(opts =>

--- a/src/IO.Ably.Tests.Shared/Realtime/CountDownTimerSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/CountDownTimerSpecs.cs
@@ -120,10 +120,12 @@ namespace IO.Ably.Tests.Realtime
             var timeout = TimeSpan.FromMilliseconds(10);
             int called1 = 0;
             int called2 = 0;
+
             Action callback1 = () =>
             {
                 called1++;
             };
+
             Action callback2 = () =>
             {
                 called2++;

--- a/src/IO.Ably.Tests.Shared/Realtime/RealtimeWorkflowSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/RealtimeWorkflowSpecs.cs
@@ -442,13 +442,17 @@ namespace IO.Ably.Tests.NETFramework.Realtime
 
                 var callbacks = new List<ValueTuple<bool, ErrorInfo>>();
                 var message = new ProtocolMessage(ProtocolMessage.MessageAction.Message, "Test");
-                Action<bool, ErrorInfo> callback = (ack, err) => { callbacks.Add((ack, err)); };
+
+                void Callback(bool ack, ErrorInfo err)
+                {
+                    callbacks.Add((ack, err));
+                }
 
                 // Act
-                client.ExecuteCommand(SendMessageCommand.Create(message, callback));
+                client.ExecuteCommand(SendMessageCommand.Create(message, Callback));
                 client.ExecuteCommand(ProcessMessageCommand.Create(
                     new ProtocolMessage(ProtocolMessage.MessageAction.Ack) { MsgSerial = 0, Count = 1 }));
-                client.ExecuteCommand(SendMessageCommand.Create(message, callback));
+                client.ExecuteCommand(SendMessageCommand.Create(message, Callback));
                 client.ExecuteCommand(ProcessMessageCommand.Create(
                     new ProtocolMessage(ProtocolMessage.MessageAction.Ack) { MsgSerial = 1, Count = 1 }));
 
@@ -514,13 +518,17 @@ namespace IO.Ably.Tests.NETFramework.Realtime
 
                 var callbacks = new List<ValueTuple<bool, ErrorInfo>>();
                 var message = new ProtocolMessage(ProtocolMessage.MessageAction.Message, "Test");
-                Action<bool, ErrorInfo> callback = (ack, err) => { callbacks.Add((ack, err)); };
+
+                void Callback(bool ack, ErrorInfo err)
+                {
+                    callbacks.Add((ack, err));
+                }
 
                 // Act
-                client.ExecuteCommand(SendMessageCommand.Create(message, callback));
+                client.ExecuteCommand(SendMessageCommand.Create(message, Callback));
                 client.ExecuteCommand(ProcessMessageCommand.Create(
                     new ProtocolMessage(ProtocolMessage.MessageAction.Nack) { MsgSerial = 0, Count = 1 }));
-                client.ExecuteCommand(SendMessageCommand.Create(message, callback));
+                client.ExecuteCommand(SendMessageCommand.Create(message, Callback));
                 client.ExecuteCommand(ProcessMessageCommand.Create(
                     new ProtocolMessage(ProtocolMessage.MessageAction.Nack) { MsgSerial = 1, Count = 1 }));
 
@@ -540,13 +548,18 @@ namespace IO.Ably.Tests.NETFramework.Realtime
                 var callbacks = new List<ValueTuple<bool, ErrorInfo>>();
 
                 var message = new ProtocolMessage(ProtocolMessage.MessageAction.Message, "Test");
-                Action<bool, ErrorInfo> callback = (ack, err) => { callbacks.Add((ack, err)); };
-                ErrorInfo error = new ErrorInfo("reason", 123);
+
+                void Callback(bool ack, ErrorInfo err)
+                {
+                    callbacks.Add((ack, err));
+                }
 
                 // Act
-                client.ExecuteCommand(SendMessageCommand.Create(message, callback));
-                client.ExecuteCommand(SendMessageCommand.Create(message, callback));
-                client.ExecuteCommand(SendMessageCommand.Create(message, callback));
+                client.ExecuteCommand(SendMessageCommand.Create(message, Callback));
+                client.ExecuteCommand(SendMessageCommand.Create(message, Callback));
+                client.ExecuteCommand(SendMessageCommand.Create(message, Callback));
+
+                var error = new ErrorInfo("reason", 123);
 
                 client.ExecuteCommand(ProcessMessageCommand.Create(
                     new ProtocolMessage(ProtocolMessage.MessageAction.Nack) { MsgSerial = 0, Count = 3, Error = error }));


### PR DESCRIPTION
Local functions don't come with the extra memory and runtime baggage that delegates do.