### PR TITLE
Delete unnecessary recover error test

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSandBoxSpecs.cs
@@ -1121,37 +1121,6 @@ namespace IO.Ably.Tests.Realtime
 
         [Theory]
         [ProtocolData]
-        [Trait("spec", "RTN16l")]
-        [Trait("spec", "RTN15c4")]
-        public async Task WithInvalidRecoverData_ShouldFailAndSetAReasonOnTheConnection(Protocol protocol)
-        {
-            var client = await GetRealtimeClient(protocol, (opts, _) =>
-            {
-                opts.Recover = "{\"connectionKey\":\"random_key\",\"msgSerial\":5,\"channelSerials\":{\"channel1\":\"98\",\"channel2\":\"32\",\"channel3\":\"09\"}}";
-                opts.AutoConnect = false;
-            });
-
-            ErrorInfo err = null;
-            client.Connection.On((args) =>
-            {
-                err = args.Reason;
-                if (args.Current == ConnectionState.Failed)
-                {
-                    ResetEvent.Set();
-                }
-            });
-            client.Connect();
-
-            var result = ResetEvent.WaitOne(10000);
-            result.Should().BeTrue("Timeout");
-            err.Should().NotBeNull();
-            err.Code.Should().Be(ErrorCodes.InvalidFormatForConnectionId);
-            client.Connection.ErrorReason.Code.Should().Be(ErrorCodes.InvalidFormatForConnectionId);
-            client.Connection.State.Should().Be(ConnectionState.Failed);
-        }
-
-        [Theory]
-        [ProtocolData]
         [Trait("issue", "65")]
         public async Task WithShortLivedToken_ShouldRenewTokenMoreThanOnce(Protocol protocol)
         {


### PR DESCRIPTION
The test removed in this commit expects that using an invalid recovery key leads to an ERROR protocol message being returned which thus fails the connection, but this isn't part of the spec, we make no guarantee that invalid recovery keys are rejected with an ERROR, and in fact returning a CONNECTED protocol message with the error field indicating the recovery key was invalid is a perfectly good response, which is in fact what we will start to do in the future.

The functionality that an ERROR protocol message is treated as fatal by the SDK and fails the connection is still tested elsewhere, so removing this test doesn't materially reduce the amount of test coverage.