### PR TITLE
Put back GettingPushDeviceDetailsFailed and fix WaitingForPushDeviceD…

### DIFF
--- a/src/IO.Ably.Shared/Push/ActivationStateMachine.Events.cs
+++ b/src/IO.Ably.Shared/Push/ActivationStateMachine.Events.cs
@@ -24,6 +24,14 @@
             }
         }
 
+        public sealed class GettingPushDeviceDetailsFailed : ErrorEvent
+        {
+            public GettingPushDeviceDetailsFailed(ErrorInfo reason)
+                : base(reason)
+            {
+            }
+        }
+
         public sealed class GettingDeviceRegistrationFailed : ErrorEvent
         {
             public GettingDeviceRegistrationFailed(ErrorInfo reason)

--- a/src/IO.Ably.Shared/Push/ActivationStateMachine.States.cs
+++ b/src/IO.Ably.Shared/Push/ActivationStateMachine.States.cs
@@ -19,7 +19,7 @@ namespace IO.Ably.Push
                 return EmptyNextEventFunc;
             }
 
-            return async () => nextEvent;
+            return () => Task.FromResult(nextEvent);
         }
 
         public abstract class State
@@ -86,7 +86,6 @@ namespace IO.Ably.Push
             }
         }
 
-        // Stub for now
         public sealed class WaitingForPushDeviceDetails : State
         {
             public WaitingForPushDeviceDetails(ActivationStateMachine machine)
@@ -101,7 +100,7 @@ namespace IO.Ably.Push
                 return @event is CalledActivate
                        || @event is CalledDeactivate
                        || @event is GotPushDeviceDetails
-                       || @event is GettingDeviceRegistrationFailed;
+                       || @event is GettingPushDeviceDetailsFailed;
             }
 
             public override async Task<(State, Func<Task<Event>>)> Transition(Event @event)
@@ -113,7 +112,7 @@ namespace IO.Ably.Push
                     case CalledDeactivate _:
                         Machine.TriggerDeactivatedCallback();
                         return (new NotActivated(Machine), EmptyNextEventFunc);
-                    case GettingDeviceRegistrationFailed failedEvent:
+                    case GettingPushDeviceDetailsFailed failedEvent:
                         Machine.TriggerActivatedCallback(failedEvent.Reason);
                         return (new NotActivated(Machine), EmptyNextEventFunc);
                     case GotPushDeviceDetails _:

--- a/src/IO.Ably.Tests.Shared/Push/ActivationStateMachineTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/ActivationStateMachineTests.cs
@@ -595,21 +595,21 @@ namespace IO.Ably.Tests.Push
 
             [Fact]
             [Trait("spec", "RSH3b4")]
-            public async Task ShouldBeAbleToHandleGettingDeviceRegistrationFailed()
+            public async Task ShouldBeAbleToHandleGettingPushDeviceDetailsFailed()
             {
                 var state = GetState();
-                state.CanHandleEvent(new ActivationStateMachine.GettingDeviceRegistrationFailed(new ErrorInfo())).Should().BeTrue();
+                state.CanHandleEvent(new ActivationStateMachine.GettingPushDeviceDetailsFailed(new ErrorInfo())).Should().BeTrue();
             }
 
             [Fact]
             [Trait("spec", "RSH3b4")]
             [Trait("spec", "RSH3c3b")]
-            public async Task GettingDeviceRegistrationFailed_ShouldTransitionToNotActivated()
+            public async Task GettingPushDeviceDetailsFailed_ShouldTransitionToNotActivated()
             {
                 var state = GetState();
 
                 var (nextState, nextEventFunc) =
-                    await state.Transition(new ActivationStateMachine.GettingDeviceRegistrationFailed(new ErrorInfo()));
+                    await state.Transition(new ActivationStateMachine.GettingPushDeviceDetailsFailed(new ErrorInfo()));
 
                 nextState.Should().BeOfType<ActivationStateMachine.NotActivated>();
                 (await nextEventFunc()).Should().BeNull();
@@ -618,7 +618,7 @@ namespace IO.Ably.Tests.Push
             [Fact]
             [Trait("spec", "RSH3b4")]
             [Trait("spec", "RSH3c3a")]
-            public async Task GettingDeviceRegistrationFailed_ShouldTriggerActivatedCallbackAndPassErrorInfo()
+            public async Task GettingPushDeviceDetailsFailed_ShouldTriggerActivatedCallbackAndPassErrorInfo()
             {
                 var state = GetState();
 
@@ -631,7 +631,7 @@ namespace IO.Ably.Tests.Push
                     return Task.CompletedTask;
                 };
 
-                await state.Transition(new ActivationStateMachine.GettingDeviceRegistrationFailed(errorInfo));
+                await state.Transition(new ActivationStateMachine.GettingPushDeviceDetailsFailed(errorInfo));
                 (await awaiter.Task).Should().BeTrue();
             }
 


### PR DESCRIPTION
…etails State

I had misspelled an event and that's where the unused state came from. Actually it has a good use so I put it back and fixed the tests