### PR TITLE
Update our 'FluentAssertions' dependency

### DIFF
--- a/src/IO.Ably.Tests.DotNetCore20/IO.Ably.Tests.DotNetCore20.csproj
+++ b/src/IO.Ably.Tests.DotNetCore20/IO.Ably.Tests.DotNetCore20.csproj
@@ -87,10 +87,6 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <ReferencePathWithRefAssemblies Update="\Users\tom.kirbygreen\.nuget\packages\fluentassertions\6.2.0\lib\netcoreapp3.0\FluentAssertions.dll" />
-  </ItemGroup>
-
   <Import Project="..\IO.Ably.Tests.Shared\IO.Ably.Tests.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/src/IO.Ably.Tests.DotNetCore20/IO.Ably.Tests.DotNetCore20.csproj
+++ b/src/IO.Ably.Tests.DotNetCore20/IO.Ably.Tests.DotNetCore20.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="FluentAssertions" Version="6.2.0" />
     <PackageReference Include="Microsoft.Build" Version="15.5.180" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MsgPack.Cli" Version="0.9.2" />
@@ -85,6 +85,10 @@
     <EmbeddedResource Include="..\delta-test-messages\4">
       <Link>delta\4</Link>
     </EmbeddedResource>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ReferencePathWithRefAssemblies Update="\Users\tom.kirbygreen\.nuget\packages\fluentassertions\6.2.0\lib\netcoreapp3.0\FluentAssertions.dll" />
   </ItemGroup>
 
   <Import Project="..\IO.Ably.Tests.Shared\IO.Ably.Tests.Shared.projitems" Label="Shared" />

--- a/src/IO.Ably.Tests.NETFramework/IO.Ably.Tests.NETFramework.csproj
+++ b/src/IO.Ably.Tests.NETFramework/IO.Ably.Tests.NETFramework.csproj
@@ -110,7 +110,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions">
-      <Version>5.10.3</Version>
+      <Version>6.2.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Build">
       <Version>15.5.180</Version>

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthorizationTests.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthorizationTests.cs
@@ -149,7 +149,7 @@ namespace IO.Ably.Tests
                 request.KeyName.Should().Be(ApiKey.Parse(client.Options.Key).KeyName);
                 request.Ttl.Should().Be(TimeSpan.FromHours(2));
                 Debug.Assert(request.Timestamp.HasValue, "Expected a 'Value', got none.");
-                request.Timestamp.Value.Should().BeCloseTo(Now.AddMinutes(1));
+                request.Timestamp.Value.Should().BeCloseTo(Now.AddMinutes(1), TimeSpan.FromMilliseconds(100));
                 request.Nonce.Should().Be("defaultnonce");
             }
 
@@ -173,7 +173,7 @@ namespace IO.Ably.Tests
                 request.ClientId.Should().Be("999");
                 request.Ttl.Should().Be(TimeSpan.FromHours(1));
                 Debug.Assert(request.Timestamp.HasValue, "Expected a 'Value', got none.");
-                request.Timestamp.Value.Should().BeCloseTo(Now.AddMinutes(10), 500);
+                request.Timestamp.Value.Should().BeCloseTo(Now.AddMinutes(10), TimeSpan.FromMilliseconds(500));
                 request.Nonce.Should().Be("overrideNonce");
             }
 
@@ -218,7 +218,7 @@ namespace IO.Ably.Tests
             {
                 var request = await CreateTokenRequest(Client);
                 Debug.Assert(request.Timestamp.HasValue, "Expected a 'Value', got none.");
-                request.Timestamp.Value.Should().BeCloseTo(Now, 500);
+                request.Timestamp.Value.Should().BeCloseTo(Now, TimeSpan.FromMilliseconds(500));
             }
 
             [Fact]
@@ -240,7 +240,7 @@ namespace IO.Ably.Tests
                 var authOptions = client.AblyAuth.CurrentAuthOptions;
                 authOptions.QueryTime = true;
                 var data = await CreateTokenRequest(client, null, authOptions);
-                data.Timestamp.Should().BeCloseTo(currentTime);
+                data.Timestamp.Should().BeCloseTo(currentTime, TimeSpan.FromMilliseconds(20));
             }
 
             [Fact]

--- a/src/IO.Ably.Tests.Shared/AuthTests/RequestTokenSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/RequestTokenSpecs.cs
@@ -129,7 +129,7 @@ namespace IO.Ably.Tests.AuthTests
             await client.Auth.RequestTokenAsync(tokenParams);
 
             var data = LastRequest.PostData as TokenRequest;
-            date.Should().BeCloseTo(data.Timestamp.Value);
+            date.Should().BeCloseTo(data.Timestamp.Value, TimeSpan.FromMilliseconds(20));
         }
 
         [Fact]
@@ -141,7 +141,7 @@ namespace IO.Ably.Tests.AuthTests
             await client.Auth.RequestTokenAsync(tokenParams);
 
             var data = LastRequest.PostData as TokenRequest;
-            Now.Should().BeCloseTo(data.Timestamp.Value, 200);
+            Now.Should().BeCloseTo(data.Timestamp.Value, TimeSpan.FromMilliseconds(200));
         }
 
         [Fact]
@@ -158,7 +158,7 @@ namespace IO.Ably.Tests.AuthTests
 
                     // Assert
                     var data = x.PostData as TokenRequest;
-                    data.Timestamp.Should().BeCloseTo(currentTime, 100);
+                    data.Timestamp.Should().BeCloseTo(currentTime, TimeSpan.FromMilliseconds(100));
                     return DummyTokenResponse.ToTask();
                 };
             var tokenParams = new TokenParams

--- a/src/IO.Ably.Tests.Shared/AuthTests/RequestTokenSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/RequestTokenSpecs.cs
@@ -448,7 +448,7 @@ namespace IO.Ably.Tests.AuthTests
 
             var token = await rest.Auth.RequestTokenAsync(tokenRequest, options);
             token.Should().NotBeNull();
-            dateTime.Should().BeWithin(TimeSpan.FromSeconds(1)).After(token.Issued);
+            dateTime.Should().BeCloseTo(token.Issued, TimeSpan.FromSeconds(1));
         }
 
         [Fact]

--- a/src/IO.Ably.Tests.Shared/AuthTests/ServerTimeTests.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/ServerTimeTests.cs
@@ -33,8 +33,9 @@ namespace IO.Ably.Tests.AuthTests
             await testAblyAuth.AuthorizeAsync(tokenParams);
             serverTimeCalled.Should().BeTrue();
             testAblyAuth.GetServerNow().Should().HaveValue();
-            testAblyAuth.GetServerNow()?.Should().BeCloseTo(await testAblyAuth.GetServerTime(), precision: 1000); // Allow 1s clock skew
-            testAblyAuth.GetServerNow()?.Should().BeCloseTo(DateTimeOffset.UtcNow.AddMinutes(30), precision: 1000); // Allow 1s clock skew
+            const int precision = 1000;
+            testAblyAuth.GetServerNow()?.Should().BeCloseTo(await testAblyAuth.GetServerTime(), TimeSpan.FromMilliseconds(precision)); // Allow 1s clock skew
+            testAblyAuth.GetServerNow()?.Should().BeCloseTo(DateTimeOffset.UtcNow.AddMinutes(30), TimeSpan.FromMilliseconds(precision)); // Allow 1s clock skew
         }
 
         [Fact]
@@ -101,7 +102,7 @@ namespace IO.Ably.Tests.AuthTests
 
             // the TokenRequest should not have been set using an offset, but should have been set
             tokenRequest.Timestamp.Should().HaveValue();
-            tokenRequest.Timestamp.Should().BeCloseTo(DateTimeOffset.UtcNow, 1000);
+            tokenRequest.Timestamp.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(1000));
         }
 
         [Fact]
@@ -144,7 +145,7 @@ namespace IO.Ably.Tests.AuthTests
 
             // the TokenRequest timestamp should have been set using the offset
             tokenRequest.Timestamp.Should().HaveValue();
-            tokenRequest.Timestamp.Should().BeCloseTo(await testAblyAuth.GetServerTime(), 1000);
+            tokenRequest.Timestamp.Should().BeCloseTo(await testAblyAuth.GetServerTime(), TimeSpan.FromMilliseconds(1000));
         }
 
         [Fact]
@@ -187,8 +188,9 @@ namespace IO.Ably.Tests.AuthTests
 
             // and we should still be getting calculated offsets
             testAblyAuth.GetServerNow().Should().HaveValue();
-            testAblyAuth.GetServerNow()?.Should().BeCloseTo(await testAblyAuth.GetServerTime(), 1000);
-            testAblyAuth.GetServerNow()?.Should().BeCloseTo(DateTimeOffset.UtcNow.AddMinutes(30), 1000);
+            const int precision = 1000;
+            testAblyAuth.GetServerNow()?.Should().BeCloseTo(await testAblyAuth.GetServerTime(), TimeSpan.FromMilliseconds(precision));
+            testAblyAuth.GetServerNow()?.Should().BeCloseTo(DateTimeOffset.UtcNow.AddMinutes(30), TimeSpan.FromMilliseconds(precision));
         }
 
         public ServerTimeTests(ITestOutputHelper output)

--- a/src/IO.Ably.Tests.Shared/LoggerTests.cs
+++ b/src/IO.Ably.Tests.Shared/LoggerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentAssertions;
+using FluentAssertions.Primitives;
 using Xunit;
 
 namespace IO.Ably.AcceptanceTests
@@ -17,7 +18,7 @@ namespace IO.Ably.AcceptanceTests
                 sink.LastLevel.Should().BeNull();
                 sink.LastMessage.Should().BeNull();
 
-                logger.LogLevel.Should().BeEquivalentTo(Defaults.DefaultLogLevel);
+                logger.LogLevel.Should().Be(Defaults.DefaultLogLevel);
                 logger.LogLevel = LogLevel.Debug;
 
                 // null destination shouldn't throw
@@ -28,15 +29,15 @@ namespace IO.Ably.AcceptanceTests
 
                 // Basic messages
                 logger.Error("Test Error Message");
-                sink.LastLevel.Should().BeEquivalentTo(LogLevel.Error);
+                sink.LastLevel.Should().Be(LogLevel.Error);
                 sink.LastMessage.Should().EndWith("Test Error Message");
 
                 logger.Debug("Test Info Message");
-                sink.LastLevel.Should().BeEquivalentTo(LogLevel.Debug);
+                sink.LastLevel.Should().Be(LogLevel.Debug);
                 sink.LastMessage.Should().EndWith("Test Info Message");
 
                 logger.Debug("Test Debug Message");
-                sink.LastLevel.Should().BeEquivalentTo(LogLevel.Debug);
+                sink.LastLevel.Should().Be(LogLevel.Debug);
                 sink.LastMessage.Should().EndWith("Test Debug Message");
 
                 // Verify the log level works
@@ -44,7 +45,7 @@ namespace IO.Ably.AcceptanceTests
                 logger.Error("Test Error Message");
                 logger.Debug("Test Info Message");
                 logger.Debug("Test Debug Message");
-                sink.LastLevel.Should().BeEquivalentTo(LogLevel.Error);
+                sink.LastLevel.Should().Be(LogLevel.Error);
                 sink.LastMessage.Should().EndWith("Test Error Message");
 
                 // Revert the level
@@ -68,12 +69,12 @@ namespace IO.Ably.AcceptanceTests
             var logger1 = InternalLogger.Create();
             var logger2 = InternalLogger.Create();
 
-            logger1.LogLevel.Should().BeEquivalentTo(logger2.LogLevel);
+            logger1.LogLevel.Should().Be(logger2.LogLevel);
             logger1.LogLevel = LogLevel.Debug;
             logger2.LogLevel = LogLevel.Error;
 
-            logger1.LogLevel.Should().BeEquivalentTo(LogLevel.Debug);
-            logger2.LogLevel.Should().BeEquivalentTo(LogLevel.Error);
+            logger1.LogLevel.Should().Be(LogLevel.Debug);
+            logger2.LogLevel.Should().Be(LogLevel.Error);
             logger1.LogLevel.Should().NotBe(logger2.LogLevel);
         }
 

--- a/src/IO.Ably.Tests.Shared/Push/PushAdminTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/PushAdminTests.cs
@@ -27,7 +27,7 @@ namespace IO.Ably.Tests.Push
                 _ = GetRestClient();
                 PushAdmin.AddDeviceAuthenticationToRequest(request, localDevice);
 
-                request.Headers.Should().ContainKey(Defaults.DeviceIdentityTokenHeader).WhichValue.Should().Be("test");
+                request.Headers.Should().ContainKey(Defaults.DeviceIdentityTokenHeader).WhoseValue.Should().Be("test");
             }
 
             [Fact]
@@ -41,7 +41,7 @@ namespace IO.Ably.Tests.Push
                 _ = GetRestClient();
                 PushAdmin.AddDeviceAuthenticationToRequest(request, localDevice);
 
-                request.Headers.Should().ContainKey(Defaults.DeviceSecretHeader).WhichValue.Should().Be("test");
+                request.Headers.Should().ContainKey(Defaults.DeviceSecretHeader).WhoseValue.Should().Be("test");
             }
 
             [Fact]
@@ -54,7 +54,7 @@ namespace IO.Ably.Tests.Push
                 _ = GetRestClient();
                 PushAdmin.AddDeviceAuthenticationToRequest(request, localDevice);
 
-                request.Headers.Should().ContainKey(Defaults.DeviceIdentityTokenHeader).WhichValue.Should().Be("test");
+                request.Headers.Should().ContainKey(Defaults.DeviceIdentityTokenHeader).WhoseValue.Should().Be("test");
                 request.Headers.Should().NotContainKey(Defaults.DeviceSecretHeader);
             }
 
@@ -232,11 +232,11 @@ namespace IO.Ably.Tests.Push
 
                 var deviceIdRequest = await ListDevices(ListDeviceDetailsRequest.WithDeviceId("123"));
                 deviceIdRequest.Url.Should().Be("/push/deviceRegistrations");
-                deviceIdRequest.QueryParameters.Should().ContainKey("deviceId").WhichValue.Should().Be("123");
+                deviceIdRequest.QueryParameters.Should().ContainKey("deviceId").WhoseValue.Should().Be("123");
 
                 var clientIdRequest = await ListDevices(ListDeviceDetailsRequest.WithClientId("234"));
                 clientIdRequest.Url.Should().Be("/push/deviceRegistrations");
-                clientIdRequest.QueryParameters.Should().ContainKey("clientId").WhichValue.Should().Be("234");
+                clientIdRequest.QueryParameters.Should().ContainKey("clientId").WhoseValue.Should().Be("234");
             }
 
             [Fact]
@@ -369,8 +369,8 @@ namespace IO.Ably.Tests.Push
                     });
 
                 currentRequest.Url.Should().Be("/push/deviceRegistrations");
-                currentRequest.QueryParameters.Should().ContainKey("deviceId").WhichValue.Should().Be("test");
-                currentRequest.QueryParameters.Should().ContainKey("random").WhichValue.Should().Be("boo");
+                currentRequest.QueryParameters.Should().ContainKey("deviceId").WhoseValue.Should().Be("test");
+                currentRequest.QueryParameters.Should().ContainKey("random").WhoseValue.Should().Be("boo");
             }
 
             [Fact]
@@ -391,7 +391,7 @@ namespace IO.Ably.Tests.Push
                         { "deviceId", "123" },
                     });
 
-                currentRequest.Headers.Should().ContainKey(Defaults.DeviceIdentityTokenHeader).WhichValue.Should().Be("token");
+                currentRequest.Headers.Should().ContainKey(Defaults.DeviceIdentityTokenHeader).WhoseValue.Should().Be("token");
             }
 
             public DeviceRegistrationTests(ITestOutputHelper output)
@@ -437,23 +437,23 @@ namespace IO.Ably.Tests.Push
                 }
 
                 var emptyFilterRequest = await CallList(ListSubscriptionsRequest.Empty(100));
-                emptyFilterRequest.QueryParameters.Should().ContainKey("limit").WhichValue.Should().Be("100");
+                emptyFilterRequest.QueryParameters.Should().ContainKey("limit").WhoseValue.Should().Be("100");
 
                 var channelDeviceIdRequest =
                     await CallList(ListSubscriptionsRequest.WithDeviceId("test-channel", "device123"));
 
                 channelDeviceIdRequest.QueryParameters.Should().ContainKey("channel")
-                    .WhichValue.Should().Be("test-channel");
+                    .WhoseValue.Should().Be("test-channel");
                 channelDeviceIdRequest.QueryParameters.Should().ContainKey("deviceId")
-                    .WhichValue.Should().Be("device123");
+                    .WhoseValue.Should().Be("device123");
 
                 var channelClientIdRequest =
                     await CallList(ListSubscriptionsRequest.WithClientId("test-channel", "clientId123"));
 
                 channelClientIdRequest.QueryParameters.Should().ContainKey("channel")
-                    .WhichValue.Should().Be("test-channel");
+                    .WhoseValue.Should().Be("test-channel");
                 channelClientIdRequest.QueryParameters.Should().ContainKey("clientId")
-                    .WhichValue.Should().Be("clientId123");
+                    .WhoseValue.Should().Be("clientId123");
             }
 
             [Fact]
@@ -477,7 +477,7 @@ namespace IO.Ably.Tests.Push
                 request.Url.Should().Be("/push/channels");
 
                 var limitRequest = await CallListChannels(new PaginatedRequestParams { Limit = 150 });
-                limitRequest.QueryParameters.Should().ContainKey("limit").WhichValue.Should().Be("150");
+                limitRequest.QueryParameters.Should().ContainKey("limit").WhoseValue.Should().Be("150");
             }
 
             [Fact]
@@ -547,7 +547,7 @@ namespace IO.Ably.Tests.Push
                 var sub = PushChannelSubscription.ForDevice("test", "123");
                 await rest.Push.Admin.ChannelSubscriptions.SaveAsync(sub);
 
-                request.Headers.Should().ContainKey(Defaults.DeviceIdentityTokenHeader).WhichValue.Should().Be("token");
+                request.Headers.Should().ContainKey(Defaults.DeviceIdentityTokenHeader).WhoseValue.Should().Be("token");
             }
 
             [Fact]
@@ -571,13 +571,13 @@ namespace IO.Ably.Tests.Push
                 request.Url.Should().Be("/push/channelSubscriptions");
                 request.Method.Should().Be(HttpMethod.Delete);
 
-                request.QueryParameters.Should().ContainKey("channel").WhichValue.Should().Be("channel");
-                request.QueryParameters.Should().ContainKey("deviceId").WhichValue.Should().Be("device");
+                request.QueryParameters.Should().ContainKey("channel").WhoseValue.Should().Be("channel");
+                request.QueryParameters.Should().ContainKey("deviceId").WhoseValue.Should().Be("device");
 
                 var requestWithClientId = await CallRemove(PushChannelSubscription.ForClientId("channel", "123"));
 
-                requestWithClientId.QueryParameters.Should().ContainKey("channel").WhichValue.Should().Be("channel");
-                requestWithClientId.QueryParameters.Should().ContainKey("clientId").WhichValue.Should().Be("123");
+                requestWithClientId.QueryParameters.Should().ContainKey("channel").WhoseValue.Should().Be("channel");
+                requestWithClientId.QueryParameters.Should().ContainKey("clientId").WhoseValue.Should().Be("123");
             }
 
             [Fact]
@@ -604,12 +604,12 @@ namespace IO.Ably.Tests.Push
 
                 var requestWithChannelAndDeviceId = await CallRemoveWhere(new Dictionary<string, string>() { { "channel", "test" }, { "deviceId", "best" } });
 
-                requestWithChannelAndDeviceId.QueryParameters.Should().ContainKey("channel").WhichValue.Should().Be("test");
-                requestWithChannelAndDeviceId.QueryParameters.Should().ContainKey("deviceId").WhichValue.Should().Be("best");
+                requestWithChannelAndDeviceId.QueryParameters.Should().ContainKey("channel").WhoseValue.Should().Be("test");
+                requestWithChannelAndDeviceId.QueryParameters.Should().ContainKey("deviceId").WhoseValue.Should().Be("best");
 
                 var requestWithRandomParameter = await CallRemoveWhere(new Dictionary<string, string>() { { "random", "value" } });
 
-                requestWithRandomParameter.QueryParameters.Should().ContainKey("random").WhichValue.Should().Be("value");
+                requestWithRandomParameter.QueryParameters.Should().ContainKey("random").WhoseValue.Should().Be("value");
             }
 
             public ChannelSubscriptionsTests(ITestOutputHelper output)

--- a/src/IO.Ably.Tests.Shared/Push/PushChannelTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/PushChannelTests.cs
@@ -167,7 +167,7 @@ namespace IO.Ably.Tests.Push
 
                 async Task<AblyResponse> RequestHandler(AblyRequest request)
                 {
-                    request.Headers.Should().ContainKey(Defaults.DeviceIdentityTokenHeader).WhichValue.Should()
+                    request.Headers.Should().ContainKey(Defaults.DeviceIdentityTokenHeader).WhoseValue.Should()
                         .Be(deviceIdentityToken);
 
                     taskAwaiter.SetCompleted();
@@ -288,12 +288,12 @@ namespace IO.Ably.Tests.Push
                     request.Url.Should().Be("/push/channelSubscriptions");
                     request.Method.Should().Be(HttpMethod.Delete);
                     var queryParams = request.QueryParameters;
-                    queryParams.Should().ContainKey("deviceId").WhichValue.Should().Be(deviceId);
-                    queryParams.Should().ContainKey("channel").WhichValue.Should().Be(channelName);
+                    queryParams.Should().ContainKey("deviceId").WhoseValue.Should().Be(deviceId);
+                    queryParams.Should().ContainKey("channel").WhoseValue.Should().Be(channelName);
                     queryParams.Should().NotContainKey("clientId");
 
                     // Check the auth header RSH7c3
-                    request.Headers.Should().ContainKey(Defaults.DeviceIdentityTokenHeader).WhichValue.Should()
+                    request.Headers.Should().ContainKey(Defaults.DeviceIdentityTokenHeader).WhoseValue.Should()
                         .Be(deviceIdentityToken);
 
                     taskAwaiter.SetCompleted();
@@ -358,8 +358,8 @@ namespace IO.Ably.Tests.Push
                     request.Url.Should().Be("/push/channelSubscriptions");
                     request.Method.Should().Be(HttpMethod.Delete);
                     var queryParams = request.QueryParameters;
-                    queryParams.Should().ContainKey("clientId").WhichValue.Should().Be(clientId);
-                    queryParams.Should().ContainKey("channel").WhichValue.Should().Be(channelName);
+                    queryParams.Should().ContainKey("clientId").WhoseValue.Should().Be(clientId);
+                    queryParams.Should().ContainKey("channel").WhoseValue.Should().Be(channelName);
                     queryParams.Should().NotContainKey("deviceId");
 
                     taskAwaiter.SetCompleted();
@@ -397,10 +397,10 @@ namespace IO.Ably.Tests.Push
                     request.Url.Should().Be("/push/channelSubscriptions");
                     request.Method.Should().Be(HttpMethod.Get);
                     var queryParams = request.QueryParameters;
-                    queryParams.Should().ContainKey("clientId").WhichValue.Should().Be(clientId);
-                    queryParams.Should().ContainKey("channel").WhichValue.Should().Be(channelName);
-                    queryParams.Should().ContainKey("deviceId").WhichValue.Should().Be(deviceid);
-                    queryParams.Should().ContainKey("concatFilters").WhichValue.Should().Be("true");
+                    queryParams.Should().ContainKey("clientId").WhoseValue.Should().Be(clientId);
+                    queryParams.Should().ContainKey("channel").WhoseValue.Should().Be(channelName);
+                    queryParams.Should().ContainKey("deviceId").WhoseValue.Should().Be(deviceid);
+                    queryParams.Should().ContainKey("concatFilters").WhoseValue.Should().Be("true");
 
                     taskAwaiter.SetCompleted();
                     return new AblyResponse { TextResponse = JsonConvert.SerializeObject(new List<PushChannelSubscription>()) };

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSandboxSpecs.cs
@@ -33,7 +33,7 @@ namespace IO.Ably.Tests.Realtime
 
             // Assert
             target.Name.Should().BeEquivalentTo("test");
-            target.State.Should().BeEquivalentTo(ChannelState.Initialized);
+            target.State.Should().Be(ChannelState.Initialized);
         }
 
         [Theory]
@@ -57,15 +57,15 @@ namespace IO.Ably.Tests.Realtime
             // Assert
             signal.WaitOne(10000);
             stateChanges.Count.Should().Be(1);
-            stateChanges[0].Current.Should().BeEquivalentTo(ChannelState.Attaching);
+            stateChanges[0].Current.Should().Be(ChannelState.Attaching);
             stateChanges[0].Error.Should().BeNull();
-            target.State.Should().BeEquivalentTo(ChannelState.Attaching);
+            target.State.Should().Be(ChannelState.Attaching);
 
             signal.WaitOne(10000);
             stateChanges.Count.Should().Be(2);
-            stateChanges[1].Current.Should().BeEquivalentTo(ChannelState.Attached);
+            stateChanges[1].Current.Should().Be(ChannelState.Attached);
             stateChanges[1].Error.Should().BeNull();
-            target.State.Should().BeEquivalentTo(ChannelState.Attached);
+            target.State.Should().Be(ChannelState.Attached);
         }
 
         [Theory]
@@ -202,7 +202,7 @@ namespace IO.Ably.Tests.Realtime
             await channel.AttachAsync();
 
             channel.Modes.Should().HaveCount(2);
-            channel.Modes.Should().BeEquivalentTo(ChannelMode.Presence, ChannelMode.Subscribe);
+            channel.Modes.Should().BeEquivalentTo(new[] { ChannelMode.Presence, ChannelMode.Subscribe });
         }
 
         [Theory]
@@ -1187,7 +1187,7 @@ namespace IO.Ably.Tests.Realtime
             stateChange2.Error.Message.Should().StartWith("Channel didn't attach within");
 
             // retry should happen after ChannelRetryTimeout has elapsed (TL3l7)
-            (end - start).Should().BeCloseTo(requestTimeout, 500);
+            (end - start).Should().BeCloseTo(requestTimeout, TimeSpan.FromMilliseconds(500));
 
             client.Close();
         }
@@ -1273,7 +1273,7 @@ namespace IO.Ably.Tests.Realtime
             stateChange2.Error.Message.Should().Be(detachedMessage.Error.Message);
 
             // retry should happen after SuspendedRetryTimeout has elapsed
-            (end - start).Should().BeCloseTo(requestTimeout, 2000);
+            (end - start).Should().BeCloseTo(requestTimeout, TimeSpan.FromMilliseconds(2000));
         }
 
         [Theory]

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelSpecs.cs
@@ -1604,7 +1604,7 @@ namespace IO.Ably.Tests.Realtime
 
                 LastRequest.QueryParameters.Should()
                     .ContainKey("fromSerial")
-                    .WhichValue.Should().Be("101");
+                    .WhoseValue.Should().Be("101");
             }
 
             [Fact]

--- a/src/IO.Ably.Tests.Shared/Realtime/ChannelsSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ChannelsSpecs.cs
@@ -244,7 +244,7 @@ namespace IO.Ably.Tests.Realtime
             var channel7 = client.Channels.Get("test7");
 
             client.Channels.Should().HaveCount(6);
-            client.Channels.Should().BeEquivalentTo(channel1, channel2, channel4, channel5, channel6, channel7);
+            client.Channels.Should().BeEquivalentTo(new[] { channel1, channel2, channel4, channel5, channel6, channel7 });
         }
 
         [Fact]

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailureSpecs.cs
@@ -68,7 +68,7 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
             var currentToken = client.RestClient.AblyAuth.CurrentToken;
             currentToken.Token.Should().Be(_returnedDummyTokenDetails.Token);
             currentToken.ClientId.Should().Be(_returnedDummyTokenDetails.ClientId);
-            currentToken.Expires.Should().BeCloseTo(_returnedDummyTokenDetails.Expires);
+            currentToken.Expires.Should().BeCloseTo(_returnedDummyTokenDetails.Expires, TimeSpan.FromMilliseconds(20));
             raisedErrors.Should().BeEmpty("No errors should be raised!");
         }
 
@@ -267,7 +267,7 @@ namespace IO.Ably.Tests.Realtime.ConnectionSpecs
             client.ExecuteCommand(SetSuspendedStateCommand.Create(ErrorInfo.ReasonSuspended));
 
             var elapsed = await client.WaitForState(ConnectionState.Connecting);
-            elapsed.Should().BeCloseTo(client.Options.SuspendedRetryTimeout, 1000);
+            elapsed.Should().BeCloseTo(client.Options.SuspendedRetryTimeout, TimeSpan.FromMilliseconds(1000));
         }
 
         private static Task WaitForConnectingOrSuspended(AblyRealtime client)

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionFailuresOnceConnectedSpecs.cs
@@ -72,7 +72,7 @@ namespace IO.Ably.Tests.Realtime
             var currentToken = client.RestClient.AblyAuth.CurrentToken;
             currentToken.Token.Should().Be(_returnedDummyTokenDetails.Token);
             currentToken.ClientId.Should().Be(_returnedDummyTokenDetails.ClientId);
-            currentToken.Expires.Should().BeCloseTo(_returnedDummyTokenDetails.Expires);
+            currentToken.Expires.Should().BeCloseTo(_returnedDummyTokenDetails.Expires, TimeSpan.Zero);
         }
 
         [Fact(Skip = "Intermittently fails")]
@@ -212,9 +212,9 @@ namespace IO.Ably.Tests.Realtime
 
             var urlParams = LastCreatedTransport.Parameters.GetParams();
             urlParams.Should().ContainKey("resume")
-                .WhichValue.Should().Be(connectionKey);
+                .WhoseValue.Should().Be(connectionKey);
             urlParams.Should().ContainKey("connection_serial")
-                .WhichValue.Should().Be(serial.ToString());
+                .WhoseValue.Should().Be(serial.ToString());
             LastCreatedTransport.Should().NotBeSameAs(firstTransport);
         }
 

--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionParameterSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/ConnectionParameterSpecs.cs
@@ -33,7 +33,7 @@ namespace IO.Ably.Tests.Realtime
 #pragma warning disable 162
             _ = GetClientWithFakeTransport(opts => opts.UseBinaryProtocol = useBinary);
             LastCreatedTransport.Parameters.UseBinaryProtocol.Should().Be(useBinary);
-            LastCreatedTransport.Parameters.GetParams().Should().ContainKey("format").WhichValue.Should().Be(format);
+            LastCreatedTransport.Parameters.GetParams().Should().ContainKey("format").WhoseValue.Should().Be(format);
 #pragma warning restore 162
         }
 
@@ -48,7 +48,7 @@ namespace IO.Ably.Tests.Realtime
             LastCreatedTransport.Parameters.EchoMessages.Should().Be(echo);
             LastCreatedTransport.Parameters.GetParams()
                 .Should().ContainKey("echo")
-                .WhichValue.Should().Be(echo.ToString().ToLower());
+                .WhoseValue.Should().Be(echo.ToString().ToLower());
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace IO.Ably.Tests.Realtime
             LastCreatedTransport.Parameters.ClientId.Should().Be(clientId);
             LastCreatedTransport.Parameters.GetParams()
                 .Should().ContainKey("clientId")
-                .WhichValue.Should().Be(clientId);
+                .WhoseValue.Should().Be(clientId);
         }
 
         [Fact]
@@ -84,7 +84,7 @@ namespace IO.Ably.Tests.Realtime
         {
             var client = await GetConnectedClient();
             LastCreatedTransport.Parameters.AuthValue.Should().Be(client.Options.Key);
-            LastCreatedTransport.Parameters.GetParams().Should().ContainKey("key").WhichValue.Should().Be(client.Options.Key);
+            LastCreatedTransport.Parameters.GetParams().Should().ContainKey("key").WhoseValue.Should().Be(client.Options.Key);
         }
 
         [Fact]
@@ -104,7 +104,7 @@ namespace IO.Ably.Tests.Realtime
             LastCreatedTransport.Parameters.AuthValue.Should().Be(tokenString);
             LastCreatedTransport.Parameters.GetParams()
                 .Should().ContainKey("accessToken")
-                .WhichValue.Should().Be(tokenString);
+                .WhoseValue.Should().Be(tokenString);
         }
 
         [Fact]
@@ -115,7 +115,7 @@ namespace IO.Ably.Tests.Realtime
 
             LastCreatedTransport.Parameters.GetParams()
                 .Should().ContainKey("v")
-                .WhichValue.Should().Be(Defaults.ProtocolVersion);
+                .WhoseValue.Should().Be(Defaults.ProtocolVersion);
         }
 
         [Fact]

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -133,7 +133,7 @@ namespace IO.Ably.Tests.Realtime
                 var channel = client.Channels.Get(channelName);
                 await channel.AttachAsync();
 
-                channel.State.Should().BeEquivalentTo(ChannelState.Attached);
+                channel.State.Should().Be(ChannelState.Attached);
 
                 const string wontPass = "Won't pass newness test";
 
@@ -238,14 +238,14 @@ namespace IO.Ably.Tests.Realtime
                     PresenceMessage factualMsg = n < presenceMessages.Count ? presenceMessages[n++] : null;
                     factualMsg.Should().NotBeNull();
                     factualMsg.Id.Should().BeEquivalentTo(testMsg.Id);
-                    factualMsg.Action.Should().BeEquivalentTo(testMsg.Action, "message was not emitted on the presence object with original action");
+                    factualMsg.Action.Should().Be(testMsg.Action, "message was not emitted on the presence object with original action");
                     var presentMessage = await channel.Presence.GetAsync(new Presence.GetParams
                     {
                         ClientId = testMsg.ClientId,
                         WaitForSync = false
                     });
                     presentMessage.FirstOrDefault().Should().NotBeNull();
-                    presentMessage.FirstOrDefault()?.Action.Should().BeEquivalentTo(PresenceAction.Present, "message was not added to the presence map and stored with PRESENT action");
+                    presentMessage.FirstOrDefault()?.Action.Should().Be(PresenceAction.Present, "message was not added to the presence map and stored with PRESENT action");
                 }
 
                 presenceMessages.Count.Should().Be(n, "the number of messages received didn't match the number of test messages sent.");
@@ -255,12 +255,12 @@ namespace IO.Ably.Tests.Realtime
 
                 var client2 = await GetRealtimeClient(protocol);
                 await client2.WaitForState(ConnectionState.Connected);
-                client2.Connection.State.Should().BeEquivalentTo(ConnectionState.Connected);
+                client2.Connection.State.Should().Be(ConnectionState.Connected);
 
                 var channel2 = client2.Channels.Get(channel2Name);
                 channel2.Attach();
                 await channel2.WaitForAttachedState();
-                channel2.State.Should().BeEquivalentTo(ChannelState.Attached);
+                channel2.State.Should().Be(ChannelState.Attached);
 
                 /* Send all the presence data in one SYNC message without channelSerial (RTP18c) */
                 ProtocolMessage syncMessage = new ProtocolMessage
@@ -288,7 +288,7 @@ namespace IO.Ably.Tests.Realtime
                 for (int i = 0; i < syncPresenceMessages.Count; i++)
                 {
                     syncPresenceMessages[i].Id.Should().BeEquivalentTo(presenceMessages[i].Id, "result should be the same in case of SYNC");
-                    syncPresenceMessages[i].Action.Should().BeEquivalentTo(presenceMessages[i].Action, "result should be the same in case of SYNC");
+                    syncPresenceMessages[i].Action.Should().Be(presenceMessages[i].Action, "result should be the same in case of SYNC");
                 }
             }
 
@@ -673,7 +673,7 @@ namespace IO.Ably.Tests.Realtime
 
                 var channel = client.Channels.Get(channelName);
                 await channel.AttachAsync();
-                channel.State.Should().BeEquivalentTo(ChannelState.Attached);
+                channel.State.Should().Be(ChannelState.Attached);
 
                 static PresenceMessage[] TestPresence1()
                 {
@@ -829,7 +829,7 @@ namespace IO.Ably.Tests.Realtime
                     PresenceMessage factualMsg = presenceMessagesLog[i];
                     PresenceMessage correctMsg = correctPresenceHistory[i];
                     factualMsg.ClientId.Should().BeEquivalentTo(correctMsg.ClientId);
-                    factualMsg.Action.Should().BeEquivalentTo(correctMsg.Action);
+                    factualMsg.Action.Should().Be(correctMsg.Action);
                 }
             }
 
@@ -1039,7 +1039,7 @@ namespace IO.Ably.Tests.Realtime
                     {
                         leaveMsg.ClientId.Should().StartWith("local");
                         leaveMsg.Action.Should().Be(PresenceAction.Leave, "Action should be leave");
-                        leaveMsg.Timestamp.Should().BeCloseTo(DateTime.UtcNow, 200, "timestamp should be current time");
+                        leaveMsg.Timestamp.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMilliseconds(200), "timestamp should be current time");
                         leaveMsg.Id.Should().BeNull("Id should be null");
                         leaveCount++;
                         partialDone(); // should be called twice
@@ -1068,12 +1068,12 @@ namespace IO.Ably.Tests.Realtime
 
                 var client = await GetRealtimeClient(protocol);
                 await client.WaitForState(ConnectionState.Connected);
-                client.Connection.State.Should().BeEquivalentTo(ConnectionState.Connected);
+                client.Connection.State.Should().Be(ConnectionState.Connected);
 
                 var channel = client.Channels.Get(channelName);
                 channel.Attach();
                 await channel.WaitForAttachedState();
-                channel.State.Should().BeEquivalentTo(ChannelState.Attached);
+                channel.State.Should().Be(ChannelState.Attached);
 
                 static PresenceMessage[] TestPresence1()
                 {

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSandboxSpecs.cs
@@ -505,7 +505,7 @@ namespace IO.Ably.Tests.Rest
             var loggerSink = new TestLoggerSink();
             ILogger logger = InternalLogger.Create(LogLevel.Error, loggerSink);
 
-            logger.LogLevel.Should().BeEquivalentTo(LogLevel.Error);
+            logger.LogLevel.Should().Be(LogLevel.Error);
             logger.IsDebug.Should().Be(false);
 
             var client = await GetRestClient(protocol, options =>

--- a/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/ChannelSpecs.cs
@@ -39,7 +39,7 @@ namespace IO.Ably.Tests.Rest
                 client.Channels.Release("test2");
                 var channel7 = client.Channels.Get("test7");
 
-                client.Channels.Should().BeEquivalentTo(channel1, channel2, channel4, channel5, channel6, channel7);
+                client.Channels.Should().BeEquivalentTo(new[] { channel1, channel2, channel4, channel5, channel6, channel7 });
             }
 
             [Fact]
@@ -170,7 +170,7 @@ namespace IO.Ably.Tests.Rest
                 LastRequest.Url.Should().Be($"/channels/{channel.Name}/messages");
                 var postedMessages = LastRequest.PostData as List<Message>;
                 postedMessages.Should().HaveCount(3);
-                postedMessages.Should().BeEquivalentTo(message, message1, message2);
+                postedMessages.Should().BeEquivalentTo(new[] { message, message1, message2 });
             }
 
             [Fact]

--- a/src/IO.Ably.Tests.Shared/Rest/RestSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestSandBoxSpecs.cs
@@ -35,7 +35,7 @@ namespace IO.Ably.Tests
 
             // server time should be similar to the system time
             // here we allow the system clock to be 15 minutes fast or slow
-            serverTime.Should().BeCloseTo(DateTimeOffset.UtcNow, (int)TimeSpan.FromMinutes(15).TotalMilliseconds);
+            serverTime.Should().BeCloseTo(DateTimeOffset.UtcNow, TimeSpan.FromMinutes(15));
 
             // server time is UTC so there should be no time zone offset
             serverTime.Offset.Ticks.Should().Be(0);

--- a/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
@@ -200,7 +200,7 @@ namespace IO.Ably.Tests
 
                 await client.StatsAsync();
 
-                client.AblyAuth.CurrentToken.Expires.Should().BeCloseTo(_returnedDummyTokenDetails.Expires);
+                client.AblyAuth.CurrentToken.Expires.Should().BeCloseTo(_returnedDummyTokenDetails.Expires, TimeSpan.FromMilliseconds(20));
                 client.AblyAuth.CurrentToken.ClientId.Should().Be(_returnedDummyTokenDetails.ClientId);
             }
 


### PR DESCRIPTION
Update our `FluentAssertions` dependency from `5.10.3` to the latest `6.2.0`.

As the `FluentAssertions` API has changed in places some interventions on our side were needed on our side.

Note that in the `5.10.3` API the precision when comparing dates and times was represented as an `int` with a default value of 20 (milliseconds).