### PR TITLE
'MsWebSocketConnection' Disable .NET 6 build error

### DIFF
--- a/src/IO.Ably.Shared/Transport/MsWebSocketConnection.cs
+++ b/src/IO.Ably.Shared/Transport/MsWebSocketConnection.cs
@@ -354,6 +354,7 @@ namespace IO.Ably.Transport
             _disposed = true;
         }
 
+#pragma warning disable CA1063  // Implement IDisposable correctly.
         /// <summary>
         /// Cleans up resources and disconnects the websocket.
         /// </summary>
@@ -368,6 +369,7 @@ namespace IO.Ably.Transport
             // and based on profiling this speeds up the release of objects
             // and reduces memory bloat considerably
         }
+#pragma warning default CA1063  // Implement IDisposable correctly.
 
         /// <summary>
         /// Attempt to query the backlog length of the queue.


### PR DESCRIPTION
Disables [CA1063](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1063) when building for .NET 6.0.100 . Need to recover the evidence trail that led to this code...

This relates to the GitHub Issues: [1007](https://github.com/ably/ably-dotnet/issues/1007), [523](https://github.com/ably/ably-dotnet/issues/523)