### PR TITLE
Remove speculative generalization

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/MockHttpRealtimeSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/MockHttpRealtimeSpecs.cs
@@ -14,7 +14,7 @@ namespace IO.Ably.Tests
 
         internal List<AblyRequest> Requests { get; } = new List<AblyRequest>();
 
-        internal virtual AblyRealtime GetRealtimeClient(Func<AblyRequest, Task<AblyResponse>> handleRequestFunc = null, Action<ClientOptions> setOptionsAction = null)
+        internal AblyRealtime GetRealtimeClient(Func<AblyRequest, Task<AblyResponse>> handleRequestFunc = null, Action<ClientOptions> setOptionsAction = null)
         {
             var options = new ClientOptions(ValidKey) { UseBinaryProtocol = false };
             setOptionsAction?.Invoke(options);


### PR DESCRIPTION
There where no `overrides` for this and besides its use was generating a 'virtual method call in constructor' warning. Two birds, one stone.