### PR TITLE
Fix collections content is never queried warning

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandboxOperatingSystemEventsForNetworkSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandboxOperatingSystemEventsForNetworkSpecs.cs
@@ -63,6 +63,7 @@ namespace IO.Ably.Tests.Realtime
 
             List<ConnectionState> states = new List<ConnectionState>();
             client.Connection.On(stateChange => states.Add(stateChange.Current));
+            states.Should().HaveCountGreaterThan(0);
 
             await WaitForState(client, ConnectionState.Connecting);
         }


### PR DESCRIPTION
In the skipped test `WhenOperatingSystemNetworkBecomesAvailableAndStateIsDisconnected_ShouldTransitionTryToConnectImmediately` we where creating and populating a collection to no end.  This quick fix addresses that.  This test needs further work.