### PR TITLE
'RestChannel' fix .NET 6 build error

### DIFF
--- a/src/IO.Ably.Shared/Rest/RestChannel.cs
+++ b/src/IO.Ably.Shared/Rest/RestChannel.cs
@@ -135,7 +135,14 @@ namespace IO.Ably.Rest
         }
 
         /// <inheritdoc/>
-        Task<PaginatedResult<PresenceMessage>> IPresence.GetAsync(PaginatedRequestParams query)
+        Task<PaginatedResult<PresenceMessage>> IPresence.GetAsync(PaginatedRequestParams query) => GetAsync(query);
+
+        /// <summary>
+        /// Obtain the set of members currently present for a channel.
+        /// </summary>
+        /// <param name="query"><see cref="PaginatedRequestParams"/> query.</param>
+        /// <returns><see cref="PaginatedResult{T}"/> of Presence messages.</returns>
+        protected virtual Task<PaginatedResult<PresenceMessage>> GetAsync(PaginatedRequestParams query)
         {
             if (query == null)
             {


### PR DESCRIPTION
Fixes [CA1033](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1033) when building for .NET 6.0.100 .

This relates to the GitHub Issues: [1007](https://github.com/ably/ably-dotnet/issues/1007), [523](https://github.com/ably/ably-dotnet/issues/523)