### PR TITLE
Update README.md to address balance in content priority / readability and platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,7 +486,7 @@ namespace testing_ably_console
 }
 ```
 
-## Unity
+## Unity Support
 
 - Unity support is currently in beta.
 - Supports both [Mono](https://docs.unity3d.com/Manual/Mono.html) and [IL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html) builds.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 _[Ably](https://ably.com) is the platform that powers synchronized digital experiences in realtime. Whether attending an event in a virtual venue, receiving realtime financial information, or monitoring live car performance data – consumers simply expect realtime digital experiences as standard. Ably provides a suite of APIs to build, extend, and deliver powerful digital experiences in realtime for more than 250 million devices across 80 countries each month. Organizations like Bloomberg, HubSpot, Verizon, and Hopin depend on Ably’s platform to offload the growing complexity of business-critical realtime data synchronization at global scale. For more information, see the [Ably documentation](https://ably.com/docs)._
 
-This is a .NET client library for Ably. The library currently targets the [Ably 1.1-beta client library specification](https://ably.com/docs/client-lib-development-guide/features). You can jump to the '[Known Limitations](#known-limitations)' section to see the features this client library does not yet support or or [view our client library SDKs feature support matrix](https://ably.com/download/sdk-feature-support-matrix) to see the list of all the available features.
+This is a .NET client library for Ably which targets the 1.2 client library specification. You can see the features this client supports in our [client library SDKs feature support matrix](https://ably.com/download/sdk-feature-support-matrix).
 
 ## Supported platforms
 
@@ -50,11 +50,13 @@ All examples assume a client has been created as follows:
 
 ```csharp
 // Using basic auth with API key
+// Note in production, an API key should not be used in untrusted mobile/browser clients
 var realtime = new AblyRealtime("<api key>");
 ```
 
 ```csharp
 // Using token auth with token string
+// Note this token is not renewable, so a token callback should be used in production
 var realtime = new AblyRealtime(new ClientOptions { Token = "token" });
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This is a .NET client library for Ably which targets the 1.2 client library spec
 * [Xamarin.Android 8.0+](https://developer.xamarin.com/releases/android/xamarin.android_8/xamarin.android_8.0/)
 * [Xamarin.iOS 10.14+](https://developer.xamarin.com/releases/ios/xamarin.ios_10/xamarin.ios_10.14/)
 * Xamarin.Mac 3.8+
-* Unity - note support is currently in beta for both[Mono](https://docs.unity3d.com/Manual/Mono.html) and [IL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html) builds. Find out more in the [Unity support section](#unity-support).
+* Unity - Support is currently in beta for both [Mono](https://docs.unity3d.com/Manual/Mono.html) and [IL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html) builds. Find out more in the [Unity support section](#unity-support).
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -20,37 +20,7 @@ This is a .NET client library for Ably. The library currently targets the [Ably 
 * [Xamarin.Android 8.0+](https://developer.xamarin.com/releases/android/xamarin.android_8/xamarin.android_8.0/)
 * [Xamarin.iOS 10.14+](https://developer.xamarin.com/releases/ios/xamarin.ios_10/xamarin.ios_10.14/)
 * Xamarin.Mac 3.8+
-
-## Push notification
-
-The Ably.net library fully supports Ably's push notifications. The feature set consists of two distinct areas: [Push Admin](https://ably.com/docs/general/push/admin), [Device Push Notifications](https://ably.com/docs/realtime/push).
-
-The [Push Notifications Readme](PushNotifications.md) describes:
-
-* How to setup Push notifications for Xamarin mobile apps
-* How to use the Push Admin api to send push notifications directly to a devices or a client
-* How to subscribe to channels that support push notification
-* How to send Ably messages that include a notification
-
-## Unity
-
-- Unity support is currently in beta.
-- Supports both [Mono](https://docs.unity3d.com/Manual/Mono.html) and [IL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html) builds.
-
-**Downloading Unity Package**
-- Please download the latest Unity package from the [GitHub releases page](https://github.com/ably/ably-dotnet/releases/latest). All releases from 1.2.4 has `.unitypackage` included.
-- Please take a look at [importing unity package](./unity/README.md#importing-unity-package) doc for initial config. and usage.
-
-**Supported Platforms**
-- Ably Unity SDK supports **Windows, MacOS, Linux, Android and iOS**.
-- It doesn't support **WebGL** due to incompatibility with WebSockets. Read the [Direct Socket Access](https://docs.unity3d.com/2019.3/Documentation/Manual/webgl-networking.html) section under WebGL Networking.
-- To support **WebGL**, you should refer to [interation with browser javascript from WebGL](https://docs.unity3d.com/Manual/webgl-interactingwithbrowserscripting.html). You can import [ably-js](https://github.com/ably/ably-js) as a browser javascript and call it from WebGL. For more information, refer to the project [Ably Tower Defence](https://github.com/ably-labs/ably-tower-defense/tree/js-branch/).
-
-
-**Note** - Please take a look at [Unity README](./unity/README.md) and [Ably Unity Blog](https://ably.com/blog/multiplayer-game-in-unity-with-ably) for more information.
-
-## Known Limitations
-* Browser push notifications in [Blazor](https://dotnet.microsoft.com/en-us/apps/aspnet/web-apps/blazor) are not supported.
+* Unity - note support is currently in beta for both[Mono](https://docs.unity3d.com/Manual/Mono.html) and [IL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html) builds. Find out more in the [Unity support section](#unity-support).
 
 ## Documentation
 
@@ -408,6 +378,21 @@ var firstItem = stats.Items.First();
 var nextStatsPage = await stats.NextAsync();
 ```
 
+### Push notifications
+
+The Ably.net library supports Ably's push notifications. The feature set consists of two distinct areas: 
+- [Push Admin](https://ably.com/docs/general/push/admin) for managing registrations and publishing notifications server-side
+- [Device Push Notifications](https://ably.com/docs/realtime/push) for subscribing to push notifications in your Xamarin applications
+
+The [Push Notifications README](PushNotifications.md) describes:
+
+* How to setup Push notifications for Xamarin mobile apps
+* How to use the Push Admin API to send push notifications directly to a devices or a client
+* How to subscribe to channels that support push notification
+* How to send Ably messages that include a notification
+
+_Please note: browser push notifications in [Blazor](https://dotnet.microsoft.com/en-us/apps/aspnet/web-apps/blazor) are not supported._
+
 ### Fetching the Ably service time
 
 ```csharp
@@ -500,6 +485,23 @@ namespace testing_ably_console
     }
 }
 ```
+
+## Unity
+
+- Unity support is currently in beta.
+- Supports both [Mono](https://docs.unity3d.com/Manual/Mono.html) and [IL2CPP](https://docs.unity3d.com/Manual/IL2CPP.html) builds.
+
+**Downloading Unity Package**
+- Please download the latest Unity package from the [GitHub releases page](https://github.com/ably/ably-dotnet/releases/latest). All releases from 1.2.4 has `.unitypackage` included.
+- Please take a look at [importing unity package](./unity/README.md#importing-unity-package) doc for initial config. and usage.
+
+**Supported Platforms**
+- Ably Unity SDK supports **Windows, MacOS, Linux, Android and iOS**.
+- It doesn't support **WebGL** due to incompatibility with WebSockets. Read the [Direct Socket Access](https://docs.unity3d.com/2019.3/Documentation/Manual/webgl-networking.html) section under WebGL Networking.
+- To support **WebGL**, you should refer to [interation with browser javascript from WebGL](https://docs.unity3d.com/Manual/webgl-interactingwithbrowserscripting.html). You can import [ably-js](https://github.com/ably/ably-js) as a browser javascript and call it from WebGL. For more information, refer to the project [Ably Tower Defence](https://github.com/ably-labs/ably-tower-defense/tree/js-branch/).
+
+
+**Note** - Please take a look at [Unity README](./unity/README.md) and [Ably Unity Blog](https://ably.com/blog/multiplayer-game-in-unity-with-ably) for more information.
 
 ## Dependencies
 


### PR DESCRIPTION
* Add Unity to list of supported platforms (not clear why it's not listed as supported and then was listed below)
* Move the Unity section to below the documentation (given it's for a small segment of our user base, I was not clear why this information should take precedence over the basis on how to use this app). Link to Unity from the listed platforms.
* Push notifications moved into the documentation on how to use this SDK. Not clear why push notifications is considered more important than all other documentation for this SDK.
* Also fixes the incorrect statement about specification target