### PR TITLE
Override the default Dependabot configuration for NuGet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily" # weekdays (Monday to Friday)
+    labels: [ ] # prevent the default `dependencies` label from being added to pull requests


### PR DESCRIPTION
I need to do this in order to prevent Dependabot from creating a `dependencies` label in this repository every time it creates a PR.

The `directory` and `schedule.interval` options are required and it doesn't look like it's possible to tell them to inherit the defaults. This is why I have had to explicitly give them values here. In turn I've upgraded from 'daily' to 'weekly' for interval as that feels more appropriately prompt.

see: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-the-dependabotyml-file

Akin / related: https://github.com/ably/ably-js/pull/1080