### PR TITLE
'AblyRealtime' fix .NET build error

### DIFF
--- a/src/IO.Ably.Shared/AblyRealtime.cs
+++ b/src/IO.Ably.Shared/AblyRealtime.cs
@@ -219,7 +219,7 @@ namespace IO.Ably
         /// Once disposed, it closes the connection and the library can't be used again.
         /// </summary>
         /// <param name="disposing">Whether the dispose method triggered it directly.</param>
-        protected void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
             if (Disposed)
             {


### PR DESCRIPTION
We can't just apply`sealed` to `AblyRealtime` since this would be a breaking change, rather we have to add `virtual` just in case anyone has derived from the type [CA1001](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1001).

This relates to the GitHub Issues: [1007](https://github.com/ably/ably-dotnet/issues/1007), [523](https://github.com/ably/ably-dotnet/issues/523)