### PR TITLE
Remove redundant argument with default value

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -830,7 +830,7 @@ namespace IO.Ably.Tests.Realtime
         [Trait("spec", "RTN15h2")]
         public async Task WhenDisconnectedMessageContainsTokenError_IfTokenIsRenewable_ShouldNotEmitError(Protocol protocol)
         {
-            var awaiter = new TaskCompletionAwaiter(10000);
+            var awaiter = new TaskCompletionAwaiter();
             var authClient = await GetRestClient(protocol);
             var tokenDetails = await authClient.AblyAuth.RequestTokenAsync(new TokenParams { ClientId = "123", Ttl = TimeSpan.FromSeconds(2) });
             tokenDetails.Expires = DateTimeOffset.UtcNow.AddMinutes(10); // Cheat the client
@@ -873,7 +873,7 @@ namespace IO.Ably.Tests.Realtime
         [Trait("spec", "RTN15h2")]
         public async Task WhenDisconnectedMessageContainsTokenError_IfTokenRenewFails_ShouldBecomeDisconnectedAndEmitError(Protocol protocol)
         {
-            var awaiter = new TaskCompletionAwaiter(10000);
+            var awaiter = new TaskCompletionAwaiter();
             var authClient = await GetRestClient(protocol);
 
             var tokenDetails = await authClient.AblyAuth.RequestTokenAsync(new TokenParams


### PR DESCRIPTION
The parameter `timeoutMs` has the same default value.