### PR TITLE
Update documentation URLs

### DIFF
--- a/PushNotifications.md
+++ b/PushNotifications.md
@@ -48,7 +48,7 @@ To get push notifications setup in your own app, read [Setting up your own app](
 
 ### Summary
 
-Devices need to be [activated](#device-activation) with Ably once. Once activated, you can use their device ID, client ID or push token (APNs device token/ FCM registration token) to push messages to them using the Ably dashboard or a [Push Admin](https://ably.com/documentation/general/push/admin) (SDKs which provide push admin functionality, such as the .net sdk, [Ably-java](https://github.com/ably/ably-java), [Ably-js](https://github.com/ably/ably-js), etc.). However, to send push notifications through Ably channels, devices need to [subscribe to a channel for push notifications](#subscribing-to-channels-for-push-notifications). Once subscribed, messages on that channel with a [push payload](#sending-messages) will be sent to devices which are subscribed to that channel.
+Devices need to be [activated](#device-activation) with Ably once. Once activated, you can use their device ID, client ID or push token (APNs device token/ FCM registration token) to push messages to them using the Ably dashboard or a [Push Admin](https://ably.com/docs/general/push/admin) (SDKs which provide push admin functionality, such as the .net sdk, [Ably-java](https://github.com/ably/ably-java), [Ably-js](https://github.com/ably/ably-js), etc.). However, to send push notifications through Ably channels, devices need to [subscribe to a channel for push notifications](#subscribing-to-channels-for-push-notifications). Once subscribed, messages on that channel with a [push payload](#sending-messages) will be sent to devices which are subscribed to that channel.
 
 The [DotNetPush app](https://github.com/ably/ably-dotnet/tree/main/examples/DotnetPush) contains an example of how to use the Push Notification functionality. For Android devices please refer to [MainActivity.cs](https://github.com/ably/ably-dotnet/blob/main/examples/DotnetPush/DotnetPush.Android/MainActivity.cs) and [MyFirebaseMessaging.cs](https://github.com/ably/ably-dotnet/blob/main/examples/DotnetPush/DotnetPush.Android/MyFirebaseMessaging.cs). For iOS please refer to [AppDelegate](https://github.com/ably/ably-dotnet/blob/main/examples/DotnetPush/DotnetPush.iOS/AppDelegate.cs).
 
@@ -86,7 +86,7 @@ private ClientOptions GetAblyOptions(string savedClientId)
 {
     var options = new ClientOptions
     {
-        // https://ably.com/documentation/best-practice-guide#auth
+        // https://ably.com/docs/best-practice-guide#auth
         // recommended for security reasons. Please, review Ably's best practise guide on Authentication
         // Please provide a way for AblyRealtime to connect to the services. Having API keys on mobile devices is not
         Key = "<key>",

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![MacOS - build and test](https://github.com/ably/ably-dotnet/actions/workflows/build-and-test-macos.yml/badge.svg)](https://github.com/ably/ably-dotnet/actions/workflows/build-and-test-macos.yml)
 [![Linux - build and test](https://github.com/ably/ably-dotnet/actions/workflows/build-and-test-linux.yml/badge.svg)](https://github.com/ably/ably-dotnet/actions/workflows/build-and-test-linux.yml)
 
-_[Ably](https://ably.com) is the platform that powers synchronized digital experiences in realtime. Whether attending an event in a virtual venue, receiving realtime financial information, or monitoring live car performance data – consumers simply expect realtime digital experiences as standard. Ably provides a suite of APIs to build, extend, and deliver powerful digital experiences in realtime for more than 250 million devices across 80 countries each month. Organizations like Bloomberg, HubSpot, Verizon, and Hopin depend on Ably’s platform to offload the growing complexity of business-critical realtime data synchronization at global scale. For more information, see the [Ably documentation](https://ably.com/documentation)._
+_[Ably](https://ably.com) is the platform that powers synchronized digital experiences in realtime. Whether attending an event in a virtual venue, receiving realtime financial information, or monitoring live car performance data – consumers simply expect realtime digital experiences as standard. Ably provides a suite of APIs to build, extend, and deliver powerful digital experiences in realtime for more than 250 million devices across 80 countries each month. Organizations like Bloomberg, HubSpot, Verizon, and Hopin depend on Ably’s platform to offload the growing complexity of business-critical realtime data synchronization at global scale. For more information, see the [Ably documentation](https://ably.com/docs)._
 
-This is a .NET client library for Ably. The library currently targets the [Ably 1.1-beta client library specification](https://ably.com/documentation/client-lib-development-guide/features). You can jump to the '[Known Limitations](#known-limitations)' section to see the features this client library does not yet support or or [view our client library SDKs feature support matrix](https://ably.com/download/sdk-feature-support-matrix) to see the list of all the available features.
+This is a .NET client library for Ably. The library currently targets the [Ably 1.1-beta client library specification](https://ably.com/docs/client-lib-development-guide/features). You can jump to the '[Known Limitations](#known-limitations)' section to see the features this client library does not yet support or or [view our client library SDKs feature support matrix](https://ably.com/download/sdk-feature-support-matrix) to see the list of all the available features.
 
 ## Supported platforms
 
@@ -62,7 +62,7 @@ A Portable Class Library version is not available. Portable Class Libraries are 
 
 ## Push notification
 
-The Ably.net library fully supports Ably's push notifications. The feature set consists of two distinct areas: [Push Admin](https://ably.com/documentation/general/push/admin), [Device Push Notifications](https://ably.com/documentation/realtime/push). 
+The Ably.net library fully supports Ably's push notifications. The feature set consists of two distinct areas: [Push Admin](https://ably.com/docs/general/push/admin), [Device Push Notifications](https://ably.com/docs/realtime/push). 
 
 The [Push Notifications Readme](PushNotifications.md) describes:
 - How to setup Push notifications on Xamarin mobile apps
@@ -76,7 +76,7 @@ The [Push Notifications Readme](PushNotifications.md) describes:
 
 ## Documentation
 
-Visit https://ably.com/documentation for a complete API reference and more examples.
+Visit https://ably.com/docs for a complete API reference and more examples.
 
 ## Installation
 
@@ -191,7 +191,7 @@ channel.On(ChannelState.Attached, args =>
 
 ### Subscribing to a channel in delta mode
 
-Subscribing to a channel in delta mode enables [delta compression](https://ably.com/documentation/realtime/channels/channel-parameters/deltas). This is a way for a client to subscribe to a channel so that message payloads sent contain only the difference (ie the delta) between the present message and the previous message on the channel.
+Subscribing to a channel in delta mode enables [delta compression](https://ably.com/docs/realtime/channels/channel-parameters/deltas). This is a way for a client to subscribe to a channel so that message payloads sent contain only the difference (ie the delta) between the present message and the previous message on the channel.
 
 Request a Vcdiff formatted delta stream using channel options when you get the channel:
 
@@ -525,7 +525,7 @@ If you want to incorporate `ably-dotnet` into your project from source (perhaps 
 
 ## Spec
 
-The dotnet library follows the Ably [`Client Library development guide`](https://ably.com/documentation). To ensure it is easier to look up whether a spec item has been implemented or not; we add a Trait attribute to tests that implement parts of the spec. The convention is to add `[Trait("spec", "spec tag")]` to unit tests.
+The dotnet library follows the Ably [`Client Library development guide`](https://ably.com/docs). To ensure it is easier to look up whether a spec item has been implemented or not; we add a Trait attribute to tests that implement parts of the spec. The convention is to add `[Trait("spec", "spec tag")]` to unit tests.
 
 To get a list of all spec items that appear in the tests you can run a script located in the tools directory. 
 You need to have .NET Core 3.1 installed. It works on Mac, Linux and Windows. Run `dotnet fsi tools/list-test-categories.fsx`. It will produce a `results.csv` file which will include all spec items, which file it was found and on what line.

--- a/examples/DotnetPush/DotnetPush.Android/MainActivity.cs
+++ b/examples/DotnetPush/DotnetPush.Android/MainActivity.cs
@@ -61,8 +61,8 @@ namespace DotnetPush.Droid
                 LogHandler = _loggerSink,
                 LogLevel = LogLevel.Debug,
 
-                // https://ably.com/documentation/best-practice-guide#auth
-                // recommended for security reasons. Please, review Ably's best practise guide on Authentication
+                // https://ably.com/docs/best-practice-guide#auth
+                // recommended for security reasons. Please, review Ably's best practice guide on Authentication
                 // Please provide a way for AblyRealtime to connect to the services. Having API keys on mobile devices is not recommended.
                 Key = "<key>"
             };

--- a/examples/DotnetPush/DotnetPush.iOS/AppDelegate.cs
+++ b/examples/DotnetPush/DotnetPush.iOS/AppDelegate.cs
@@ -53,8 +53,8 @@ namespace DotnetPush.iOS
         {
             var options = new ClientOptions
             {
-                // https://ably.com/documentation/best-practice-guide#auth
-                // recommended for security reasons. Please, review Ably's best practise guide on Authentication
+                // https://ably.com/docs/best-practice-guide#auth
+                // recommended for security reasons. Please, review Ably's best practice guide on Authentication
                 // Please provide a way for AblyRealtime to connect to the services. Having API keys on mobile devices is not recommended.
                 Key = "<key>",
                 LogHandler = (ILoggerSink)_loggerSink,

--- a/src/IO.Ably.Shared/AblyRest.cs
+++ b/src/IO.Ably.Shared/AblyRest.cs
@@ -86,7 +86,7 @@ namespace IO.Ably
 
         /// <summary>
         /// Expose Push Admin Rest APIs.
-        /// Rest API documentation: https://ably.com/documentation/rest-api#push.
+        /// Rest API documentation: https://ably.com/docs/rest-api#push.
         /// </summary>
         public PushRest Push { get; private set; }
 

--- a/src/IO.Ably.Shared/Push/DeviceDetails.cs
+++ b/src/IO.Ably.Shared/Push/DeviceDetails.cs
@@ -57,7 +57,7 @@ namespace IO.Ably.Push
         {
             /// <summary>
             /// Push Recipient. Currently supporter recipients are Apple (apns), Google (fcm) and Browser (web).
-            /// For more information - https://ably.com/documentation/rest-api#post-device-registration.
+            /// For more information - https://ably.com/docs/rest-api#post-device-registration.
             /// </summary>
             [JsonProperty("recipient")]
             public JObject Recipient { get; set; }

--- a/src/IO.Ably.Shared/Push/IDeviceRegistrations.cs
+++ b/src/IO.Ably.Shared/Push/IDeviceRegistrations.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 namespace IO.Ably.Push
 {
     /// <summary>
-    /// Device Registrations APIs. For more information visit the Ably Rest Documentation: https://ably.com/documentation/rest-api#post-device-registration.
+    /// Device Registrations APIs. For more information visit the Ably Rest Documentation: https://ably.com/docs/rest-api#post-device-registration.
     /// </summary>
     public interface IDeviceRegistrations
     {
@@ -12,13 +12,13 @@ namespace IO.Ably.Push
         /// Update a device registration.
         /// </summary>
         /// <param name="details">Device to be updated. Only `clientId`, `metadata` and `Push.Recipient` can be updates. The rest of the values must match what the server contains.
-        /// RestApi: https://ably.com/documentation/rest-api#update-device-registration.</param>
+        /// RestApi: https://ably.com/docs/rest-api#update-device-registration.</param>
         /// <returns>Updated Device Registration.</returns>
-        Task<DeviceDetails> SaveAsync(DeviceDetails details); // The Rest API only allows clientId, metadata and push.recipient to be updates FYI: https://ably.com/documentation/rest-api#update-device-registration
+        Task<DeviceDetails> SaveAsync(DeviceDetails details); // The Rest API only allows clientId, metadata and push.recipient to be updates FYI: https://ably.com/docs/rest-api#update-device-registration
 
         /// <summary>
         /// Obtain the details for a device registered for receiving push registrations.
-        /// RestApi: https://ably.com/documentation/rest-api#get-device-registration.
+        /// RestApi: https://ably.com/docs/rest-api#get-device-registration.
         /// </summary>
         /// <param name="deviceId">Id of the device.</param>
         /// <returns>Returns a DeviceDetails class if the device is found or `null` if not.</returns>
@@ -26,7 +26,7 @@ namespace IO.Ably.Push
 
         /// <summary>
         /// Obtain the details for devices registered for receiving push registrations.
-        /// RestApi: https://ably.com/documentation/rest-api#list-device-registrations.
+        /// RestApi: https://ably.com/docs/rest-api#list-device-registrations.
         /// </summary>
         /// <param name="request">Allows to filter by clientId or deviceId. For further information <see cref="ListDeviceDetailsRequest"/>.</param>
         /// <returns>A paginated list of DeviceDetails.</returns>
@@ -34,7 +34,7 @@ namespace IO.Ably.Push
 
         /// <summary>
         /// Removes a registered device.
-        /// RestAPI: https://ably.com/documentation/rest-api#delete-device-registration.
+        /// RestAPI: https://ably.com/docs/rest-api#delete-device-registration.
         /// </summary>
         /// <param name="details">DeviceDetails to be removed.</param>
         /// <returns>Task.</returns>
@@ -42,7 +42,7 @@ namespace IO.Ably.Push
 
         /// <summary>
         /// Removes a registered device.
-        /// RestAPI: https://ably.com/documentation/rest-api#delete-device-registration.
+        /// RestAPI: https://ably.com/docs/rest-api#delete-device-registration.
         /// </summary>
         /// <param name="deviceId">The deviceId of the device to be removed.</param>
         /// <returns>Task.</returns>
@@ -50,7 +50,7 @@ namespace IO.Ably.Push
 
         /// <summary>
         /// Removes a registered devices based on a filter of parameters.
-        /// RestAPI: https://ably.com/documentation/rest-api#delete-device-registration.
+        /// RestAPI: https://ably.com/docs/rest-api#delete-device-registration.
         /// </summary>
         /// <param name="deleteFilter">Filter devices by deviceId or clientId.</param>
         /// <returns>Task.</returns>

--- a/src/IO.Ably.Shared/Push/IPushChannelSubscriptions.cs
+++ b/src/IO.Ably.Shared/Push/IPushChannelSubscriptions.cs
@@ -10,7 +10,7 @@ namespace IO.Ably.Push
     {
         /// <summary>
         /// Subscribe either a single device or all devices associated with a client ID to receive push notifications from messages sent to a channel.
-        /// RestApi: https://ably.com/documentation/rest-api#post-channel-subscription.
+        /// RestApi: https://ably.com/docs/rest-api#post-channel-subscription.
         /// </summary>
         /// <param name="subscription">Channel subscription object.</param>
         /// <returns>Return an updated Channel subscription object.</returns>
@@ -18,7 +18,7 @@ namespace IO.Ably.Push
 
         /// <summary>
         /// Get a list of push notification subscriptions to channels.
-        /// RestApi: https://ably.com/documentation/rest-api#list-channel-subscriptions.
+        /// RestApi: https://ably.com/docs/rest-api#list-channel-subscriptions.
         /// </summary>
         /// <param name="requestFilter">Provides a way to filter results. <see cref="ListSubscriptionsRequest"/>.</param>
         /// <returns>Returns a paginated list of ChannelSubscriptions.</returns>
@@ -26,7 +26,7 @@ namespace IO.Ably.Push
 
         /// <summary>
         /// List all channels with at least one subscribed device.
-        /// RestApi: https://ably.com/documentation/rest-api#list-channels.
+        /// RestApi: https://ably.com/docs/rest-api#list-channels.
         /// </summary>
         /// <param name="requestParams">Allows adding a limit to the number of results and supports paginated requests handling.</param>
         /// <returns>Paginated list of channel names.</returns>
@@ -35,7 +35,7 @@ namespace IO.Ably.Push
         /// <summary>
         /// Stop receiving push notifications when push messages are published on the specified channels.
         /// Please note that this operation is done asynchronously so immediate requests subsequent to this delete request may briefly still return the subscription.
-        /// RestApi: https://ably.com/documentation/rest-api#delete-channel-subscription.
+        /// RestApi: https://ably.com/docs/rest-api#delete-channel-subscription.
         /// </summary>
         /// <param name="subscription">Channel Subscription object to unsubscribe.</param>
         /// <returns>Task.</returns>
@@ -45,7 +45,7 @@ namespace IO.Ably.Push
         /// Stop receiving push notifications when push messages are published on the specified channels.
         /// Please note that this operation is done asynchronously so immediate requests subsequent to this delete request may briefly still return the subscription.
         /// Allows custom parameters to be passed in the filter.
-        /// RestApi: https://ably.com/documentation/rest-api#delete-channel-subscription.
+        /// RestApi: https://ably.com/docs/rest-api#delete-channel-subscription.
         /// </summary>
         /// <param name="removeParams">Dictionary with query parameters passed to the server. Possible values are `clientId`, `deviceId` and `channel`.</param>
         /// <returns>Task.</returns>

--- a/src/IO.Ably.Shared/Push/PushAdmin.cs
+++ b/src/IO.Ably.Shared/Push/PushAdmin.cs
@@ -151,7 +151,7 @@ namespace IO.Ably.Push
         /// <summary>
         /// Publish a push notification message.
         /// </summary>
-        /// <param name="recipient">Recipient. Best description of what is allowed can be found in the RestApi documentation: https://ably.com/documentation/rest-api#post-device-registration.</param>
+        /// <param name="recipient">Recipient. Best description of what is allowed can be found in the RestApi documentation: https://ably.com/docs/rest-api#post-device-registration.</param>
         /// <param name="payload">Message payload.</param>
         /// <returns>Task.</returns>
         public async Task PublishAsync(JObject recipient, JObject payload)

--- a/src/IO.Ably.Shared/Rest/ChannelOptions.cs
+++ b/src/IO.Ably.Shared/Rest/ChannelOptions.cs
@@ -25,7 +25,7 @@ namespace IO.Ably
         /// <summary>
         /// Params allows custom parameters to be passed to the server when attaching the channel.
         /// In that list are 'delta' and 'rewind'. For more information about channel params visit
-        /// https://www.ably.io/documentation/realtime/channel-params.
+        /// https://ably.com/docs/realtime/channels/channel-parameters/overview.
         /// </summary>
         public ChannelParams Params
         {

--- a/src/IO.Ably.Shared/Types/ProtocolMessage.cs
+++ b/src/IO.Ably.Shared/Types/ProtocolMessage.cs
@@ -90,7 +90,7 @@ namespace IO.Ably.Types
         /// Channel params is a Dictionary&lt;string, string&gt; which is used to pass parameters to the server when
         /// attaching a channel. Some params include `delta` and `rewind`. The server will also echo the params in the
         /// ATTACHED message.
-        /// For more information https://www.ably.io/documentation/realtime/channel-params.
+        /// For more information https://ably.com/docs/realtime/channels/channel-parameters/overview.
         /// </summary>
         [JsonProperty("params")]
         public ChannelParams Params { get; set; }

--- a/src/IO.Ably.Tests.Shared/ChannelOptionsExtensions.cs
+++ b/src/IO.Ably.Tests.Shared/ChannelOptionsExtensions.cs
@@ -40,7 +40,7 @@ namespace IO.Ably.Tests.DotNetCore20
 
         /// <summary>
         /// Makes adding Rewind by a number of messages easier.
-        /// Full documentation can be found here: https://www.ably.io/documentation/realtime/channel-params#rewind.
+        /// Full documentation can be found here: https://ably.com/docs/realtime/channels/channel-parameters/overview#rewind.
         /// </summary>
         /// <param name="options">the <see cref="ChannelOptions"/> that will be modified.</param>
         /// <param name="numberOfMessages">the value passed to Rewind param.</param>
@@ -52,7 +52,7 @@ namespace IO.Ably.Tests.DotNetCore20
 
         /// <summary>
         /// Makes adding Rewind by a time period with an option interval easier.
-        /// Full documentation can be found here: https://www.ably.io/documentation/realtime/channel-params#rewind.
+        /// Full documentation can be found here: https://ably.com/docs/realtime/channels/channel-parameters/overview#rewind.
         /// </summary>
         /// <param name="options">the <see cref="ChannelOptions"/> that will be modified.</param>
         /// <param name="rewindBy">by how much should we rewind.</param>


### PR DESCRIPTION
Updatre any documentation URLs in the Markdown Files from `ably.com/documentation` to `ably.com/docs`.