### PR TITLE
Disable code analysis for sample code

### DIFF
--- a/src/IO.Ably.Tests.Shared/Samples/DocumentationSamples.cs
+++ b/src/IO.Ably.Tests.Shared/Samples/DocumentationSamples.cs
@@ -8,6 +8,8 @@ using IO.Ably.Realtime;
 
 namespace IO.Ably.Tests.Samples
 {
+    // ReSharper disable All
+
     public static class DocumentationSamples
     {
         public static async Task AuthSamples1()
@@ -444,4 +446,6 @@ namespace IO.Ably.Tests.Samples
             Console.WriteLine($"Published this hour {thisHour.Inbound.All.All.Count}");
         }
     }
+
+    // ReSharper restore All
 }

--- a/src/IO.Ably.Tests.Shared/Samples/RealtimeSamples.cs
+++ b/src/IO.Ably.Tests.Shared/Samples/RealtimeSamples.cs
@@ -10,6 +10,8 @@ using Xunit;
 
 namespace IO.Ably.Tests.GithubSamples
 {
+    // ReSharper disable all
+
     public class RealtimeSamples
     {
         private const string PlaceholderKey = "key.placeholder:placeholder";
@@ -215,4 +217,6 @@ namespace IO.Ably.Tests.GithubSamples
             var realtime = new AblyRealtime(options);
         }
     }
+
+    // ReSharper restore All
 }


### PR DESCRIPTION
The sample code takes the form of small snippets that focus on use-cases and common workflows. These samples are by necessity brief and often omit error checking etc so as not to distract, as such the samples generate a lot of warnings about unused variables etc.