### PR TITLE
Fix redundant argument with default value

### DIFF
--- a/src/IO.Ably.Tests.Shared/DefaultTests.cs
+++ b/src/IO.Ably.Tests.Shared/DefaultTests.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using FluentAssertions;
+using Xunit;
 
 namespace IO.Ably.Tests.Shared
 {
@@ -14,7 +15,7 @@ namespace IO.Ably.Tests.Shared
                 "b.ably-realtime.com",
                 "c.ably-realtime.com",
                 "d.ably-realtime.com",
-                "e.ably-realtime.com"
+                "e.ably-realtime.com",
             };
             var fallbackHosts = Defaults.FallbackHosts;
             Assert.Equal(expectedFallBackHosts, fallbackHosts);
@@ -30,10 +31,16 @@ namespace IO.Ably.Tests.Shared
                 "sandbox-b-fallback.ably-realtime.com",
                 "sandbox-c-fallback.ably-realtime.com",
                 "sandbox-d-fallback.ably-realtime.com",
-                "sandbox-e-fallback.ably-realtime.com"
+                "sandbox-e-fallback.ably-realtime.com",
             };
             var fallbackHosts = Defaults.GetEnvironmentFallbackHosts("sandbox");
             Assert.Equal(expectedFallBackHosts, fallbackHosts);
+        }
+
+        [Fact]
+        public void Defaults_ProtocolIsJson()
+        {
+            Defaults.Protocol.Should().Be(Protocol.Json);
         }
     }
 }

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
@@ -547,7 +547,7 @@ namespace IO.Ably.Tests.Rest
                 ["encoding"] = messageData["encoding"],
             };
 
-            var request = new AblyRequest($"/channels/{channelName}/messages", HttpMethod.Post, Protocol.Json)
+            var request = new AblyRequest($"/channels/{channelName}/messages", HttpMethod.Post)
             {
                 RequestBody = rawMessage.ToJson().GetBytes(),
             };
@@ -605,7 +605,7 @@ namespace IO.Ably.Tests.Rest
 
             await Task.Delay(1000);
 
-            var request = new AblyRequest($"/channels/{channelName}/messages", HttpMethod.Get, Protocol.Json);
+            var request = new AblyRequest($"/channels/{channelName}/messages", HttpMethod.Get);
             await client1.AblyAuth.AddAuthHeader(request);
             var response = await httpClient.Execute(request);
 

--- a/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
@@ -397,7 +397,7 @@ namespace IO.Ably.Tests
             // Arrange
             var rest = new AblyRest(ValidKey);
             ApiKey key = ApiKey.Parse(ValidKey);
-            var request = new AblyRequest("/test", HttpMethod.Get, Protocol.Json);
+            var request = new AblyRequest("/test", HttpMethod.Get);
             var expectedValue = "Basic " + key.ToString().ToBase64();
 
             // Act
@@ -416,7 +416,7 @@ namespace IO.Ably.Tests
             // Arrange
             const string tokenValue = "TokenValue";
             var rest = new AblyRest(opts => opts.Token = tokenValue);
-            var request = new AblyRequest("/test", HttpMethod.Get, Protocol.Json);
+            var request = new AblyRequest("/test", HttpMethod.Get);
             var expectedValue = "Bearer " + tokenValue.ToBase64();
 
             // Act
@@ -441,7 +441,7 @@ namespace IO.Ably.Tests
                 opts.Token = tokenValue;
                 opts.Tls = tls;
             });
-            var request = new AblyRequest("/test", HttpMethod.Get, Protocol.Json);
+            var request = new AblyRequest("/test", HttpMethod.Get);
 
             // Act
             await rest.AblyAuth.AddAuthHeader(request);


### PR DESCRIPTION
The parameter `protocol` has the same default value.