### PR TITLE
'AcivationStateMachine' fix .NET 6 build error

### DIFF
--- a/src/IO.Ably.Shared/Push/ActivationStateMachine.cs
+++ b/src/IO.Ably.Shared/Push/ActivationStateMachine.cs
@@ -8,7 +8,7 @@ using IO.Ably.Utils;
 
 namespace IO.Ably.Push
 {
-    internal partial class ActivationStateMachine
+    internal partial class ActivationStateMachine : IDisposable
     {
         private readonly SemaphoreSlim _handleEventsLock = new SemaphoreSlim(1, 1);
         private readonly AblyRest _restClient;
@@ -393,6 +393,21 @@ namespace IO.Ably.Push
         {
             CurrentState = new NotActivated(this);
             PendingEvents.Clear();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                // Dispose managed resources.
+                _handleEventsLock.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
Fixes
[CA1001](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1001) when building for .NET 6.0.100 .

This relates to the GitHub Issues: [1007](https://github.com/ably/ably-dotnet/issues/1007), [523](https://github.com/ably/ably-dotnet/issues/523)