### PR TITLE
Fix 'CA1063' issues

### DIFF
--- a/src/IO.Ably.Tests.Shared/LoggerTests.cs
+++ b/src/IO.Ably.Tests.Shared/LoggerTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace IO.Ably.AcceptanceTests
 {
-    public class LoggerTests : IDisposable
+    public sealed class LoggerTests : IDisposable
     {
         [Fact]
         public void TestLogger()

--- a/src/IO.Ably.Tests.Shared/Push/ActivationStateMachineTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/ActivationStateMachineTests.cs
@@ -16,7 +16,7 @@ namespace IO.Ably.Tests.Push
 {
     public static class ActivationStateMachineTests
     {
-        public class GeneralTests : MockHttpRestSpecs, IDisposable
+        public sealed class GeneralTests : MockHttpRestSpecs, IDisposable
         {
             [Fact]
             [Trait("spec", "RSH4")]
@@ -313,7 +313,7 @@ namespace IO.Ably.Tests.Push
             }
         }
 
-        public class NotActivatedStateTests : MockHttpRestSpecs, IDisposable
+        public sealed class NotActivatedStateTests : MockHttpRestSpecs, IDisposable
         {
             [Fact]
             [Trait("spec", "RSH3a1")]
@@ -554,7 +554,7 @@ namespace IO.Ably.Tests.Push
         }
 
         [Trait("spec", "RSH3b")]
-        public class WaitingForPushDeviceDetailsTests : MockHttpRestSpecs, IDisposable
+        public sealed class WaitingForPushDeviceDetailsTests : MockHttpRestSpecs, IDisposable
         {
             [Fact]
             [Trait("spec", "RSH3b1")]
@@ -739,7 +739,7 @@ namespace IO.Ably.Tests.Push
         }
 
         [Trait("spec", "RSH3c")]
-        public class WaitingForDeviceRegistrationTests : MockHttpRestSpecs, IDisposable
+        public sealed class WaitingForDeviceRegistrationTests : MockHttpRestSpecs, IDisposable
         {
             [Fact]
             [Trait("spec", "RSH3c1")]
@@ -868,7 +868,7 @@ namespace IO.Ably.Tests.Push
         }
 
         [Trait("spec", "RSH3d")]
-        public class WaitingForNewPushDeviceDetailsTests : MockHttpRestSpecs, IDisposable
+        public sealed class WaitingForNewPushDeviceDetailsTests : MockHttpRestSpecs, IDisposable
         {
             [Fact]
             [Trait("spec", "RSH3d1")]
@@ -1055,7 +1055,7 @@ namespace IO.Ably.Tests.Push
         }
 
         [Trait("spec", "RSH3e")]
-        public class WaitingForRegistrationSync : MockHttpRestSpecs, IDisposable
+        public sealed class WaitingForRegistrationSync : MockHttpRestSpecs, IDisposable
         {
             [Fact]
             [Trait("spec", "RSH3e1")]
@@ -1225,7 +1225,7 @@ namespace IO.Ably.Tests.Push
         }
 
         [Trait("spec", "RSH3f")]
-        public class AfterRegistrationSyncFailedTests : MockHttpRestSpecs, IDisposable
+        public sealed class AfterRegistrationSyncFailedTests : MockHttpRestSpecs, IDisposable
         {
             [Fact]
             [Trait("spec", "RSH3f1")]
@@ -1348,7 +1348,7 @@ namespace IO.Ably.Tests.Push
         }
 
         [Trait("spec", "RSH3g")]
-        public class WaitingForDeregistrationTests : MockHttpRestSpecs, IDisposable
+        public sealed class WaitingForDeregistrationTests : MockHttpRestSpecs, IDisposable
         {
             [Fact]
             [Trait("spec", "RSH3g1")]

--- a/src/IO.Ably.Tests.Shared/Push/LocalDeviceTests.cs
+++ b/src/IO.Ably.Tests.Shared/Push/LocalDeviceTests.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 
 namespace IO.Ably.Tests.Push
 {
-    public class LocalDeviceTests : MockHttpRestSpecs, IDisposable
+    public sealed class LocalDeviceTests : MockHttpRestSpecs, IDisposable
     {
         [Fact]
         [Trait("spec", "RSH3a2b")]


### PR DESCRIPTION
Applying `sealed` to these test classes as part of [CA1063](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1063) guidance.