### PR TITLE
Update netstandard assemblyInfo

### DIFF
--- a/src/IO.Ably.NETStandard20/Properties/AssemblyInfo.cs
+++ b/src/IO.Ably.NETStandard20/Properties/AssemblyInfo.cs
@@ -13,7 +13,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("IO.Ably.Push.iOS,     PublicKey=002400000480000094000000060200000024000052534131000400000100010001394bb0af9eb8e04f43676c91691de20f2137847e153e27bb96cf2dedf43bce3073f699ca136fb7f9eea0d9b9c6748e9c0be5543761945e101062f8770129512c4c397a08c1b459357e7a49a4dfd7e16ac9c84d1ab3fe1177b3e7741ea10eba746433691bbf1ad643bdf25bcf397a384f96e8d138b129bdb663189200d33dcf")]
 #if !PACKAGE
 [assembly: InternalsVisibleTo("IO.Ably.Tests.DotNetCore20")]
-[assembly: InternalsVisibleTo("Assets.Tests.AblySandbox")]
-[assembly: InternalsVisibleTo("Assets.Tests.EditMode")]
-[assembly: InternalsVisibleTo("Assets.Tests.PlayMode")]
+[assembly: InternalsVisibleTo("Unity.Assets.Tests.AblySandbox")]
+[assembly: InternalsVisibleTo("Unity.Assets.Tests.EditMode")]
+[assembly: InternalsVisibleTo("Unity.Assets.Tests.PlayMode")]
 #endif

--- a/src/IO.Ably.NETStandard20/Properties/AssemblyInfo.cs
+++ b/src/IO.Ably.NETStandard20/Properties/AssemblyInfo.cs
@@ -13,4 +13,7 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("IO.Ably.Push.iOS,     PublicKey=002400000480000094000000060200000024000052534131000400000100010001394bb0af9eb8e04f43676c91691de20f2137847e153e27bb96cf2dedf43bce3073f699ca136fb7f9eea0d9b9c6748e9c0be5543761945e101062f8770129512c4c397a08c1b459357e7a49a4dfd7e16ac9c84d1ab3fe1177b3e7741ea10eba746433691bbf1ad643bdf25bcf397a384f96e8d138b129bdb663189200d33dcf")]
 #if !PACKAGE
 [assembly: InternalsVisibleTo("IO.Ably.Tests.DotNetCore20")]
+[assembly: InternalsVisibleTo("Assets.Tests.AblySandbox")]
+[assembly: InternalsVisibleTo("Assets.Tests.EditMode")]
+[assembly: InternalsVisibleTo("Assets.Tests.PlayMode")]
 #endif


### PR DESCRIPTION
- Fixes #1123 
- Doesn't affect the published NuGet package, since `PACKAGE` flag is set while packaging.