### PR TITLE
Add message extras to the Message equality comparison

### DIFF
--- a/src/IO.Ably.Shared/Types/Message.cs
+++ b/src/IO.Ably.Shared/Types/Message.cs
@@ -108,7 +108,14 @@ namespace IO.Ably
         /// <returns>true / false..</returns>
         protected bool Equals(Message other)
         {
-            return string.Equals(Id, other.Id) && string.Equals(ClientId, other.ClientId) && string.Equals(ConnectionId, other.ConnectionId) && string.Equals(Name, other.Name) && Timestamp.Equals(other.Timestamp) && Equals(Data, other.Data) && string.Equals(Encoding, other.Encoding);
+            return string.Equals(Id, other.Id)
+                   && string.Equals(ClientId, other.ClientId)
+                   && string.Equals(ConnectionId, other.ConnectionId)
+                   && string.Equals(Name, other.Name)
+                   && Timestamp.Equals(other.Timestamp)
+                   && Equals(Data, other.Data)
+                   && string.Equals(Encoding, other.Encoding)
+                   && Equals(Extras, other.Extras);
         }
 
         /// <inheritdoc/>
@@ -144,6 +151,7 @@ namespace IO.Ably
                 hashCode = (hashCode * 397) ^ Timestamp.GetHashCode();
                 hashCode = (hashCode * 397) ^ (Data != null ? Data.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (Encoding != null ? Encoding.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (Extras != null ? Extras.GetHashCode() : 0);
                 return hashCode;
             }
         }

--- a/src/IO.Ably.Shared/Types/MessageExtras.cs
+++ b/src/IO.Ably.Shared/Types/MessageExtras.cs
@@ -10,6 +10,7 @@ namespace IO.Ably.Types
     [JsonConverter(typeof(MessageExtrasConverter))]
     public class MessageExtras
     {
+        private static readonly JTokenEqualityComparer _comparer = new JTokenEqualityComparer();
         internal const string DeltaProperty = "delta";
 
         /// <summary>
@@ -67,6 +68,48 @@ namespace IO.Ably.Types
         public JToken ToJson()
         {
             return Data?.DeepClone();
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            if (Data != null)
+            {
+                return _comparer.GetHashCode(Data);
+            }
+
+            return 0;
+        }
+
+        /// <summary>
+        /// Compares two MessageExtras objects by comparing the underlying json data.
+        /// </summary>
+        /// <param name="other">other Message extras object.</param>
+        /// <returns>true or false.</returns>
+        private bool Equals(MessageExtras other)
+        {
+            return JToken.DeepEquals(Data, other.Data);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != GetType())
+            {
+                return false;
+            }
+
+            return Equals((MessageExtras)obj);
         }
     }
 

--- a/src/IO.Ably.Tests.Shared/Realtime/ProtocolMessageTests.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ProtocolMessageTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using IO.Ably.Types;
 
 using FluentAssertions;
+using Newtonsoft.Json.Linq;
 using Xunit;
 
 namespace IO.Ably.Tests.Shared.Realtime
@@ -32,6 +33,37 @@ namespace IO.Ably.Tests.Shared.Realtime
         public void ProtocolMessageHasFlagCorrectForNull()
         {
             ProtocolMessage.HasFlag(null, ProtocolMessage.Flag.HasPresence).Should().BeFalse();
+        }
+
+        [Fact]
+        public void AMessageWithExtras_ShouldNotEqualToAnEmptyMessage()
+        {
+            MessageExtras CreateExtrasWithDelta(DeltaExtras delta)
+            {
+                var jObject = new JObject();
+                jObject[MessageExtras.DeltaProperty] = JObject.FromObject(delta);
+                return new MessageExtras(jObject);
+            }
+
+            var message = new Message { Extras = CreateExtrasWithDelta(new DeltaExtras("1", string.Empty)) };
+            message.IsEmpty.Should().BeFalse();
+        }
+
+        [Fact]
+        public void MessageEquals_ShouldBeCorrectWhenOnlyTheExtrasObjectDiffers()
+        {
+            MessageExtras CreateExtrasWithDelta(DeltaExtras delta)
+            {
+                var jObject = new JObject();
+                jObject[MessageExtras.DeltaProperty] = JObject.FromObject(delta);
+                return new MessageExtras(jObject);
+            }
+
+            var message1 = new Message { Extras = CreateExtrasWithDelta(new DeltaExtras("1", string.Empty)) };
+            var message2 = new Message { Extras = CreateExtrasWithDelta(new DeltaExtras("1", string.Empty)) };
+            var message3 = new Message { Extras = CreateExtrasWithDelta(new DeltaExtras("2", string.Empty)) };
+            message1.Equals(message2).Should().BeTrue();
+            message1.Equals(message3).Should().BeFalse();
         }
 
         [Fact]


### PR DESCRIPTION
Sachin caught the issue when serialising a `ProtocolMessage` containing Messages with only `MessageExtras` and no other properties. As Message extras was not in the Equality comparison the `OnSerializing` method in `ProtocolMessage` thought all the messages were empty and set the whole `Messages` property to `null` thus causing issues.
I don't think it would have caused any real user issues because having a message with only Extras is a pointless. It did however cause issues when Sachin enabled Debug logging in the RealtimeWorkflow class.