### PR TITLE
Tests need to implement IDisposble

### DIFF
--- a/src/IO.Ably.Tests.Shared/Infrastructure/AblyRealtimeSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/AblyRealtimeSpecs.cs
@@ -16,6 +16,7 @@ namespace IO.Ably.Tests
         protected const string TestChannelName = "test";
 
         private readonly AutoResetEvent _signal = new AutoResetEvent(false);
+        private bool _disposedValue;
 
         protected AblyRealtimeSpecs(ITestOutputHelper output)
             : base(output)
@@ -37,19 +38,30 @@ namespace IO.Ably.Tests
 
         public void Dispose()
         {
-            foreach (var client in RealtimeClients)
-            {
-                try
-                {
-                    client.Dispose();
-                }
-                catch (Exception ex)
-                {
-                    Output?.WriteLine("Error disposing Client: " + ex.Message);
-                }
-            }
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
 
-            _signal?.Dispose();
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                foreach (var client in RealtimeClients)
+                {
+                    try
+                    {
+                        client.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        Output?.WriteLine("Error disposing Client: " + ex.Message);
+                    }
+                }
+
+                _signal?.Dispose();
+
+                _disposedValue = true;
+            }
         }
 
         internal AblyRealtime GetRealtimeClient(ClientOptions options = null, Func<AblyRequest, Task<AblyResponse>> handleRequestFunc = null, IMobileDevice mobileDevice = null)

--- a/src/IO.Ably.Tests.Shared/Infrastructure/ConditionalAwaiter.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/ConditionalAwaiter.cs
@@ -7,7 +7,7 @@ using Timer = System.Timers.Timer;
 
 namespace IO.Ably.Tests.Infrastructure
 {
-    public class ConditionalAwaiter
+    public sealed class ConditionalAwaiter : IDisposable
     {
         private readonly Func<bool> _condition;
         private readonly Func<string> _getError;
@@ -54,6 +54,11 @@ namespace IO.Ably.Tests.Infrastructure
                 _timer.Elapsed -= TimerOnElapsed;
                 _timer.Dispose();
             }
+        }
+
+        public void Dispose()
+        {
+            _timer.Dispose();
         }
     }
 }

--- a/src/IO.Ably.Tests.Shared/Infrastructure/TaskCountAwaiter.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/TaskCountAwaiter.cs
@@ -6,7 +6,7 @@ namespace IO.Ably.Tests.Infrastructure
     /// <summary>
     /// Count a certain number of ticks and complete or timeout
     /// </summary>
-    internal class TaskCountAwaiter
+    internal sealed class TaskCountAwaiter : IDisposable
     {
         private readonly TaskCompletionAwaiter _awaiter;
         private int _index;
@@ -31,6 +31,11 @@ namespace IO.Ably.Tests.Infrastructure
             {
                 _awaiter.SetCompleted();
             }
+        }
+
+        public void Dispose()
+        {
+            _awaiter.Dispose();
         }
     }
 }

--- a/src/IO.Ably.Tests.Shared/Infrastructure/TimeoutCallback.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/TimeoutCallback.cs
@@ -5,7 +5,7 @@ using IO.Ably.Tests.Infrastructure;
 
 namespace IO.Ably.Tests
 {
-    internal class TimeoutCallback<T>
+    internal sealed class TimeoutCallback<T> : IDisposable
     {
         private readonly TaskCompletionAwaiter _tca;
 
@@ -23,6 +23,11 @@ namespace IO.Ably.Tests
                 callback(csc);
                 _tca.SetCompleted();
             };
+        }
+
+        public void Dispose()
+        {
+            _tca.Dispose();
         }
     }
 }

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -1987,7 +1987,7 @@ namespace IO.Ably.Tests.Realtime
             }
         }
 
-        private class PresenceAwaiter
+        private sealed class PresenceAwaiter : IDisposable
         {
             private IRealtimeChannel _channel;
             private TaskCompletionAwaiter _tsc;
@@ -2005,6 +2005,11 @@ namespace IO.Ably.Tests.Realtime
             {
                 _tsc = new TaskCompletionAwaiter(10000, count);
                 return await _tsc.Task;
+            }
+
+            public void Dispose()
+            {
+                _tsc?.Dispose();
             }
         }
     }

--- a/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/RestSpecs.cs
@@ -248,7 +248,7 @@ namespace IO.Ably.Tests
         }
 
         [Trait("spec", "RSC11")]
-        public class HostSpecs : AblySpecs
+        public sealed class HostSpecs : AblySpecs, IDisposable
         {
             private readonly FakeHttpMessageHandler _handler;
 
@@ -373,6 +373,11 @@ namespace IO.Ably.Tests
             {
                 await client.Channels.Get("boo").PublishAsync("boo", "baa");
             }
+
+            public void Dispose()
+            {
+                _handler?.Dispose();
+            }
         }
 
         [Fact]
@@ -449,7 +454,7 @@ namespace IO.Ably.Tests
             // If it throws the test will fail
         }
 
-        public class FallbackSpecs : AblySpecs
+        public sealed class FallbackSpecs : AblySpecs, IDisposable
         {
             private readonly FakeHttpMessageHandler _handler;
             private readonly HttpResponseMessage _response;
@@ -768,6 +773,12 @@ namespace IO.Ably.Tests
             private static async Task MakeAnyRequest(AblyRest client)
             {
                 await client.Channels.Get("boo").PublishAsync("boo", "baa");
+            }
+
+            public void Dispose()
+            {
+                _handler?.Dispose();
+                _response?.Dispose();
             }
         }
 

--- a/src/IO.Ably.Tests.Shared/Rest/SandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Rest/SandboxSpecs.cs
@@ -14,6 +14,7 @@ namespace IO.Ably.Tests
     public abstract class SandboxSpecs : IClassFixture<AblySandboxFixture>, IDisposable
     {
         private readonly List<AblyRealtime> _realtimeClients = new List<AblyRealtime>();
+        private bool _disposedValue;
 
         protected SandboxSpecs(AblySandboxFixture fixture, ITestOutputHelper output)
         {
@@ -52,20 +53,31 @@ namespace IO.Ably.Tests
 
         public void Dispose()
         {
-            Output.WriteLine("Test end disposing connections: " + _realtimeClients.Count);
-            foreach (var client in _realtimeClients)
-            {
-                try
-                {
-                    client.Dispose();
-                }
-                catch (Exception ex)
-                {
-                    Output?.WriteLine("Error disposing Client: " + ex.Message);
-                }
-            }
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
 
-            ResetEvent?.Dispose();
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                Output.WriteLine("Test end disposing connections: " + _realtimeClients.Count);
+                foreach (var client in _realtimeClients)
+                {
+                    try
+                    {
+                        client.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        Output?.WriteLine("Error disposing Client: " + ex.Message);
+                    }
+                }
+
+                ResetEvent?.Dispose();
+
+                _disposedValue = true;
+            }
         }
 
         protected async Task<AblyRest> GetRestClient(Protocol protocol, Action<ClientOptions> optionsAction = null, string environment = null)


### PR DESCRIPTION
Class that have member(s) (field(s)) that implement IDisposable should themselves implement IDisposable and delegate to the appropriate member(s) (field(s)) as appropriate.