### PR TITLE
Fix/980 release realtime channels

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Presence.cs
+++ b/src/IO.Ably.Shared/Realtime/Presence.cs
@@ -84,6 +84,8 @@ namespace IO.Ably.Realtime
         /// </summary>
         internal void RemoveAllListeners()
         {
+            InitialSyncCompleted = null;
+            SyncCompleted = null;
             _handlers.RemoveAll();
         }
 

--- a/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannel.cs
@@ -554,7 +554,7 @@ namespace IO.Ably.Realtime
 
             if (error != null)
             {
-                RealtimeClient.NotifyExternalClients(() => Error.Invoke(this, new ChannelErrorEventArgs(error)));
+                RealtimeClient.NotifyExternalClients(() => Error?.Invoke(this, new ChannelErrorEventArgs(error)));
             }
         }
 
@@ -564,6 +564,9 @@ namespace IO.Ably.Realtime
             DetachedAwaiter?.Dispose();
             _handlers.RemoveAll();
             Presence?.RemoveAllListeners();
+            StateChanged = null;
+            Error = null;
+            InternalStateChanged = null;
         }
 
         internal void AddUntilAttachParameter(PaginatedRequestParams query)
@@ -628,14 +631,14 @@ namespace IO.Ably.Realtime
             var channelStateChange = new ChannelStateChange(channelEvent, state, State, error, protocolMessage);
             HandleStateChange(state, error, protocolMessage);
 
-            InternalStateChanged.Invoke(this, channelStateChange);
+            InternalStateChanged?.Invoke(this, channelStateChange);
 
             // Notify external client using the thread they subscribe on
             RealtimeClient.NotifyExternalClients(() =>
             {
                 try
                 {
-                    StateChanged.Invoke(this, channelStateChange);
+                    StateChanged?.Invoke(this, channelStateChange);
                 }
                 catch (Exception ex)
                 {

--- a/src/IO.Ably.Tests.Shared/Rest/SandboxSpecExtension.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/SandboxSpecExtension.cs
@@ -25,6 +25,11 @@ namespace IO.Ably.Tests
 
         internal static async Task WaitForState(this IRealtimeChannel channel, ChannelState awaitedState = ChannelState.Attached, TimeSpan? waitSpan = null)
         {
+            if (channel.State == awaitedState)
+            {
+                return;
+            }
+
             var channelAwaiter = new ChannelAwaiter(channel, awaitedState);
             var timespan = waitSpan.GetValueOrDefault(TimeSpan.FromSeconds(5));
             Result<bool> result = await channelAwaiter.WaitAsync(timespan);


### PR DESCRIPTION
This PR addresses issue #980. 

I found we needed to handle a couple of edge cases. 

1. Channels were not released when they were not attached. 
2. Channels that failed while detaching were also not released

I've also simplified how we monitor if a channel should be released (thanks @ikbalkaya). Instead of listening for internal state changes I just pass a callback to the Detach method which fires once the detach operation completes. To make sure that is reliable I had to fix an issue with the ChannelAwaiter where the callback would not fire if it failed without an error (another edge case). 

Finally I've improved the clean up on Dispose by setting all EventHandlers to `null`. 