### PR TITLE
ci: tighten GitHub Actions workflow security

### DIFF
--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: ably/features/.github/workflows/sdk-features.yml@main
+    uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main as of 2026-05-26
     with:
       repository-name: ably-dotnet
     secrets: inherit

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -14,4 +14,5 @@ jobs:
     uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main as of 2026-05-26
     with:
       repository-name: ably-dotnet
-    secrets: inherit
+    secrets:
+      ABLY_AWS_ACCOUNT_ID_SDK: ${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main as of 2026-05-26

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -6,11 +6,14 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
+    permissions:
+      contents: read
+      deployments: write
+      id-token: write
     # Track the live SDK feature spec on main rather than pinning.
     uses: ably/features/.github/workflows/sdk-features.yml@main # zizmor: ignore[unpinned-uses]
     with:

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -11,7 +11,8 @@ permissions:
 
 jobs:
   build:
-    uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main as of 2026-05-26
+    # Track the live SDK feature spec on main rather than pinning.
+    uses: ably/features/.github/workflows/sdk-features.yml@main # zizmor: ignore[unpinned-uses]
     with:
       repository-name: ably-dotnet
     secrets:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -24,12 +24,12 @@ jobs:
   package-library:
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
 
       - name: Download dotnet framework
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: |
             3.1.426
@@ -37,7 +37,7 @@ jobs:
             7.0.410
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
         
       - name: Install Android SDK Platform 30
         shell: pwsh
@@ -84,7 +84,7 @@ jobs:
         run: ./package.cmd $env:VERSION
         
       - name: Archive package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ably-package
           path: |
@@ -96,17 +96,17 @@ jobs:
       DOTNET_NOLOGO: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
 
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: '14.3'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3.2.2
         
       - name: Install Android SDK Platform 30
         run: |
@@ -114,7 +114,7 @@ jobs:
           yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" "build-tools;30.0.3"
 
       - name: Download dotnet framework
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: |
             3.1.426
@@ -144,7 +144,7 @@ jobs:
         run: ./package-push.sh "$VERSION"
 
       - name: Archive push packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ably-push-package
           path: |
@@ -153,12 +153,12 @@ jobs:
   package-unity:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
 
       - name: Download dotnet framework
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: |
             2.1.818
@@ -173,7 +173,7 @@ jobs:
         run: ./package-unity.sh "$VERSION"
         
       - name: Archive Unity package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ably-unity-package
           path: |
@@ -184,7 +184,7 @@ jobs:
     needs: [package-library, package-push, package-unity]
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
           
@@ -229,7 +229,7 @@ jobs:
           echo "Total files: $(ls -1 output-package | wc -l)"
           
       - name: Upload merged artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: output-package
           path: output-package/

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -79,7 +79,9 @@ jobs:
         run: dotnet tool restore
 
       - name: Package
-        run: ./package.cmd ${{ github.event.inputs.version }}
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: ./package.cmd $env:VERSION
         
       - name: Archive package
         uses: actions/upload-artifact@v4
@@ -137,7 +139,9 @@ jobs:
         run: dotnet tool restore
 
       - name: Package Push (iOS & Android)
-        run: ./package-push.sh ${{ github.event.inputs.version }}
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: ./package-push.sh "$VERSION"
 
       - name: Archive push packages
         uses: actions/upload-artifact@v4
@@ -164,7 +168,9 @@ jobs:
         run: dotnet tool restore
 
       - name: Package Unity
-        run: ./package-unity.sh ${{ github.event.inputs.version }}
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: ./package-unity.sh "$VERSION"
         
       - name: Archive Unity package
         uses: actions/upload-artifact@v4

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -20,6 +20,9 @@ on:
         description: 'Ably version'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   package-library:
     runs-on: windows-2022

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
+          persist-credentials: false
 
       - name: Download dotnet framework
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
@@ -99,6 +100,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
+          persist-credentials: false
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
@@ -156,6 +158,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
+          persist-credentials: false
 
       - name: Download dotnet framework
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
+          persist-credentials: false
 
       - name: Download dotnet framework
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-22.04

--- a/.github/workflows/run-tests-linux.yml
+++ b/.github/workflows/run-tests-linux.yml
@@ -17,12 +17,12 @@ jobs:
         targetframework: [ "net6.0", "net7.0", "net8.0", "net9.0" ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
 
       - name: Download dotnet framework
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: |
             6.0.428

--- a/.github/workflows/run-tests-macos-mono.yml
+++ b/.github/workflows/run-tests-macos-mono.yml
@@ -12,12 +12,12 @@ jobs:
       DOTNET_NOLOGO: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
 
       - name: Download dotnet framework
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: |
             3.1.426

--- a/.github/workflows/run-tests-macos-mono.yml
+++ b/.github/workflows/run-tests-macos-mono.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
+          persist-credentials: false
 
       - name: Download dotnet framework
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1

--- a/.github/workflows/run-tests-macos-mono.yml
+++ b/.github/workflows/run-tests-macos-mono.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: macos-14

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
+          persist-credentials: false
 
       - name: Download dotnet framework
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -17,12 +17,12 @@ jobs:
         targetframework: [ "net6.0", "net7.0", "net8.0", "net9.0" ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
 
       - name: Download dotnet framework
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: |
             6.0.428

--- a/.github/workflows/run-tests-macos.yml
+++ b/.github/workflows/run-tests-macos.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: macos-14

--- a/.github/workflows/run-tests-windows-netframework.yml
+++ b/.github/workflows/run-tests-windows-netframework.yml
@@ -12,12 +12,12 @@ jobs:
       DOTNET_NOLOGO: true
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
 
       - name: Download dotnet framework
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: |
             7.0.410

--- a/.github/workflows/run-tests-windows-netframework.yml
+++ b/.github/workflows/run-tests-windows-netframework.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
+          persist-credentials: false
 
       - name: Download dotnet framework
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1

--- a/.github/workflows/run-tests-windows-netframework.yml
+++ b/.github/workflows/run-tests-windows-netframework.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: windows-2022

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -17,12 +17,12 @@ jobs:
         targetframework: [ "net6.0", "net7.0", "net8.0", "net9.0" ]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
 
       - name: Download framework
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: |
             6.0.428

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: windows-2022

--- a/.github/workflows/run-tests-windows.yml
+++ b/.github/workflows/run-tests-windows.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           submodules: 'recursive'
+          persist-credentials: false
 
       - name: Download framework
         uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1


### PR DESCRIPTION
Routine hardening of the workflows under `.github/workflows/` based on a [zizmor](https://docs.zizmor.sh) audit. No CI behaviour changes are intended - pinned action versions match what the floating tags currently resolve to, and the added permissions match what the workflows already do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned GitHub Actions steps to specific commit versions across CI workflows for more consistent builds.
  * Strengthened CI security by setting explicit minimal GitHub token permissions and disabling credential persistence in checkout steps.
  * Updated packaging/build workflows to use explicit permissions and forwarding of required secrets for safer, more controlled deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->