### PR TITLE
'RealtimeChannels' fix .NET 6 build error

### DIFF
--- a/src/IO.Ably.Shared/Realtime/RealtimeChannels.cs
+++ b/src/IO.Ably.Shared/Realtime/RealtimeChannels.cs
@@ -189,16 +189,16 @@ namespace IO.Ably.Realtime
         }
 
         /// <inheritdoc/>
-        IEnumerator<IRealtimeChannel> IEnumerable<IRealtimeChannel>.GetEnumerator()
-        {
-            lock (_orderedChannels)
-            {
-                return _orderedChannels.ToList().GetEnumerator();
-            }
-        }
+        IEnumerator<IRealtimeChannel> IEnumerable<IRealtimeChannel>.GetEnumerator() => GetEnumerator();
 
         /// <inheritdoc/>
-        IEnumerator IEnumerable.GetEnumerator()
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the channel collection.
+        /// </summary>
+        /// <returns>An object that can be used to iterate through the channel collection.</returns>
+        protected IEnumerator<IRealtimeChannel> GetEnumerator()
         {
             lock (_orderedChannels)
             {


### PR DESCRIPTION
Fixes [CA1033](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1033) when building for .NET 6.0.100 .

This relates to the GitHub Issues: [1007](https://github.com/ably/ably-dotnet/issues/1007), [523](https://github.com/ably/ably-dotnet/issues/523)