### PR TITLE
Fix virtual method call in constructor warning

### DIFF
--- a/src/IO.Ably.Shared/Transport/States/Connection/ConnectionStateBase.cs
+++ b/src/IO.Ably.Shared/Transport/States/Connection/ConnectionStateBase.cs
@@ -32,7 +32,7 @@ namespace IO.Ably.Transport.States.Connection
 
         public virtual bool CanSend => false;
 
-        public virtual bool IsUpdate { get; protected set; }
+        public bool IsUpdate { get; protected set; }
 
         public virtual ErrorInfo DefaultErrorInfo => ErrorInfo.ReasonUnknown;
 


### PR DESCRIPTION
Since we have no overrides of `IsUpdate` the easiest fix is to remove it's `virtual`-ness.