### PR TITLE
'PushAdmin' fix .NET 6 build error

### DIFF
--- a/src/IO.Ably.Shared/Push/PushAdmin.cs
+++ b/src/IO.Ably.Shared/Push/PushAdmin.cs
@@ -12,7 +12,7 @@ namespace IO.Ably.Push
     /// <summary>
     /// Push Admin APIs.
     /// </summary>
-    public class PushAdmin : IPushChannelSubscriptions, IDeviceRegistrations
+    public sealed class PushAdmin : IPushChannelSubscriptions, IDeviceRegistrations
     {
         private const string ChannelSubUrl = "/push/channelSubscriptions";
 


### PR DESCRIPTION
Fixes [CA1033](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1033) when building for .NET 6.0.100 .

This relates to the GitHub Issues: [1007](https://github.com/ably/ably-dotnet/issues/1007), [523](https://github.com/ably/ably-dotnet/issues/523)