### PR TITLE
'RealtimeWorkflow' fix 'NullReferenceException'

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
+++ b/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
@@ -426,11 +426,7 @@ namespace IO.Ably.Realtime.Workflow
                     }
 
                 case HandleConnectingErrorCommand cmd:
-
-                    // split into two parts
-                    // Errors come from error messages
-                    // Exceptions only come from Transport
-                    var error = cmd.Error ?? cmd.Exception.ErrorInfo;
+                    var error = cmd.Error ?? cmd.Exception?.ErrorInfo ?? ErrorInfo.ReasonUnknown;
 
                     if (error.IsTokenError)
                     {


### PR DESCRIPTION
Observed during test runs, it is possible to get a command with a non-null `Exception` but a null `ErrorInfo`.