### PR TITLE
[ECO-5650] ClientOptions.HttpClient for better connection pool management

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -89,7 +89,7 @@ jobs:
             ${{ github.workspace }}/*.nupkg
 
   package-push:
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       DOTNET_NOLOGO: true
 

--- a/.github/workflows/run-tests-macos-mono.yml
+++ b/.github/workflows/run-tests-macos-mono.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check:
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       DOTNET_NOLOGO: true
 

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check:
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       DOTNET_NOLOGO: true
 

--- a/src/IO.Ably.Shared/ClientOptions.cs
+++ b/src/IO.Ably.Shared/ClientOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading;
 using IO.Ably.Transport;
 using Newtonsoft.Json;
@@ -412,6 +413,16 @@ namespace IO.Ably
         /// RSC7d6.
         /// </summary>
         public Dictionary<string, string> Agents { get; set; }
+
+        /// <summary>
+        /// Allows injection of an externally managed HttpClient instance.
+        /// When provided, the library will use this HttpClient instead of creating its own.
+        /// This enables proper HttpClient lifecycle management and connection pooling.
+        /// The injected HttpClient should be configured with appropriate timeouts and handlers.
+        /// Default: null (library creates its own HttpClient).
+        /// </summary>
+        [JsonIgnore]
+        public HttpClient HttpClient { get; set; }
 
         [JsonIgnore]
         internal Func<DateTimeOffset> NowFunc

--- a/src/IO.Ably.Shared/Http/AblyHttpOptions.cs
+++ b/src/IO.Ably.Shared/Http/AblyHttpOptions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net.Http;
 
 namespace IO.Ably
 {
@@ -37,6 +38,8 @@ namespace IO.Ably
 
         public Dictionary<string, string> Agents { get; set; }
 
+        public HttpClient HttpClient { get; set; }
+
         public AblyHttpOptions()
         {
             // Used for testing
@@ -73,6 +76,7 @@ namespace IO.Ably
             FallbackHostsUseDefault = options.FallbackHostsUseDefault;
             AddRequestIds = options.AddRequestIds;
             Agents = options.Agents;
+            HttpClient = options.HttpClient;
 
             NowFunc = options.NowFunc;
             Logger = options.Logger;

--- a/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/AuthTests/AuthSandboxSpecs.cs
@@ -62,7 +62,7 @@ namespace IO.Ably.Tests
             // Get a very short lived token and wait for it to expire
             var authClient = await GetRestClient(protocol);
             var almostExpiredToken = await authClient.AblyAuth.RequestTokenAsync(new TokenParams { ClientId = "123", Ttl = TimeSpan.FromMilliseconds(1) });
-            await Task.Delay(TimeSpan.FromMilliseconds(2));
+            await Task.Delay(TimeSpan.FromMilliseconds(500));
 
             // Modify the expiry date to fool the client it has a valid token
             almostExpiredToken.Expires = DateTimeOffset.UtcNow.AddHours(1);

--- a/src/IO.Ably.Tests.Shared/Infrastructure/AblyRealtimeSpecs.cs
+++ b/src/IO.Ably.Tests.Shared/Infrastructure/AblyRealtimeSpecs.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -75,13 +76,12 @@ namespace IO.Ably.Tests
         {
             var clientOptions = options ?? new ClientOptions(ValidKey);
             clientOptions.SkipInternetCheck = true; // This is for the Unit tests
-            var client = new AblyRealtime(clientOptions, mobileDevice);
             if (fakeMessageHandler != null)
             {
-                client.RestClient.HttpClient.CreateInternalHttpClient(TimeSpan.FromSeconds(10), fakeMessageHandler);
+                clientOptions.HttpClient = new HttpClient(fakeMessageHandler);
             }
 
-            return client;
+            return new AblyRealtime(clientOptions, mobileDevice);
         }
 
         internal AblyRealtime GetRealtimeClient(Action<ClientOptions> optionsAction, Func<AblyRequest, Task<AblyResponse>> handleRequestFunc = null)

--- a/unity/Assets/Tests/EditMode/AblyRealtimeSpecs.cs
+++ b/unity/Assets/Tests/EditMode/AblyRealtimeSpecs.cs
@@ -215,7 +215,7 @@ namespace Assets.Tests.EditMode
             {
                 var response = new HttpResponseMessage(HttpStatusCode.Accepted) { Content = new StringContent("Success") };
                 var handler = new FakeHttpMessageHandler(response);
-                var client = new AblyHttpClient(new AblyHttpOptions(), handler);
+                var client = new AblyHttpClient(new AblyHttpOptions { HttpClient = new HttpClient(handler) });
 
                 await client.Execute(new AblyRequest("/test", HttpMethod.Get));
                 string[] values = handler.LastRequest.Headers.GetValues("Ably-Agent").ToArray();

--- a/unity/Assets/Tests/EditMode/AuthSpecs.cs
+++ b/unity/Assets/Tests/EditMode/AuthSpecs.cs
@@ -95,7 +95,7 @@ namespace Assets.Tests.EditMode
                     Ttl = TimeSpan.FromMilliseconds(1)
                 });
 
-                await Task.Delay(TimeSpan.FromMilliseconds(2));
+                await Task.Delay(TimeSpan.FromMilliseconds(500));
 
                 // Modify the expiry date to fool the client it has a valid token
                 almostExpiredToken.Expires = DateTimeOffset.UtcNow.AddHours(1);

--- a/unity/Assets/Tests/PlayMode/AblyRealtimeSpecs.cs
+++ b/unity/Assets/Tests/PlayMode/AblyRealtimeSpecs.cs
@@ -215,7 +215,7 @@ namespace Assets.Tests.PlayMode
             {
                 var response = new HttpResponseMessage(HttpStatusCode.Accepted) { Content = new StringContent("Success") };
                 var handler = new FakeHttpMessageHandler(response);
-                var client = new AblyHttpClient(new AblyHttpOptions(), handler);
+                var client = new AblyHttpClient(new AblyHttpOptions { HttpClient = new HttpClient(handler) });
 
                 await client.Execute(new AblyRequest("/test", HttpMethod.Get));
                 string[] values = handler.LastRequest.Headers.GetValues("Ably-Agent").ToArray();

--- a/unity/Assets/Tests/PlayMode/AuthSpecs.cs
+++ b/unity/Assets/Tests/PlayMode/AuthSpecs.cs
@@ -96,7 +96,7 @@ namespace Assets.Tests.PlayMode
                     Ttl = TimeSpan.FromMilliseconds(1)
                 });
 
-                await Task.Delay(TimeSpan.FromMilliseconds(2));
+                await Task.Delay(TimeSpan.FromMilliseconds(500));
 
                 // Modify the expiry date to fool the client it has a valid token
                 almostExpiredToken.Expires = DateTimeOffset.UtcNow.AddHours(1);


### PR DESCRIPTION
- Added a way to inject external httpclient for better caching.
- Fixed https://github.com/ably/ably-dotnet/issues/1322

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public HTTP client property in configuration so callers can supply and manage their own HTTP client instance.

* **Breaking Changes**
  * HTTP client construction API updated — callers must use the new configuration-based injection.

* **Chores**
  * CI runner images updated from macOS 13 to macOS 14.

* **Tests**
  * Expanded tests for external HTTP client behavior; adjusted timing in a token-expiry test.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->