### PR TITLE
'LockedList' Suppress inconsistent sync on field warning

### DIFF
--- a/src/IO.Ably.Shared/Types/LockedList.cs
+++ b/src/IO.Ably.Shared/Types/LockedList.cs
@@ -1,9 +1,11 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace IO.Ably
 {
+    [SuppressMessage("ReSharper", "InconsistentlySynchronizedField", Justification = "Double-check locking pattern used.")]
     internal sealed class LockedList<T> : IEnumerable<T>
     {
         private readonly List<T> _items = new List<T>();


### PR DESCRIPTION
We're explicitly using the double-check locking pattern so in this specific case its OK to suppress the warning about inconsistent synchronization on the `_items` field.