### PR TITLE
Fix QueueMessages when set to false

### DIFF
--- a/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
+++ b/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
@@ -334,7 +334,7 @@ namespace IO.Ably.Realtime.Workflow
                     if (State.Connection.CurrentStateObject.CanSend || cmd.Force)
                     {
                         var sendResult = SendMessage(cmd.ProtocolMessage, cmd.Callback);
-                        if (sendResult.IsFailure && State.Connection.CurrentStateObject.CanQueue)
+                        if (sendResult.IsFailure && State.Connection.CurrentStateObject.CanQueue && Client.Options.QueueMessages)
                         {
                             Logger.Debug("Failed to send message. Queuing it.");
                             State.PendingMessages.Add(new MessageAndCallback(
@@ -343,7 +343,7 @@ namespace IO.Ably.Realtime.Workflow
                                 Logger));
                         }
                     }
-                    else if (State.Connection.CurrentStateObject.CanQueue)
+                    else if (State.Connection.CurrentStateObject.CanQueue && Client.Options.QueueMessages)
                     {
                         Logger.Debug("Queuing message");
                         State.PendingMessages.Add(new MessageAndCallback(
@@ -811,6 +811,11 @@ namespace IO.Ably.Realtime.Workflow
                         };
 
                         SetState(disconnectedState, skipTimer: cmd.SkipAttach);
+
+                        if (Client.Options.QueueMessages == false)
+                        {
+                            ClearAckQueueAndFailMessages(ErrorInfo.ReasonMsgQueueNotAllowed);
+                        }
 
                         if (cmd.SkipAttach == false)
                         {

--- a/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
+++ b/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
@@ -814,7 +814,13 @@ namespace IO.Ably.Realtime.Workflow
 
                         if (Client.Options.QueueMessages == false)
                         {
-                            ClearAckQueueAndFailMessages(ErrorInfo.ReasonMsgQueueNotAllowed);
+                            var failAckMessages = new ErrorInfo(
+                                "Clearing message AckQueue(created at connected state) because Options.QueueMessages is false",
+                                ErrorCodes.Disconnected,
+                                HttpStatusCode.BadRequest,
+                                null,
+                                cmd.Error);
+                            ClearAckQueueAndFailMessages(failAckMessages);
                         }
 
                         if (cmd.SkipAttach == false)

--- a/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
+++ b/src/IO.Ably.Shared/Realtime/Workflows/RealtimeWorkflow.cs
@@ -554,6 +554,7 @@ namespace IO.Ably.Realtime.Workflow
                     return ErrorInfo.ReasonRefused;
                 }
 
+                @default.InnerException = ex;
                 return @default;
             }
 

--- a/src/IO.Ably.Shared/Transport/ConnectionManager.cs
+++ b/src/IO.Ably.Shared/Transport/ConnectionManager.cs
@@ -232,13 +232,16 @@ namespace IO.Ably.Transport
                 {
                     throw new AblyException(
                         $"Not queuing messages for [{State.State}] since Options.QueueMessages is set to False.",
-                        Connection.ConnectionState.DefaultErrorInfo.Code,
-                        HttpStatusCode.ServiceUnavailable);
+                        ErrorInfo.ReasonUnknown.Code,
+                        HttpStatusCode.BadRequest);
                 }
 
                 if (State.CanQueue == false)
                 {
-                    throw new AblyException($"The current state [{State.State}] does not allow messages to be sent.");
+                    throw new AblyException(
+                        $"The current connection state [{State.State}] does not allow messages to be sent.",
+                        ErrorInfo.ReasonUnknown.Code,
+                        HttpStatusCode.BadRequest);
                 }
             }
 

--- a/src/IO.Ably.Shared/Types/ErrorInfo.cs
+++ b/src/IO.Ably.Shared/Types/ErrorInfo.cs
@@ -13,7 +13,7 @@ namespace IO.Ably
     public class ErrorInfo
     {
         internal static readonly ErrorInfo ReasonClosed = new ErrorInfo("Connection closed by client", ErrorCodes.NoError);
-        internal static readonly ErrorInfo ReasonDisconnected = new ErrorInfo("Connection temporarily unavailable", 80003);
+        internal static readonly ErrorInfo ReasonDisconnected = new ErrorInfo("Connection temporarily unavailable", ErrorCodes.Disconnected);
         internal static readonly ErrorInfo ReasonSuspended = new ErrorInfo("Connection unavailable", ErrorCodes.ConnectionSuspended);
         internal static readonly ErrorInfo ReasonFailed = new ErrorInfo("Connection failed", ErrorCodes.ConnectionFailed);
         internal static readonly ErrorInfo ReasonRefused = new ErrorInfo("Access refused", ErrorCodes.Unauthorized);
@@ -22,6 +22,8 @@ namespace IO.Ably
         internal static readonly ErrorInfo ReasonTimeout = new ErrorInfo("Unable to establish connection", 80014);
         internal static readonly ErrorInfo ReasonUnknown = new ErrorInfo("Unknown error", ErrorCodes.InternalError, HttpStatusCode.InternalServerError);
         internal static readonly ErrorInfo NonRenewableToken = new ErrorInfo("The library was initialized with a token without any way to renew the token when it expires (no authUrl, authCallback, or key). See https://help.ably.io/error/40171 for help", ErrorCodes.NoMeansProvidedToRenewAuthToken, HttpStatusCode.Unauthorized);
+
+        internal static readonly ErrorInfo ReasonMsgQueueNotAllowed = new ErrorInfo("Clearing message AckQueue(created at connected state) because Options.QueueMessages is false", ErrorCodes.Disconnected);
 
         internal const string CodePropertyName = "code";
         internal const string StatusCodePropertyName = "statusCode";

--- a/src/IO.Ably.Shared/Types/ErrorInfo.cs
+++ b/src/IO.Ably.Shared/Types/ErrorInfo.cs
@@ -23,8 +23,6 @@ namespace IO.Ably
         internal static readonly ErrorInfo ReasonUnknown = new ErrorInfo("Unknown error", ErrorCodes.InternalError, HttpStatusCode.InternalServerError);
         internal static readonly ErrorInfo NonRenewableToken = new ErrorInfo("The library was initialized with a token without any way to renew the token when it expires (no authUrl, authCallback, or key). See https://help.ably.io/error/40171 for help", ErrorCodes.NoMeansProvidedToRenewAuthToken, HttpStatusCode.Unauthorized);
 
-        internal static readonly ErrorInfo ReasonMsgQueueNotAllowed = new ErrorInfo("Clearing message AckQueue(created at connected state) because Options.QueueMessages is false", ErrorCodes.Disconnected);
-
         internal const string CodePropertyName = "code";
         internal const string StatusCodePropertyName = "statusCode";
         internal const string ReasonPropertyName = "message";

--- a/src/IO.Ably.Tests.Shared/Infrastructure/TestTransportFactory.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/TestTransportFactory.cs
@@ -9,6 +9,7 @@ namespace IO.Ably.Tests.Infrastructure
         private readonly Action<TestTransportWrapper> _onWrappedTransportCreated;
         internal Action<TestTransportWrapper> OnTransportCreated = delegate { };
 
+        internal Action<ProtocolMessage> BeforeMessageSent = delegate { };
         internal Action<ProtocolMessage> OnMessageSent = delegate { };
 
         internal Action<ProtocolMessage> BeforeDataProcessed;
@@ -30,6 +31,7 @@ namespace IO.Ably.Tests.Infrastructure
 
             transport.BeforeDataProcessed = BeforeDataProcessed;
             OnTransportCreated(transport);
+            transport.BeforeMessageSend = BeforeMessageSent;
             transport.AfterMessageSent = OnMessageSent;
             _onWrappedTransportCreated?.Invoke(transport);
             return transport;

--- a/src/IO.Ably.Tests.Shared/Infrastructure/TestTransportFactory.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/TestTransportFactory.cs
@@ -30,7 +30,7 @@ namespace IO.Ably.Tests.Infrastructure
 
             transport.BeforeDataProcessed = BeforeDataProcessed;
             OnTransportCreated(transport);
-            transport.MessageSent = OnMessageSent;
+            transport.AfterMessageSent = OnMessageSent;
             _onWrappedTransportCreated?.Invoke(transport);
             return transport;
         }

--- a/src/IO.Ably.Tests.Shared/Infrastructure/TestTransportWrapper.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/TestTransportWrapper.cs
@@ -10,8 +10,6 @@ namespace IO.Ably.Tests.Infrastructure
 {
     internal class TestTransportWrapper : ITransport
     {
-        public bool RaiseExceptionForSend { get; set; } = false;
-
         private class TransportListenerWrapper : ITransportListener
         {
             private readonly ITransportListener _wrappedListener;

--- a/src/IO.Ably.Tests.Shared/Infrastructure/TestTransportWrapper.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/TestTransportWrapper.cs
@@ -10,6 +10,8 @@ namespace IO.Ably.Tests.Infrastructure
 {
     internal class TestTransportWrapper : ITransport
     {
+        public bool RaiseExceptionForSend { get; set; } = false;
+
         private class TransportListenerWrapper : ITransportListener
         {
             private readonly ITransportListener _wrappedListener;
@@ -135,6 +137,11 @@ namespace IO.Ably.Tests.Infrastructure
 
         public Result Send(RealtimeTransportData data)
         {
+            if (RaiseExceptionForSend)
+            {
+                throw new Exception("Error while sending the message");
+            }
+
             if (BlockSendActions.Contains(data.Original.Action))
             {
                 return Result.Ok();

--- a/src/IO.Ably.Tests.Shared/Infrastructure/TestTransportWrapper.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/TestTransportWrapper.cs
@@ -91,9 +91,11 @@ namespace IO.Ably.Tests.Infrastructure
 
         public List<ProtocolMessage.MessageAction> BlockReceiveActions { get; set; } = new List<ProtocolMessage.MessageAction>();
 
+        public Action<ProtocolMessage> BeforeMessageSend = delegate { };
+        public Action<ProtocolMessage> AfterMessageSent = delegate { };
+
         public Action<ProtocolMessage> BeforeDataProcessed;
         public Action<ProtocolMessage> AfterDataReceived;
-        public Action<ProtocolMessage> MessageSent = delegate { };
 
         public TestTransportWrapper(ITransport wrappedTransport, Protocol protocol)
         {
@@ -137,10 +139,7 @@ namespace IO.Ably.Tests.Infrastructure
 
         public Result Send(RealtimeTransportData data)
         {
-            if (RaiseExceptionForSend)
-            {
-                throw new Exception("Error while sending the message");
-            }
+            BeforeMessageSend(data.Original);
 
             if (BlockSendActions.Contains(data.Original.Action))
             {
@@ -148,9 +147,8 @@ namespace IO.Ably.Tests.Infrastructure
             }
 
             ProtocolMessagesSent.Add(data.Original);
-            MessageSent(data.Original);
             WrappedTransport.Send(data);
-
+            AfterMessageSent(data.Original);
             return Result.Ok();
         }
 

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -1626,58 +1626,6 @@ namespace IO.Ably.Tests.Realtime
                 [Theory]
                 [ProtocolData]
                 [Trait("spec", "RTP16b")]
-                public async Task ChannelStateCondition_WhenQueueMessagesIsFalse_WhenChannelIsInitializedOrAttaching_MessageAreNotPublished(Protocol protocol)
-                {
-                    var client = await GetRealtimeClient(protocol, (options, settings) =>
-                    {
-                        options.ClientId = "RTP16b";
-                        options.QueueMessages = false;
-                    });
-                    var channel = GetRandomChannel(client, "RTP16a");
-
-                    await client.WaitForState(ConnectionState.Connected);
-                    client.Workflow.QueueCommand(SetDisconnectedStateCommand.Create(null));
-                    await client.WaitForState(ConnectionState.Disconnected);
-
-                    channel.Presence.Enter(client.Connection.State.ToString(), (b, info) => { });
-
-                    Presence.QueuedPresenceMessage[] presenceMessages = channel.Presence.PendingPresenceQueue.ToArray();
-
-                    presenceMessages.Should().HaveCount(0);
-
-                    // clean up
-                    client.Close();
-                }
-
-                [Theory]
-                [ProtocolData]
-                [Trait("spec", "RTP16b")]
-                public async Task ChannelStateCondition_WhenQueueMessagesIsFalse_RealtimeWorkflowQueueShouldntAllowMessagesToPublish(Protocol protocol)
-                {
-                    var client = await GetRealtimeClient(protocol, (options, settings) =>
-                    {
-                        options.ClientId = "RTP16b";
-                        options.QueueMessages = false;
-                    });
-                    var channel = GetRandomChannel(client, "RTP16a");
-
-                    await client.WaitForState(ConnectionState.Connected);
-                    client.Workflow.QueueCommand(SetDisconnectedStateCommand.Create(null));
-                    await client.WaitForState(ConnectionState.Disconnected);
-
-                    channel.Presence.Enter(client.Connection.State.ToString(), (b, info) => { });
-
-                    Presence.QueuedPresenceMessage[] presenceMessages = channel.Presence.PendingPresenceQueue.ToArray();
-
-                    presenceMessages.Should().HaveCount(0);
-
-                    // clean up
-                    client.Close();
-                }
-
-                [Theory]
-                [ProtocolData]
-                [Trait("spec", "RTP16b")]
                 public async Task ChannelStateCondition_WhenQueueMessagesIsFalse_WhenChannelIsInitialisedOrAttaching_MessageAreNotPublished(Protocol protocol)
                 {
                     var client = await GetRealtimeClient(protocol, (options, settings) =>

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -1652,6 +1652,32 @@ namespace IO.Ably.Tests.Realtime
                 [Theory]
                 [ProtocolData]
                 [Trait("spec", "RTP16b")]
+                public async Task ChannelStateCondition_WhenQueueMessagesIsFalse_RealtimeWorkflowQueueShouldntAllowMessagesToPublish(Protocol protocol)
+                {
+                    var client = await GetRealtimeClient(protocol, (options, settings) =>
+                    {
+                        options.ClientId = "RTP16b";
+                        options.QueueMessages = false;
+                    });
+                    var channel = GetRandomChannel(client, "RTP16a");
+
+                    await client.WaitForState(ConnectionState.Connected);
+                    client.Workflow.QueueCommand(SetDisconnectedStateCommand.Create(null));
+                    await client.WaitForState(ConnectionState.Disconnected);
+
+                    channel.Presence.Enter(client.Connection.State.ToString(), (b, info) => { });
+
+                    Presence.QueuedPresenceMessage[] presenceMessages = channel.Presence.PendingPresenceQueue.ToArray();
+
+                    presenceMessages.Should().HaveCount(0);
+
+                    // clean up
+                    client.Close();
+                }
+
+                [Theory]
+                [ProtocolData]
+                [Trait("spec", "RTP16b")]
                 public async Task ChannelStateCondition_WhenQueueMessagesIsFalse_WhenChannelIsInitialisedOrAttaching_MessageAreNotPublished(Protocol protocol)
                 {
                     var client = await GetRealtimeClient(protocol, (options, settings) =>

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -1714,12 +1714,12 @@ namespace IO.Ably.Tests.Realtime
 
                     await tsc.Task;
 
-                    // No pending message queue, since QueueMessages is false
+                    // No pending message queue, since QueueMessages=false
                     channel.RealtimeClient.State.PendingMessages.Should().HaveCount(0);
 
                     await WaitFor(500, done =>
                     {
-                        // Ack cleared after flushing the queue for transport disconnection.
+                        // Ack cleared after flushing the queue for transport disconnection, because QueueMessages=false
                         if (channel.RealtimeClient.State.WaitingForAck.Count == 0)
                         {
                             done();
@@ -1729,6 +1729,8 @@ namespace IO.Ably.Tests.Realtime
                     success.Should().HaveValue();
                     success.Value.Should().BeFalse();
                     err.Should().NotBeNull();
+                    err.Message.Should().Be("Clearing message AckQueue(created at connected state) because Options.QueueMessages is false");
+                    err.Cause.InnerException.Message.Should().Be("RTP16b : error while sending message");
 
                     // clean up
                     client.Close();

--- a/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/PresenceSandboxSpecs.cs
@@ -1828,7 +1828,7 @@ namespace IO.Ably.Tests.Realtime
 
                         // capture all outbound protocol messages for later inspection
                         List<ProtocolMessage> messageList = new List<ProtocolMessage>();
-                        client.GetTestTransport().MessageSent = messageList.Add;
+                        client.GetTestTransport().AfterMessageSent = messageList.Add;
 
                         // force state
                         client.Workflow.QueueCommand(changeStateCommand);
@@ -1883,7 +1883,7 @@ namespace IO.Ably.Tests.Realtime
 
                         // capture all outbound protocol messages for later inspection
                         List<ProtocolMessage> messageList = new List<ProtocolMessage>();
-                        client.GetTestTransport().MessageSent = messageList.Add;
+                        client.GetTestTransport().AfterMessageSent = messageList.Add;
 
                         // force state
                         channel.SetChannelState(state);


### PR DESCRIPTION
~Fixed queueing that happens for following states~
~CONNECTIONCLOSING, CONNECTIONCLOSED, CONNECTIONSUSPENDED, CONNECTIONFAILED~
~when `QueueMessages=false`~

- Fixed queueing where RealtimeWorkflowScheduler is queuing messages on connected state and sending them after client is disconnected.
- Added missing check to fix the same.
- Implemented https://github.com/ably/specification/issues/134
- Fixed #1219 
