### PR TITLE
Increase .NET Framework min ver from 4.6.1 to 4.6.2

### DIFF
--- a/src/IO.Ably.NETFramework/IO.Ably.NETFramework.csproj
+++ b/src/IO.Ably.NETFramework/IO.Ably.NETFramework.csproj
@@ -10,10 +10,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IO.Ably</RootNamespace>
     <AssemblyName>IO.Ably</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/IO.Ably.NETFramework/app.config
+++ b/src/IO.Ably.NETFramework/app.config
@@ -12,4 +12,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>

--- a/src/IO.Ably.Tests.NETFramework/App.config
+++ b/src/IO.Ably.Tests.NETFramework/App.config
@@ -1,10 +1,10 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <connectionStrings>
-    <add name="Ably" connectionString="AHSz6w.uQXPNQ:FGBZbsKSwqbCpkob" />
+    <add name="Ably" connectionString="AHSz6w.uQXPNQ:FGBZbsKSwqbCpkob"/>
   </connectionStrings>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
   </startup>
 
 

--- a/src/IO.Ably.Tests.NETFramework/IO.Ably.Tests.NETFramework.csproj
+++ b/src/IO.Ably.Tests.NETFramework/IO.Ably.Tests.NETFramework.csproj
@@ -9,9 +9,10 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>IO.Ably.Tests.NETFramework</RootNamespace>
     <AssemblyName>IO.Ably.Tests.NETFramework</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <LangVersion>8</LangVersion>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
@sacOO7 ran into a CI build issue involving `4.6.1`. After some investigation it turns out we need to move on to `4.6.2` because:

```
The following versions of .NET Framework will reach end-of-support on April 26, 2022: 4.5.2, 4.6, and 4.6.1. After this date, security fixes, updates, and technical support for these versions will no longer be provided.

If you're using .NET Framework 4.5.2, 4.6, or 4.6.1, update your deployed runtime to a more recent version, such as .NET Framework 4.6.2, before April 26, 2022 in order to continue to receive updates and technical support.
```

[ref](https://docs.microsoft.com/en-gb/dotnet/framework/install/guide-for-developers)

[GitHub Issue](https://github.com/ably/ably-dotnet/issues/1126)

