### PR TITLE
'Handlers' fix .NET 6 build error

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Handlers.cs
+++ b/src/IO.Ably.Shared/Realtime/Handlers.cs
@@ -1,11 +1,13 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Newtonsoft.Json.Linq;
 
 namespace IO.Ably.Realtime
 {
-    internal class Handlers<T> where T : IMessage
+    internal class Handlers<T> : IDisposable
+        where T : IMessage
     {
         private readonly List<MessageHandlerAction<T>> _handlers = new List<MessageHandlerAction<T>>();
         private readonly Dictionary<string, List<MessageHandlerAction<T>>> _specificHandlers = new Dictionary<string, List<MessageHandlerAction<T>>>();
@@ -151,6 +153,11 @@ namespace IO.Ably.Realtime
             }
 
             return state;
+        }
+
+        public void Dispose()
+        {
+            _lock.Dispose();
         }
     }
 }


### PR DESCRIPTION
Fixes [CA1001](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1001) when building for .NET 6.0.100 .

This relates to the GitHub Issues: [1007](https://github.com/ably/ably-dotnet/issues/1007), [523](https://github.com/ably/ably-dotnet/issues/523)