### PR TITLE
'PushRealtime' Fix .NET 6 build error

### DIFF
--- a/src/IO.Ably.Shared/Push/PushRealtime.cs
+++ b/src/IO.Ably.Shared/Push/PushRealtime.cs
@@ -6,7 +6,7 @@ namespace IO.Ably.Push
     /// <summary>
     /// Push Apis for Realtime clients.
     /// </summary>
-    public class PushRealtime : IDisposable
+    public sealed class PushRealtime : IDisposable
     {
         private readonly AblyRest _restClient;
         private readonly ILogger _logger;


### PR DESCRIPTION
Fixes
[CA1063](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1063)
when building for .NET 6.0.100 .

This relates to the GitHub Issues:
[1007](https://github.com/ably/ably-dotnet/issues/1007),
[523](https://github.com/ably/ably-dotnet/issues/523)