### PR TITLE
Fix possible 'NullReferenceException' warning

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -597,7 +597,9 @@ namespace IO.Ably.Tests.Realtime
             var protocolMessage = client.GetTestTransport().ProtocolMessagesReceived.FirstOrDefault(x => x.Action == ProtocolMessage.MessageAction.Connected);
 
             protocolMessage.Should().NotBeNull();
+            Debug.Assert(protocolMessage != null, "Expected a non-null 'TestTransportWrapper', got null");
             protocolMessage.ConnectionId.Should().NotBe(oldConnectionId);
+
             client.Connection.Id.Should().NotBe(oldConnectionId);
             client.Connection.Key.Should().NotBe(oldKey);
             client.Connection.MessageSerial.Should().Be(0);


### PR DESCRIPTION
Unfortunately code-analysis doesn't take into account checks made with the Fluent Assertions library.