### PR TITLE
[ECO-5646] Fix behaviour when internet connection is not available

### DIFF
--- a/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/AblyRealtimeTestExtensions.cs
+++ b/src/IO.Ably.Tests.Shared/Realtime/ConnectionSpecs/AblyRealtimeTestExtensions.cs
@@ -20,14 +20,30 @@ namespace IO.Ably.Tests.Realtime
                 new ProtocolMessage(ProtocolMessage.MessageAction.Message) { Messages = new[] { message }, Channel = channel });
         }
 
-        public static async Task DisconnectWithRetryableError(this AblyRealtime client)
+        public static async Task DisconnectWithRetryableError(this AblyRealtime client, bool waitForDisconnectedState = true)
         {
             client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Disconnected)
             {
                 Error = new ErrorInfo { StatusCode = HttpStatusCode.GatewayTimeout }
             });
 
-            await client.WaitForState(ConnectionState.Disconnected);
+            if (waitForDisconnectedState)
+            {
+                await client.WaitForState(ConnectionState.Disconnected);
+            }
+        }
+
+        public static async Task DisconnectWithNonRetryableError(this AblyRealtime client, bool waitForDisconnectedState = true)
+        {
+            client.FakeProtocolMessageReceived(new ProtocolMessage(ProtocolMessage.MessageAction.Disconnected)
+            {
+                Error = new ErrorInfo { StatusCode = HttpStatusCode.Forbidden }
+            });
+
+            if (waitForDisconnectedState)
+            {
+                await client.WaitForState(ConnectionState.Disconnected);
+            }
         }
 
         public static async Task ConnectClient(this AblyRealtime client)


### PR DESCRIPTION
Fixed https://github.com/ably/ably-dotnet/issues/1319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Client now consistently prefers the default realtime host and more explicitly handles instant-retry and connection-key clearing, improving reconnection reliability.

* **Tests**
  * Added tests verifying default-host-first behavior after non-retryable errors and network-down scenarios.

* **Chores**
  * Added a test helper to simulate non-retryable disconnects and made the retryable-disconnect helper optionally wait for the Disconnected state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->