### PR TITLE
'RestChannels' fix .NET 6 build error

### DIFF
--- a/src/IO.Ably.Shared/Rest/RestChannels.cs
+++ b/src/IO.Ably.Shared/Rest/RestChannels.cs
@@ -88,16 +88,16 @@ namespace IO.Ably.Rest
         }
 
         /// <inheritdoc/>
-        IEnumerator<IRestChannel> IEnumerable<IRestChannel>.GetEnumerator()
-        {
-            lock (_orderedChannels)
-            {
-                return _orderedChannels.ToList().GetEnumerator();
-            }
-        }
+        IEnumerator<IRestChannel> IEnumerable<IRestChannel>.GetEnumerator() => GetEnumerator();
 
         /// <inheritdoc/>
-        IEnumerator IEnumerable.GetEnumerator()
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the channels collection.
+        /// </summary>
+        /// <returns>An enumerator that can be used to iterate through the channels collection.</returns>
+        protected virtual IEnumerator<IRestChannel> GetEnumerator()
         {
             lock (_orderedChannels)
             {


### PR DESCRIPTION
Fixes [CA1033](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1033) when building for .NET 6.0.100 .

This relates to the GitHub Issues: [1007](https://github.com/ably/ably-dotnet/issues/1007), [523](https://github.com/ably/ably-dotnet/issues/523)